### PR TITLE
fix: too long username cause scroll horizontally

### DIFF
--- a/components/account/AccountHandle.vue
+++ b/components/account/AccountHandle.vue
@@ -9,7 +9,8 @@ const serverName = $computed(() => getServerName(account))
 </script>
 
 <template>
-  <p ws-nowrap text-ellipsis of-hidden text-secondary-light>
+  <p line-clamp-1 whitespace-pre-wrap break-all text-secondary-light>
+    <!-- fix: #274 only line-clamp-1 can be used here, using text-ellipsis is not valid -->
     <span text-secondary>{{ getShortHandle(account) }}</span>
     <span v-if="serverName" text-secondary-light>@{{ serverName }}</span>
   </p>


### PR DESCRIPTION
### fix again: #274 
too long username cause scroll horizontally
only line-clamp-1 can be used here, using text-ellipsis is not valid

It was broken in this commit [code](https://github.com/elk-zone/elk/blob/57eef8e77f81306e81ada9134a3072a847c2937d/components/account/AccountHandle.vue#L12)
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/19204772/205343096-8486a516-70a0-4d84-8208-fe1e480f66fc.png">
<img width="503" alt="image" src="https://user-images.githubusercontent.com/19204772/205343116-f3507a52-a023-46f8-8036-a9d7b1df4094.png">
