### PR TITLE
fix(a11y): better secondary colors

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -8,13 +8,7 @@ defineProps<{
   <div relative>
     <div
       sticky top-0 z10
-<<<<<<< HEAD
-      border="b base"
-      class="bg-base dark:bg-transparent"
-      backdrop="dark:blur-10px dark:brightness-30"
-=======
       border="b base" bg-base
->>>>>>> origin/main
       :class="isZenMode ? 'op0 hover:op100 transition duration-300' : ''"
     >
       <div flex justify-between px5 py4>


### PR DESCRIPTION
After this PR:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/583075/204124575-62fb5a58-5f05-41b6-96cc-da32d7c698d3.png">

<img width="218" alt="image" src="https://user-images.githubusercontent.com/583075/204124579-20f7d822-d72a-49c7-8724-6ba2a9be7f77.png">

What we get:
- `text-secondary` is now accessible on light mode
- `text-secondary-light` bumped from 2.54 -> 3.15