### PR TITLE
fix(command): alternative to cmd+/

### DIFF
--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -11,8 +11,16 @@ import {
 const isMac = useIsMac()
 
 // TODO: temporary, await for keybind system
+// open search panel
+// listen to ctrl+k on windows/linux or cmd+k on mac
+// open command panel
 // listen to ctrl+/ on windows/linux or cmd+/ on mac
+// or shift+ctrl+k on windows/linux or shift+cmd+k on mac
 useEventListener('keydown', (e: KeyboardEvent) => {
+  if (e.key === 'k' && (isMac.value ? e.metaKey : e.ctrlKey)) {
+    e.preventDefault()
+    openCommandPanel(e.shiftKey)
+  }
   if (e.key === '/' && (isMac.value ? e.metaKey : e.ctrlKey)) {
     e.preventDefault()
     openCommandPanel(true)


### PR DESCRIPTION
### fix issue: #379 

#### open search panel

listen to `ctrl+k` on windows/linux or `cmd+k` on mac

#### open command panel

listen to `ctrl+/` on windows/linux or `cmd+/` on mac
or `shift+ctrl+k` on windows/linux or `shift+cmd+k` on mac