### PR TITLE
fix: add … after ellipsis css class

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -56,6 +56,9 @@ html {
     }
     .ellipsis {
       --at-apply: truncate overflow-hidden ws-nowrap;
+      &::after {
+        content: '…';
+      }
     }
   }
   b, strong {


### PR DESCRIPTION
closes #70

Before:
![image](https://user-images.githubusercontent.com/7195563/204032709-44849902-44cd-4ca4-a0b0-d9c1ab0fbe88.png)


After:
![image](https://user-images.githubusercontent.com/7195563/204032590-5d69ebe8-fb6e-4947-93da-5957356c4005.png)
