### PR TITLE
fix(ui): close modals when navigating

### DIFF
--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -78,6 +78,8 @@ useEventListener('keydown', (e: KeyboardEvent) => {
   }
 })
 
+let unsubscribe: () => void
+
 watch(modelValue, async (v) => {
   if (v) {
     isOut = true
@@ -85,8 +87,14 @@ watch(modelValue, async (v) => {
     setTimeout(() => {
       isOut = false
     }, 10)
+
+    unsubscribe = useRouter().beforeEach(() => {
+      unsubscribe()
+      close()
+    })
   }
   else {
+    unsubscribe?.()
     isOut = true
   }
 })


### PR DESCRIPTION
we could also _prevent_ navigation. in the case of the image preview, for example, it might make sense for a back button just to close the image - for example on a mobile phone when swiping - wdyt?