### PR TITLE
fix: line height in content editor

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -91,7 +91,7 @@ html {
 
 .content-editor.content-rich {
   p {
-    --at-apply: my-4;
+    --at-apply: my-0;
   }
 }
 


### PR DESCRIPTION
Avoid extra `my2` in paragraphs. Follow regular line height as Twitter does.

Before and after: 
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/583075/204385159-da268027-eb56-4d98-b3fc-68f36fc1f100.png">

Note: I added back the `my2` to the StatusBody, we may need to add it later to other places. But I don't see which ones really need it now.