### PR TITLE
fix: hidden unnecessary dom render

### DIFF
--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -58,7 +58,7 @@ useCommand({
       </div>
     </CommonTooltip>
 
-    <CommonAnimateNumber v-if="(text != null)" :increased="active" text-sm>
+    <CommonAnimateNumber v-if="text !== undefined" :increased="active" text-sm>
       <span text-secondary-light>{{ text }}</span>
       <template #next>
         <span :class="[color]">{{ text }}</span>


### PR DESCRIPTION
Because of this dom render, added the parent dom width
<img width="376" alt="image" src="https://user-images.githubusercontent.com/42139754/205419122-dd81b6ff-fcf5-4d60-b2e6-eccbc033e278.png">
