### PR TITLE
fix(ui): left menu not scrollable

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,7 @@
       <div class="hidden md:block w-1/4 zen-hide" relative>
         <div sticky top-0 h-screen flex="~ col">
           <slot name="left">
-            <NavTitle p5 z-index-1 />
+            <NavTitle p5 />
             <div border="t base" flex="~ col" overflow-y-auto>
               <NavSide border="b base" />
               <PublishButton v-if="currentUser" m5 />


### PR DESCRIPTION
Also fixes `AccountInfo` on default layout to allow use it with keyboard: added `tabindex=0` and `keydown.enter` listener.

closes #51 

![imagen](https://user-images.githubusercontent.com/6311119/203844292-3449ab0f-29d7-4285-950d-3d8e3cc4c116.png)
