### PR TITLE
fix: prevent spoiler text shown when undefined

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -104,7 +104,7 @@ const avatarOnAvatar = $(computedEager(() => useFeatureFlags().experimentalAvata
           }"
         >
           <StatusSpoiler :enabled="status.sensitive || isFiltered" :filter="isFiltered">
-            <template #spoiler>
+            <template v-if="status.spoilerText || filterPhrase" #spoiler>
               <p>{{ status.spoilerText || `${$t('status.filter_hidden_phrase')}: ${filterPhrase}` }}</p>
             </template>
             <StatusBody :status="status" />


### PR DESCRIPTION
Fixes #400 

Prevents scenario "Filtered by: undefined" is shown when status.sensitive is true but no spoiler.text or filter phrase.
 
This is just a quickfix so we don't show "undefined". The best approach is still to handle sensitive media here: https://github.com/elk-zone/elk/issues/318