### PR TITLE
feat: direct messages bubbles

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -80,7 +80,7 @@ const timeago = useTimeAgo(() => status.createdAt, timeAgoOptions)
           </div>
         </div>
         <StatusReplyingTo v-if="status.inReplyToAccountId" :status="status" pt1 />
-        <div :class="status.visibility === 'direct' ? 'my3 p2 px5 br2 bg-direct rounded-3 rounded-tl-none' : ''">
+        <div :class="status.visibility === 'direct' ? 'my3 p2 px5 br2 bg-fade rounded-3 rounded-tl-none' : ''">
           <StatusSpoiler :enabled="status.sensitive">
             <template #spoiler>
               <p>{{ status.spoilerText }}</p>

--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -26,7 +26,7 @@ const visibility = $computed(() => STATUS_VISIBILITIES.find(v => v.value === sta
     </NuxtLink>
     <StatusReplyingTo v-if="status.inReplyToAccountId" :status="status" />
     <div
-      :class="status.visibility === 'direct' ? 'my3 p2 px5 br2 bg-direct rounded-3 rounded-tl-none' : ''"
+      :class="status.visibility === 'direct' ? 'my3 p2 px5 br2 bg-fade rounded-3 rounded-tl-none' : ''"
     >
       <StatusSpoiler :enabled="status.sensitive">
         <template #spoiler>

--- a/styles/vars.css
+++ b/styles/vars.css
@@ -7,7 +7,7 @@
   --c-bg-active: #f6f6f6;
   --c-bg-code: #00000006;
   --c-bg-selection: #8885;
-  --c-bg-direct: #EA9E4433;
+  --c-bg-fade: #EA9E4422;
 
   --c-text-base: #232323;
   --c-text-code: #7ca72f;
@@ -23,7 +23,7 @@
   --c-bg-base: #111;
   --c-bg-active: #191919;
   --c-bg-code: #ffffff06;
-  --c-bg-direct: #EA9E4433;
+  --c-bg-fade: #EA9E4422;
 
   --c-text-base: #fff;
   --c-text-code: #90be3d;

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       'bg-base': 'bg-$c-bg-base',
       'bg-active': 'bg-$c-bg-active',
       'bg-code': 'bg-$c-bg-code',
-      'bg-direct': 'bg-$c-bg-direct',
+      'bg-fade': 'bg-$c-bg-fade',
 
       // text colors
       'text-base': 'text-$c-text-base',


### PR DESCRIPTION
First steps towards
- #240

For now, DMs are in a bubble. Some apps are placing the avatar to the right if the author is the logged-in user. I don't know if it is really needed.

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/583075/204930446-34dfda10-aadf-4304-ac8c-3918e8cc56da.png">

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/583075/204930744-a059ea7d-7e82-4c45-833b-6d73bc75011f.png">

