### PR TITLE
fix(publishWidget): add max height

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -265,4 +265,3 @@ onUnmounted(() => {
     </div>
   </div>
 </template>
-


### PR DESCRIPTION
- Add max-height to prevent overflow (I refer to the height of Twitter and find that it is 720px, maybe there are other calculation logics, I don’t know, please allow me to use 720px)
- Disable the publish button when no draft content