### PR TITLE
fix: use form for validating using enter key

### DIFF
--- a/components/user/UserSignIn.vue
+++ b/components/user/UserSignIn.vue
@@ -15,7 +15,7 @@ async function handleInput() {
 </script>
 
 <template>
-  <div h-full text-center justify-center flex="~ col items-center gap2">
+  <form h-full text-center justify-center flex="~ col items-center gap2" @submit.prevent="oauth">
     <div text-3xl mb2>
       Sign in
     </div>
@@ -24,8 +24,8 @@ async function handleInput() {
       <span op35 mr1 text-sm>https://</span>
       <input v-model="server" :placeholder="DEFAULT_SERVER" outline-none bg-transparent @input="handleInput">
     </div>
-    <button btn-solid mxa mt2 @click="oauth()">
+    <button btn-solid mxa mt2>
       Sign in
     </button>
-  </div>
+  </form>
 </template>


### PR DESCRIPTION
As Twitter, and other application, time element on card have a link to the status url.

Here's the PR for adding it.