### PR TITLE
fix: preserve mentions when replying

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -34,10 +34,16 @@ const { editor } = useTiptap({
     get: () => draft.params.status,
     set: newVal => draft.params.status = newVal,
   }),
-  placeholder: computed(() => placeholder || draft.params.inReplyToId ? t('placeholder.replying') : t('placeholder.default_1')),
+  placeholder: computed(() => placeholder ?? draft.params.inReplyToId ? t('placeholder.replying') : t('placeholder.default_1')),
   autofocus: shouldExpanded,
   onSubmit: publish,
-  onFocus() { isExpanded = true },
+  onFocus() {
+    if (!isExpanded && draft.initialText) {
+      editor.value?.chain().insertContent(`${draft.initialText} `).focus('end').run()
+      draft.initialText = ''
+    }
+    isExpanded = true
+  },
   onPaste: handlePaste,
 })
 

--- a/composables/statusDrafts.ts
+++ b/composables/statusDrafts.ts
@@ -4,6 +4,7 @@ import type { Mutable } from '~/types/utils'
 
 export interface Draft {
   editingStatus?: Status
+  initialText?: string
   params: Omit<Mutable<CreateStatusParams>, 'status'> & {
     status?: Exclude<CreateStatusParams['status'], null>
   }
@@ -28,6 +29,7 @@ export function getDefaultDraft(options: Partial<Draft['params'] & Omit<Draft, '
     inReplyToId,
     visibility = 'public',
     attachments = [],
+    initialText = '',
   } = options
 
   return {
@@ -37,6 +39,7 @@ export function getDefaultDraft(options: Partial<Draft['params'] & Omit<Draft, '
       visibility,
     },
     attachments,
+    initialText,
   }
 }
 
@@ -49,13 +52,25 @@ export async function getDraftFromStatus(status: Status, text?: null | string): 
   })
 }
 
+function mentionHTML(acct: string) {
+  return `<span data-type="mention" data-id="${acct}" contenteditable="false">@${acct}</span>`
+}
+
 export function getReplyDraft(status: Status) {
+  const acountsToMention: string[] = []
+  const userId = currentUser.value?.account.id
+  if (status.account.id !== userId)
+    acountsToMention.push(status.account.acct)
+  acountsToMention.push(...(status.mentions.filter(mention => mention.id !== userId).map(mention => mention.acct)))
   return {
     key: `reply-${status.id}`,
-    draft: () => getDefaultDraft({
-      inReplyToId: status!.id,
-      visibility: status.visibility,
-    }),
+    draft: () => {
+      return getDefaultDraft({
+        initialText: acountsToMention.map(acct => mentionHTML(acct)).join(' '),
+        inReplyToId: status!.id,
+        visibility: status.visibility,
+      })
+    },
   }
 }
 


### PR DESCRIPTION
When replying, there is a list of mentions that needs to be preserved for the notification to work. The user may decide to delete some of the handles for example.

To test, go to any post or DM and focus on the reply publish widget, a list of the mentioned accounts will appear (filtering the user one)