### PR TITLE
chore: use 5314 as a custom dev port

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,7 +1,7 @@
 export const APP_NAME = 'Elk'
 
 export const HOST_DOMAIN = process.dev
-  ? 'http://localhost:3000'
+  ? 'http://localhost:5314'
   : 'https://elk.zone'
 
 export const DEFAULT_POST_CHARS_LIMIT = 500

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://elk.zone/",
   "scripts": {
     "build": "nuxi build",
-    "dev": "nuxi dev",
+    "dev": "nuxi dev --port 5314",
     "start": "node .output/server/index.mjs",
     "lint": "eslint .",
     "postinstall": "nuxi prepare",

--- a/public/registered-apps.json
+++ b/public/registered-apps.json
@@ -3,7 +3,7 @@
     "id": "1505854",
     "name": "Elk",
     "website": null,
-    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:3000/api/mastodon.social/oauth\nhttps://elk.netlify.app/api/mastodon.social/oauth\nhttps://elk.zone/api/mastodon.social/oauth",
+    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:5314/api/mastodon.social/oauth\nhttps://elk.netlify.app/api/mastodon.social/oauth\nhttps://elk.zone/api/mastodon.social/oauth",
     "client_id": "MsxxG2t3ETcH0oNL571ckUfwUOmWhBPBK6EWrnSSqgg",
     "client_secret": "V6p1tuKpoVJ2QR2zbBqxVxDhsFtjPIfpc946_sQxFn8",
     "vapid_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M="
@@ -12,7 +12,7 @@
     "id": "218417",
     "name": "Elk",
     "website": null,
-    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:3000/api/mas.to/oauth\nhttps://elk.netlify.app/api/mas.to/oauth\nhttps://elk.zone/api/mas.to/oauth",
+    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:5314/api/mas.to/oauth\nhttps://elk.netlify.app/api/mas.to/oauth\nhttps://elk.zone/api/mas.to/oauth",
     "client_id": "b076ebc4xMQQI80m0aGxW6B41st33mOaARnrSc379L0",
     "client_secret": "wEuorjZ5QkmyCFgGVzcHZdYV31uY4-YNkdBg7Wah7XA",
     "vapid_key": "BN3Nf2bG70_5AVlWDOw9AJQwkrXS6WQPNkLIKlYSkWjYxPSqAJ6oxEzNYMNQhFch1gCyTAuI4fu5z1uyboHLO0o="
@@ -21,7 +21,7 @@
     "id": "101752",
     "name": "Elk",
     "website": null,
-    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:3000/api/fosstodon.org/oauth\nhttps://elk.netlify.app/api/fosstodon.org/oauth\nhttps://elk.zone/api/fosstodon.org/oauth",
+    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:5314/api/fosstodon.org/oauth\nhttps://elk.netlify.app/api/fosstodon.org/oauth\nhttps://elk.zone/api/fosstodon.org/oauth",
     "client_id": "uNXRXIjQRJUEs5Zg-86E5FUCsMQX-BHeoetqn11TEwc",
     "client_secret": "GALHIKfNfHyEA72-6fzNMJp8lsfbhTTu_7wMC3IEFs4",
     "vapid_key": "BHKY6hkaUL7WByhqx8H8Knbfrpixu8vqTNjiu3XblHR-H6eY2ZD9LYe7fUxOuav6eCfwmK2LHWmzL22vvwN8B2E="
@@ -30,7 +30,7 @@
     "id": "91206",
     "name": "Elk",
     "website": null,
-    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:3000/api/m.cmx.im/oauth\nhttps://elk.netlify.app/api/m.cmx.im/oauth\nhttps://elk.zone/api/m.cmx.im/oauth",
+    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:5314/api/m.cmx.im/oauth\nhttps://elk.netlify.app/api/m.cmx.im/oauth\nhttps://elk.zone/api/m.cmx.im/oauth",
     "client_id": "-wu49ZeEI3oDca7ZKsFPiGr6kUNmIlISgbMtjCtOYL8",
     "client_secret": "8Dhgwn0rs6-HYl7GYGyMTBXlfv7r8ZrkxcjA46jbodU",
     "vapid_key": "BOtsUyc0M779KJ0j-AAsv_wANoDuLkh6tTh6l1muA8OY3xVs34iGsUichN7VXNxcMoGKdSbyIEZsnsbJf6e46DA"
@@ -39,7 +39,7 @@
     "id": "189312",
     "name": "Elk",
     "website": null,
-    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:3000/api/mastodon.world/oauth\nhttps://elk.netlify.app/api/mastodon.world/oauth\nhttps://elk.zone/api/mastodon.world/oauth",
+    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost:5314/api/mastodon.world/oauth\nhttps://elk.netlify.app/api/mastodon.world/oauth\nhttps://elk.zone/api/mastodon.world/oauth",
     "client_id": "s_t9JSDmAVbkQuZ38LApZZO12-nFYjUyloiMObOK0X0",
     "client_secret": "YpYOn-k3VBa4uY7pS1uHtC2qxxm0lpMITulwsZUOB4c",
     "vapid_key": ""

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -29,7 +29,7 @@ else {
 }
 
 const KNOWN_DOMAINS = [
-  'http://localhost:3000',
+  'http://localhost:5314',
   'https://elk.netlify.app',
   'https://elk.zone',
 ]


### PR DESCRIPTION
The port 3000 is used by some other apps and so it's highly possible that it collides

I have a local running grafana on port 3000
When auth my account in dev, it tries to callback on port 3000 instead of 3001

In discord @patak-dev suggested port 5314