### PR TITLE
fix: StatusSpoiler filter value type

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -97,7 +97,7 @@ const avatarOnAvatar = $(computedEager(() => useFeatureFlags().experimentalAvata
           <StatusActionsMore :status="status" mr--2 />
         </div>
         <div :class="status.visibility === 'direct' ? 'my3 p1 px4 br2 bg-fade border-primary border-1 rounded-3 rounded-tl-none' : ''">
-          <StatusSpoiler :enabled="status.sensitive || isFiltered" :filter="filter?.filterAction">
+          <StatusSpoiler :enabled="status.sensitive || isFiltered" :filter="isFiltered">
             <template #spoiler>
               <p>{{ filterPhrase ? `${$t('status.filter_hidden_phrase')}: ${filterPhrase}` : status.spoilerText }}</p>
             </template>

--- a/components/status/StatusSpoiler.vue
+++ b/components/status/StatusSpoiler.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { FilterAction } from 'masto'
-
-const props = defineProps<{ enabled?: boolean; filter?: FilterAction }>()
+const props = defineProps<{ enabled?: boolean; filter?: boolean }>()
 
 const showContent = ref(!props.enabled)
 const toggleContent = useToggle(showContent)


### PR DESCRIPTION
This PR will fix the console warning for wrong type of value to StatusSpoiler prop `filter`