### PR TITLE
fix: update masto.js to 4.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.27.0",
     "form-data": "^4.0.0",
     "fs-extra": "^10.1.0",
-    "masto": "^4.6.2",
+    "masto": "^4.6.5",
     "nuxt": "^3.0.0",
     "pinia": "^2.0.23",
     "postcss-nested": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ specifiers:
   eslint: ^8.27.0
   form-data: ^4.0.0
   fs-extra: ^10.1.0
-  masto: ^4.6.2
+  masto: ^4.6.5
   nuxt: ^3.0.0
   pinia: ^2.0.23
   postcss-nested: ^6.0.0
@@ -39,7 +39,7 @@ devDependencies:
   eslint: 8.27.0
   form-data: 4.0.0
   fs-extra: 10.1.0
-  masto: 4.6.2
+  masto: 4.6.5
   nuxt: 3.0.0_e3uo4sehh4zr4i6m57mkkxxv7y
   pinia: 2.0.23_typescript@4.9.3
   postcss-nested: 6.0.0
@@ -4417,12 +4417,12 @@ packages:
       form-data: 2.5.1
     dev: true
 
-  /isomorphic-ws/5.0.0_ws@8.9.0:
+  /isomorphic-ws/5.0.0_ws@8.11.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
       ws: '*'
     dependencies:
-      ws: 8.9.0
+      ws: 8.11.0
     dev: true
 
   /jest-worker/26.6.2:
@@ -4686,16 +4686,16 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /masto/4.6.2:
-    resolution: {integrity: sha512-b30x9pHXCcFeHBVyMRhwikn2J9x4ajNDGeFF1PdDxw2F+9vwqCfRX/d18jKIa8Qh07NAAnOMWGVBtp5FpJWqVg==}
+  /masto/4.6.5:
+    resolution: {integrity: sha512-bcc6QA9RmtYE51rHKhhgv1ITUr6ssIMnPMguAEJ3YOdgKHh38skuljtmvrq+S2bIrI5wJ+k/XuVHcMkymQJGoQ==}
     dependencies:
       axios: 1.1.3
       change-case: 4.1.2
       eventemitter3: 4.0.7
       isomorphic-form-data: 2.0.0
-      isomorphic-ws: 5.0.0_ws@8.9.0
+      isomorphic-ws: 5.0.0_ws@8.11.0
       semver: 7.3.8
-      ws: 8.9.0
+      ws: 8.11.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -7309,19 +7309,6 @@ packages:
 
   /ws/8.11.0:
     resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
-
-  /ws/8.9.0:
-    resolution: {integrity: sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
### Description

Fixes https://github.com/neet/masto.js/issues/686, notifications type selector works after updating