### PR TITLE
fix: modal dialog style

### DIFF
--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -160,9 +160,7 @@ export default {
             <!-- Dialog it self -->
             <div
               ref="elDialogMain"
-              class="dialog-main"
-              rounded shadow-lg pointer-events-auto isolate bg-base
-              border="~ base" max-h-full flex flex-col
+              class="dialog-main w-full rounded shadow-lg pointer-events-auto isolate bg-base border-base border-1px border-solid w-full max-w-125 max-h-full flex flex-col"
               v-bind="bindTypeToAny($attrs)"
             >
               <!-- header -->
@@ -170,7 +168,7 @@ export default {
               <!-- main -->
               <div
                 ref="elDialogScroll"
-                overflow-y-auto touch-pan-y touch-pan-x overscroll-none
+                class="overflow-y-auto touch-pan-y touch-pan-x overscroll-none flex-1"
                 :class="customClass"
               >
                 <slot />


### PR DESCRIPTION
this part of the code must not be modified, as this will result in broken styles. The use of class is to ensure that they can be overridden by the styles that come with v-bind="bindTypeToAny($attrs)" and :class="customClass", so that when you need to customize the appearance of the window it will be easy, as you can see in the image preview window example.

### Normal:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/19204772/205244088-fe07993f-f77e-4caf-879d-e5e964615f8d.png">

### Wrong:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/19204772/205244314-38aba4e3-4d80-4cac-a42a-ccb85a842b98.png">
