### PR TITLE
chore: bump up nuxtjs/i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@iconify-json/ph": "^1.1.3",
     "@iconify-json/ri": "^1.1.4",
     "@iconify-json/twemoji": "^1.1.7",
-    "@nuxtjs/i18n": "^8.0.0-beta.6",
+    "@nuxtjs/i18n": "^8.0.0-beta.7",
     "@pinia/nuxt": "^0.4.6",
     "@tiptap/extension-character-count": "2.0.0-beta.204",
     "@tiptap/extension-code-block": "2.0.0-beta.204",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@iconify-json/ph': ^1.1.3
   '@iconify-json/ri': ^1.1.4
   '@iconify-json/twemoji': ^1.1.7
-  '@nuxtjs/i18n': ^8.0.0-beta.6
+  '@nuxtjs/i18n': ^8.0.0-beta.7
   '@pinia/nuxt': ^0.4.6
   '@tiptap/extension-character-count': 2.0.0-beta.204
   '@tiptap/extension-code-block': 2.0.0-beta.204
@@ -75,7 +75,7 @@ devDependencies:
   '@iconify-json/ph': 1.1.3
   '@iconify-json/ri': 1.1.4
   '@iconify-json/twemoji': 1.1.7
-  '@nuxtjs/i18n': 8.0.0-beta.6
+  '@nuxtjs/i18n': 8.0.0-beta.7
   '@pinia/nuxt': 0.4.6_typescript@4.9.3
   '@tiptap/extension-character-count': 2.0.0-beta.204
   '@tiptap/extension-code-block': 2.0.0-beta.204
@@ -1110,8 +1110,8 @@ packages:
       - vti
     dev: true
 
-  /@nuxtjs/i18n/8.0.0-beta.6:
-    resolution: {integrity: sha512-aZJ1cYmRR/r92O33PTmL8czMq2lBMliyPFzLCOB5BA3oFKY0WafTAPxi8f/VYtlWf+8JT22oZ2UeZRhpxdFPuw==}
+  /@nuxtjs/i18n/8.0.0-beta.7:
+    resolution: {integrity: sha512-TH0cQz2XDSOdBsO3ZBjWC107IaPNTezPwDFPdUwCU0wCP7JfB1kwke4mkCLeizUijFbKTTlAsFnGkyyvQe7UmQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
       '@intlify/bundle-utils': 3.4.0_vue-i18n@9.3.0-beta.10
@@ -7627,6 +7627,7 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
   /spdx-correct/3.1.1:


### PR DESCRIPTION
release note is here:
https://github.com/nuxt-modules/i18n/releases/tag/v8.0.0-beta.7

> Optimize tree-shaking for vue-i18n related modules

v8.0.0-beta.6 had the bundle size issue that vue-i18n was bundled in duplicate, and the message compiler was bundled even though the i18n JSON resource was compiled.
I have resolved it in v8.0.0-beta.7

Thanks to @danielroe  for telling it to me :)