### PR TITLE
feat: prevent arbitrary zooming on mobile devices

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,6 +69,10 @@ export default defineNuxtConfig({
   },
   app: {
     keepalive: true,
+    head: {
+      // Prevent arbitrary zooming on mobile devices
+      viewport: 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no',
+    },
   },
   i18n: {
     locales: [

--- a/styles/global.css
+++ b/styles/global.css
@@ -123,3 +123,8 @@ html.dark {
 html {
   --at-apply: bg-base text-base;
 }
+
+body {
+  /* Prevent arbitrary zooming on mobile devices */
+  touch-action: pan-x pan-y;
+}


### PR DESCRIPTION
This prevents arbitrary zooming on mobile devices

When scrolling around on mobile it was possible to accidentally zoom the whole page
This doesn't fix well with the responsiveness of the page itself
Instead (in a later PR) we could implement a setting (per `localStorage`) to allow configuring the font size