### PR TITLE
fix(ui): display hostname instead of full url

### DIFF
--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -6,8 +6,7 @@ const prop = defineProps<{
 }>()
 const alt = $computed(() => `${prop.card.title} - ${prop.card.title}`)
 const isSquare = $computed(() => prop.card.width === prop.card.height)
-const url = new URL(prop.card.url)
-const description = $computed(() => prop.card.description ? prop.card.description : url.hostname)
+const description = $computed(() => prop.card.description ? prop.card.description : new URL(prop.card.url).hostname)
 
 // TODO: handle card.type: 'photo' | 'video' | 'rich';
 </script>


### PR DESCRIPTION
fixes #365 

This PR will display the hostname only instead of long URLS

![Screenshot 2022-12-08 at 1 23 06 PM](https://user-images.githubusercontent.com/4262489/206445459-3dcdbbd3-7491-4bd4-bd99-0f9a852430e4.png)