### PR TITLE
fix: center zoomed in image in modal

### DIFF
--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -23,7 +23,7 @@ watchOnce(modelValue, () => {
     />
     <div
       class="
-        bg-base absolute transition-all duration-200 ease-out shadow rounded-md transform
+        bg-base absolute transition-all duration-200 ease-out shadow rounded-md transform ml-0
         border border-base top-1/2 -translate-y-1/2 mx-8 md:(left-1/2 -translate-x-1/2)
       "
       :class="modelValue ? 'opacity-100' : 'opacity-0'"


### PR DESCRIPTION
Fixes alignment of zoomed in images in preview.

Before and after:
<img width="1338" alt="Screenshot 2022-11-25 at 21 48 09" src="https://user-images.githubusercontent.com/822287/204049380-63962cc9-c0e7-4569-8697-f9749e85b256.png">
<img width="1338" alt="Screenshot 2022-11-25 at 21 48 19" src="https://user-images.githubusercontent.com/822287/204049410-6ebf3d47-1131-4463-ade7-8c37dd12c625.png">


Example post where bug can be seen: https://sunny.garden/@zoneblanche/109387128420822651