### PR TITLE
fix: priority spoiler vs filter phrase

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -104,7 +104,7 @@ const avatarOnAvatar = $(computedEager(() => useFeatureFlags().experimentalAvata
         >
           <StatusSpoiler :enabled="status.sensitive || isFiltered" :filter="isFiltered">
             <template #spoiler>
-              <p>{{ filterPhrase ? `${$t('status.filter_hidden_phrase')}: ${filterPhrase}` : status.spoilerText }}</p>
+              <p>{{ status.spoilerText || `${$t('status.filter_hidden_phrase')}: ${filterPhrase}` }}</p>
             </template>
             <StatusBody :status="status" />
             <StatusPoll v-if="status.poll" :poll="status.poll" />


### PR DESCRIPTION
Fixes #334 

This PR will prioritize showing CW/Spoiler over Filter text when both are present