### PR TITLE
feat(a11y): improve contrast on poll results accessibility

### DIFF
--- a/components/status/StatusPoll.vue
+++ b/components/status/StatusPoll.vue
@@ -42,8 +42,8 @@ async function vote(e: Event) {
     </form>
     <template v-else>
       <div v-for="(option, index) of poll.options" :key="index" flex justify-between p-1 relative :style="{ '--bar-width': toPercentage((option.votesCount || 0) / poll.votesCount) }">
-        <div absolute top-0 left-0 bottom-0 bg-primary-active rounded-lg h-full class="w-[var(--bar-width)]" />
-        <div z-1 flex items-center gap-1 px-1 text-light>
+        <div absolute top-0 left-0 bottom-0 bg-primary-active rounded-l-sm rounded-r-lg h-full class="w-[var(--bar-width)]" />
+        <div z-1 flex items-center gap-1 px-1 text-inverted>
           {{ option.title }}
 
           <div v-if="poll.voted && poll.ownVotes?.includes(index)" i-ri:checkbox-circle-line />


### PR DESCRIPTION
Fixes #250 by setting `text-light` on both themes to ensure enough contrast for Aa

Also, reduce the number of divs needed to keep DOM lighter. @danielroe let me know if there was a specific reason for those divs there.

Cheers