### PR TITLE
feat: avoid follow button flash on hover card

### DIFF
--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
 import type { Account } from 'masto'
 
-defineProps<{
+const { account } = defineProps<{
   account: Account
 }>()
+
+const relationship = $(useRelationship(account))
 </script>
 
 <template>
-  <div flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+  <div v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
     <div flex="~ gap2" items-center>
       <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pr5 mr-a>
         <AccountInfo :account="account" />
       </NuxtLink>
-      <AccountFollowButton text-sm :account="account" />
+      <AccountFollowButton text-sm :account="account" :relationship="relationship" />
     </div>
     <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
     <AccountPostsFollowers text-sm :account="account" />


### PR DESCRIPTION
Only show the hover card once we have the information about the relationship to avoid the follow button flashing from primary to base. There is now a little delay, but that is expected when you hover. I think this feels better.