### PR TITLE
fix: copyLink's type & check before copy

### DIFF
--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -76,8 +76,8 @@ const toggleTranslation = async () => {
   isLoading.translation = false
 }
 
-const copyLink = async (url: string) => {
-  await clipboard.copy(url)
+const copyLink = async (url?: string | null) => {
+  url && await clipboard.copy(url)
 }
 const deleteStatus = async () => {
   // TODO confirm to delete


### PR DESCRIPTION
fix copyLink's type & check before copy

before:

![Snipaste_2022-11-30_00-08-33](https://user-images.githubusercontent.com/41336612/204583242-5fce7ed7-9a83-4da9-9de4-7983890f9ca1.png)

![Snipaste_2022-11-30_00-17-34](https://user-images.githubusercontent.com/41336612/204583806-576bd3be-04cc-4c0f-948b-3de2880318dc.png)

after:

![Snipaste_2022-11-30_00-18-15](https://user-images.githubusercontent.com/41336612/204584123-fef5e6d9-c1a5-41c7-b4fa-9dbb66959d8c.png)