### PR TITLE
fix: hide details when no status or no repliers

### DIFF
--- a/components/conversation/ConversationCard.vue
+++ b/components/conversation/ConversationCard.vue
@@ -12,7 +12,7 @@ const withAccounts = $computed(() =>
 
 <template>
   <article v-if="conversation.lastStatus" flex flex-col gap-2>
-    <div v-if="withAccounts.length" absolute flex gap-2 text-sm text-secondary font-bold left-3 px2 pt2>
+    <div absolute flex gap-2 text-sm text-secondary font-bold left-3 px2 pt2>
       <p mr-1>
         {{ $t('conversation.with') }}
       </p>


### PR DESCRIPTION
only question is - why are there phantom conversations in the list - didn't have time to investigate more. Maybe we can add a dev TODO display item.

related: https://github.com/elk-zone/elk/pull/358