### PR TITLE
feat: explore

### DIFF
--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -12,7 +12,7 @@
       <div i-ri:notification-4-line />
       <span>Notifications</span>
     </NuxtLink>
-    <NuxtLink flex gap2 items-center active-class="text-primary">
+    <NuxtLink flex gap2 items-center to="/explore" active-class="text-primary">
       <div i-ri:hashtag />
       <span>Explore</span>
     </NuxtLink>

--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
+
+const masto = await useMasto()
+const paginator = masto.trends.getStatuses()
+</script>
+
+<template>
+  <MainContent>
+    <template #title>
+      <div i-ri:hashtag h-6 mr-1 /><span>Explore</span>
+    </template>
+    <template #actions>
+      <div color-gray i-ri:equalizer-fill mr-1 h-6 />
+    </template>
+    <slot>
+      <!-- TODO: Tabs for trending statuses, tags, and links -->
+      <TimelinePaginator :paginator="paginator" />
+    </slot>
+  </MainContent>
+</template>


### PR DESCRIPTION
### Description

Basic /explore, later on, there need to be tabs for statuses, tags, and links.

https://mas.to isn't showing the explore timeline when you are logged in, but I don't see a reason for it not to be there.