### PR TITLE
fix: register apps when dir is missing

### DIFF
--- a/scripts/registerApps.ts
+++ b/scripts/registerApps.ts
@@ -43,4 +43,7 @@ for (const server of KNOWN_SERVERS) {
   }
 }
 
+if (!fs.existsSync('public'))
+  await fs.mkdir('public')
+
 await fs.writeJSON(filename, registeredApps, { spaces: 2, EOL: '\n' })


### PR DESCRIPTION
### Description

The script wasn't working if the `public` folder is inexistent.