### PR TITLE
feat: unify follow button

### DIFF
--- a/components/account/AccountCard.vue
+++ b/components/account/AccountCard.vue
@@ -4,27 +4,13 @@ import type { Account } from 'masto'
 const { account } = defineProps<{
   account: Account
 }>()
-
-const masto = await useMasto()
-
-const relationship = $(useRelationship(account))
-
-function unfollow() {
-  masto.accounts.unfollow(account.id)
-  relationship!.following = false
-}
-function follow() {
-  masto.accounts.follow(account.id)
-  relationship!.following = true
-}
 </script>
 
 <template>
   <div flex justify-between>
-    <AccountInfo :account="account" p3 />
-    <div h-full p5>
-      <div v-if="relationship?.following === true" color-purple hover:color-gray hover:cursor-pointer i-ri:user-unfollow-fill @click="unfollow" />
-      <div v-else-if="relationship?.following === false" color-gray hover:color-purple hover:cursor-pointer i-ri:user-follow-fill @click="follow" />
+    <AccountInfo :account="account" p1 />
+    <div h-full p1>
+      <AccountFollowButton :account="account" />
     </div>
   </div>
 </template>

--- a/components/account/AccountFollowButton.vue
+++ b/components/account/AccountFollowButton.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { Account, MastoClient } from 'masto'
+
+const { account } = defineProps<{
+  account: Account
+}>()
+
+const relationship = $(useRelationship(account))
+
+let masto: MastoClient
+
+async function toggleFollow() {
+  relationship!.following = !relationship!.following
+  masto ??= await useMasto()
+  await masto.accounts[relationship!.following ? 'follow' : 'unfollow'](account.id)
+}
+</script>
+
+<template>
+  <button v-if="relationship" flex gap-1 items-center w-full rounded hover="op100 text-white b-purple" group @click="toggleFollow">
+    <div rounded w-28 p2 :group-hover="relationship?.following ? 'bg-red/30' : 'bg-purple/30'" :class="!relationship?.following ? 'bg-cyan/10' : ' bg-purple/10'">
+      <template v-if="relationship?.following">
+        <span group-hover="hidden">Following</span>
+        <span hidden group-hover="inline">Unfollow</span>
+      </template>
+      <template v-else>
+        {{ relationship?.followedBy ? 'Follow back' : 'Follow' }}
+      </template>
+    </div>
+  </button>
+</template>

--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -1,19 +1,9 @@
 <script setup lang="ts">
-import type { Account, MastoClient } from 'masto'
+import type { Account } from 'masto'
 
 const { account } = defineProps<{
   account: Account
 }>()
-
-const relationship = $(useRelationship(account))
-
-let masto: MastoClient
-
-async function toggleFollow() {
-  relationship!.following = !relationship!.following
-  masto ??= await useMasto()
-  await masto.accounts[relationship!.following ? 'follow' : 'unfollow'](account.id)
-}
 
 const createdAt = $computed(() => {
   const date = new Date(account.createdAt)
@@ -42,11 +32,7 @@ const createdAt = $computed(() => {
           </NuxtLink>
         </div>
         <div flex gap-2>
-          <button v-if="relationship" flex gap-1 items-center w-full rounded op75 hover="op100 text-white b-purple" group @click="toggleFollow">
-            <div rounded w-30 p2 group-hover="bg-rose/10">
-              {{ relationship?.following ? 'Unfollow' : relationship?.followedBy ? 'Follow back' : 'Follow' }}
-            </div>
-          </button>
+          <AccountFollowButton :account="account" />
           <!-- <button flex gap-1 items-center w-full rounded op75 hover="op100 text-purple" group>
             <div rounded p2 group-hover="bg-rose/10">
               <div i-ri:bell-line />


### PR DESCRIPTION
### Description

Before this PR, we had the same UI as the official web app:
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/583075/203422560-770f9956-45f8-4491-8256-7b6cb13a6ad2.png">

It is hard to see who you are following with the tiny icons. And also the button is totally different from the one in the profile. This PR proposes to unify the buttons, that is the UI of the official android app.

New button in notifications is the same as in a user profile:
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/583075/203421998-9e95c16f-a220-4889-89aa-a42955b0bdcd.png">

Hover on Following changes to Unfollow (in red):
<img width="556" alt="image" src="https://user-images.githubusercontent.com/583075/203422063-d1e60726-08a1-4d82-be7d-7d7c7611f6e6.png">

Hover on Follow back changes to purple:
<img width="556" alt="image" src="https://user-images.githubusercontent.com/583075/203422166-e50796e1-6816-477e-b55d-4c6c53d637ed.png">