### PR TITLE
feat: Additional instance configuration

### DIFF
--- a/composables/users.ts
+++ b/composables/users.ts
@@ -39,6 +39,10 @@ export async function loginTo(user?: Omit<UserLogin, 'account'> & { account?: Ac
   const masto = await loginMasto({
     url: `https://${user?.server || DEFAULT_SERVER}`,
     accessToken: user?.token,
+    // Masto uses Mastodon version checks to see what features are enabled.
+    // Mastodon alternatives like GoToSocial will always fail these checks, so
+    // provide a way to disable them.
+    disableVersionCheck: process.env.MASTO_DISABLE_VERSION_CHECK === 'true',
   })
 
   if (!user?.token) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,10 @@ export default defineNuxtConfig({
     public: {
       translateApi: '',
     },
+    storage: {
+      driver: process.env.ELK_STORAGE_DRIVER || 'cloudflare', // 'cloudflare' | 'fs'
+      fsBase: process.env.ELK_STORAGE_PATH ?? 'node_modules/.cache/servers',
+    },
   },
   nitro: {
     prerender: {

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -21,8 +21,8 @@ const kv = _kv as typeof import('unstorage/dist/drivers/cloudflare-kv-http')['de
 
 const storage = useStorage() as Storage
 
-if (config.env === 'local') {
-  storage.mount('servers', fs({ base: 'node_modules/.cache/servers' }))
+if (config.env === 'local' || config.storage.driver === 'fs') {
+  storage.mount('servers', fs({ base: config.storage.fsBase }))
 }
 else {
   storage.mount('servers', cached(kv({
@@ -31,6 +31,7 @@ else {
     apiToken: config.cloudflare.apiToken,
   })))
 }
+
 export function getRedirectURI(server: string) {
   return `${HOST_URL}/api/${server}/oauth`
 }


### PR DESCRIPTION
These are additional configuration values I needed in order to deploy my own instance. They are:

- `process.env.ELK_STORAGE_DRIVER` allows configuring which storage driver to use, either `'cloudflare'` (the default) or `'fs'`.
- `process.env.ELK_STORAGE_PATH` is what pass to use for storage with the fs driver.
- `process.env.MASTO_DISABLE_VERSION_CHECK` can be used to disable version checking in Masto. This is needed if you are using a server backend other than Mastodon.