### PR TITLE
fix: placeholder for broken image urls and avoid overlowing emoji alt text

### DIFF
--- a/components/account/AccountAvatar.vue
+++ b/components/account/AccountAvatar.vue
@@ -6,17 +6,19 @@ defineProps<{
 }>()
 
 const loaded = $ref(false)
+const error = $ref(false)
 </script>
 
 <template>
   <img
     :key="account.avatar"
-    :src="account.avatar"
+    :src="error ? 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7' : account.avatar"
     :alt="$t('account.avatar_description', [account.username])"
     loading="lazy"
     rounded-full
     :class="loaded ? 'bg-gray' : 'bg-gray:10'"
     v-bind="$attrs"
     @load="loaded = true"
+    @error="error = true"
   >
 </template>

--- a/styles/global.css
+++ b/styles/global.css
@@ -43,6 +43,7 @@ body {
 
 .custom-emoji {
   display: inline-block;
+  overflow: hidden;
   max-height: 1.3em;
   max-width: 1.3em;
   vertical-align: text-bottom;


### PR DESCRIPTION
**Before**:

<img width="346" alt="CleanShot 2022-12-04 at 13 55 45@2x" src="https://user-images.githubusercontent.com/28706372/205494660-7eeadd04-60d6-47ba-a3e3-1c87c55c1458.png">

**After**:

<img width="306" alt="CleanShot 2022-12-04 at 13 56 43@2x" src="https://user-images.githubusercontent.com/28706372/205494682-9cb5e4eb-fd4d-480f-9b33-a0ddcdc2ce5a.png">
