### PR TITLE
chore: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: "\U0001F41E Bug report"
+description: Report an issue
+labels: ['s: pending triage', 'c: bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        If you are unsure whether your problem is a bug or not, you can check the following:
+
+        - use our [Discord community](https://chat.elk.zone)
+        - open a new [discussion](https://github.com/elk-zone/elk/discussions) and ask your question there
+
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Pre-Checks
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        # - label: Follow our [Code of Conduct](https://github.com/elk-zone/elk/blob/main/CODE_OF_CONDUCT.md).
+        #   required: true
+        # - label: Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
+        #   required: true
+        - label: Check that there isn't [already an issue](https://github.com/elk-zone/elk/issues) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: Check that this is a concrete bug. For Q&A open a [GitHub Discussion](https://github.com/elk-zone/elk/discussions) or join our [Discord Chat Server](https://chat.elk.zone).
+          required: true
+        - label: Providing a screenshot or video to reproduce the issue or show visually what was meant.
+          required: true
+        - label: I am willing to provide a PR.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: I am doing ... What I expect is ... What actually happening is ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction video or screenshot
+      description: |
+        A video or screenshot that visually shows the issue.
+        **Tip:** You can attach images or recordings files by clicking this area to highlight it and then dragging files in.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: |
+        Anything else relevant? Please tell us here, e.g. your used web browser and/or you are on desktop or mobile.
+        **Tip:** You can attach images or recordings files by clicking this area to highlight it and then dragging files in.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Chat
+    url: https://chat.elk.zone
+    about: Ask questions and discuss with other users in real time.
+  - name: Questions & Discussions
+    url: https://github.com/elk-zone/elk/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: "\U0001F680 New feature proposal"
+description: Propose a new feature
+labels: ['s: pending triage'] # This will automatically assign the 's: pending triage' label
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for your interest in the project and taking the time to fill out this feature report!
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Clear and concise description of the problem
+      description: 'As a user I want [goal / wish] so that [benefit]. If you intend to submit a PR for this issue, tell us in the description. Thanks!'
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-solution
+    attributes:
+      label: Suggested solution
+      description: 'In section [xy] we could provide following feature...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative
+      description: Clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/freestyle.md
+++ b/.github/ISSUE_TEMPLATE/freestyle.md
@@ -1,0 +1,5 @@
+---
+name: Freestyle Report
+about: Create a report to help us improve
+labels: 'pending triage' # This will automatically assign the 'pending triage' label
+---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A nimble Mastodon web client made with 🧡
 
 Elk is in early alpha, but it is already quite usable. We would love your feedback and contributions.
 
-Check out the [Open Issues](https://github.com/elk-zone/elk/issues) and jump in the action. Join the [Elk discord server](https://discord.gg/vAZSDU9J) to learn more and get involved!
+Check out the [Open Issues](https://github.com/elk-zone/elk/issues) and jump in the action. Join the [Elk discord server](https://chat.elk.zone) to learn more and get involved!
 
 The client is deployed to [elk.zone](https://elk.zone), you can share screenshots on social media but avoid sharing this URL or the discord server until we open the repo.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,13 @@
   publish = "dist"
   command = "npx pnpm i --store=node_modules/.pnpm-store && npx pnpm run build"
 
+# Redirect to Discord server
+[[redirects]]
+  from = "https://chat.elk.zone"
+  to = "https://discord.gg/vAZSDU9J"
+  status = 301
+  force = true
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
This provides issue templates to report bugs as also suggest features
If both these do not fit, the user are free to use the free-style template, so they are not blocked

The templates are attaching labels like `pending triage` so it is possible to filter what was coming in newly

Otherwise it suggest to use GitHub Discussion (not enabled yet because of private repo)
Or use the discord server

I directly added the discord url so users can join freely without having a confusing string value