### PR TITLE
fix: incorrect logic in useStatusActions

### DIFF
--- a/composables/status.ts
+++ b/composables/status.ts
@@ -42,7 +42,12 @@ export function useStatusActions(props: StatusActionsProps) {
   }
   const toggleReblog = () => toggleStatusAction(
     'reblogged',
-    () => useMasto().statuses[status.reblogged ? 'unreblog' : 'reblog'](status.id),
+    () => useMasto().statuses[status.reblogged ? 'unreblog' : 'reblog'](status.id).then((res) => {
+      if (status.reblogged)
+      // returns the original status
+        return res.reblog!
+      return res
+    }),
     'reblogsCount',
   )
 


### PR DESCRIPTION
closes #291 , fix incorrect logic in `useStatusActions`

Run `updateStatus` before optimistic update, to avoid `getNewStatus` function use `updated status` instead of `old status`.