### PR TITLE
feat: publish widget markup

### DIFF
--- a/components/account/AccountMe.client.vue
+++ b/components/account/AccountMe.client.vue
@@ -3,10 +3,11 @@ const { currentUser } = useAppStore()
 </script>
 
 <template>
-  <div p4>
+  <div flex flex-col gap-4 p4>
     <!-- TODO: multiple account switcher -->
     <AccountInfo v-if="currentUser?.account" :account="currentUser.account" />
     <!-- TODO: dialog for select server -->
     <a v-else href="/api/mas.to/login" px2 py1 bg-teal6 text-white m2 rounded>Login</a>
+    <PublishWidget />
   </div>
 </template>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <div flex flex-col gap-4>
+    <textarea p2 border-rounded w-full h-40 color-black placeholder="What's on your mind?" />
+    <div flex justify-end>
+      <button h-9 w-22 bg-primary border-rounded>
+        Publish!
+      </button>
+    </div>
+  </div>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,7 +3,7 @@
     <main grid="~ lg:cols-[1fr_40rem_1fr]" max-w-70rem mxa h-full>
       <div>
         <slot name="left">
-          <NavTitle p4 />
+          <AccountMe />
         </slot>
       </div>
       <div h-full of-auto border="l r border">
@@ -11,7 +11,7 @@
       </div>
       <div flex="~ col">
         <slot name="right">
-          <AccountMe />
+          <NavTitle p5 />
           <NavSide border="y border" py8 />
           <div flex-auto />
           <NavFooter />


### PR DESCRIPTION
### Description

There was a bug in `currentIndex` storage. I switched to `currentId` as I think it may be more robust once there are multiple accounts. You shouldn't need to re-login.

Now when you are logged it will show your current user, and there is a non-functional markup for posting.

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/583075/202297337-bd0b5fee-759e-4b59-b4c3-6695ef17b38c.png">
