### PR TITLE
fix: add missing notification status card

### DIFF
--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -41,7 +41,7 @@ const { notification } = defineProps<{
       </div>
       <StatusCard :status="notification.status!" p3 />
     </template>
-    <template v-if="notification.type === 'mention' || notification.type === 'poll'">
+    <template v-if="notification.type === 'mention' || notification.type === 'poll' || notification.type === 'status'">
       <StatusCard :status="notification.status!" p3 />
     </template>
   </div>


### PR DESCRIPTION
Fixes these empty containers in Notifications

![image](https://user-images.githubusercontent.com/7195563/204026821-0cb62d57-1a7b-4d70-9d9e-041f94caf360.png)
