### PR TITLE
feat: allow translation of statuses

### DIFF
--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -22,6 +22,7 @@ const isLoading = $ref({
   favourited: false,
   bookmarked: false,
   pinned: false,
+  translation: false,
 })
 async function toggleStatusAction(action: 'reblogged' | 'favourited' | 'bookmarked' | 'pinned', newStatus: Promise<Status>) {
   // Optimistic update
@@ -58,6 +59,13 @@ const togglePin = async () => toggleStatusAction(
   'pinned',
   masto.statuses[status.pinned ? 'unpin' : 'pin'](status.id),
 )
+
+const { toggle: _toggleTranslation, translation, enabled: isTranslationEnabled } = useTranslation(_status)
+const toggleTranslation = async () => {
+  isLoading.translation = true
+  await _toggleTranslation()
+  isLoading.translation = false
+}
 
 const copyLink = async () => {
   await clipboard.copy(`${location.origin}${getStatusPath(status)}`)
@@ -157,6 +165,16 @@ function mention() {
         :active="status.bookmarked"
         :disabled="isLoading.bookmarked"
         @click="toggleBookmark()"
+      />
+    </CommonTooltip>
+
+    <CommonTooltip v-if="isTranslationEnabled" placement="bottom" content="Translate">
+      <StatusActionButton
+        color="text-pink" hover="text-pink" group-hover="bg-pink/10"
+        icon="i-ri:translate"
+        :active="translation.visible"
+        :disabled="isLoading.translation"
+        @click="toggleTranslation()"
       />
     </CommonTooltip>
 

--- a/components/status/StatusBody.vue
+++ b/components/status/StatusBody.vue
@@ -4,10 +4,11 @@ import type { Status } from 'masto'
 const { status } = defineProps<{
   status: Status
 }>()
+const { translation } = useTranslation(status)
 </script>
 
 <template>
   <div class="status-body">
-    <ContentRich :content="status.content" :emojis="status.emojis" />
+    <ContentRich :content="translation.visible ? translation.text : status.content" :emojis="status.emojis" />
   </div>
 </template>

--- a/composables/translate.ts
+++ b/composables/translate.ts
@@ -1,0 +1,47 @@
+import type { Status } from 'masto'
+
+export interface TranslationResponse {
+  translatedText: string
+  detectedLanguage: {
+    confidence: number
+    language: string
+  }
+}
+
+const config = useRuntimeConfig()
+
+export async function translateText(text: string) {
+  const { translatedText } = await $fetch<TranslationResponse>(config.public.translateApi, {
+    method: 'POST',
+    body: {
+      q: text,
+      source: 'auto',
+      target: navigator.language.replace(/-.*$/, ''),
+      format: 'html',
+      api_key: '',
+    },
+  })
+  return translatedText
+}
+
+const translations = new WeakMap<Status, { visible: boolean; text: string }>()
+
+export function useTranslation(status: Status) {
+  if (!translations.has(status))
+    translations.set(status, reactive({ visible: false, text: '' }))
+
+  const translation = translations.get(status)!
+
+  async function toggle() {
+    if (!translation.text)
+      translation.text = await translateText(status.content)
+
+    translation.visible = !translation.visible
+  }
+
+  return {
+    enabled: !!config.public.translateApi,
+    toggle,
+    translation,
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,5 +40,8 @@ export default defineNuxtConfig({
       namespaceId: '',
       apiToken: '',
     },
+    public: {
+      translateApi: '',
+    },
   },
 })


### PR DESCRIPTION
resolves #38

This uses https://github.com/LibreTranslate/LibreTranslate as a backend. I've spun up a server which I can move under the elk namespace - just need to talk to @patak-dev to get it set up.