### PR TITLE
feat: add gap-x in main content actions

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -20,7 +20,7 @@ defineProps<{
           </div>
           <div h-7 w-1px />
         </div>
-        <div flex items-center flex-shrink-0>
+        <div flex items-center flex-shrink-0 gap-x-2>
           <slot name="actions" />
           <NavUser v-if="isMediumScreen" />
         </div>


### PR DESCRIPTION
When there is an action on main content actions, on mobile the user avatar is also shown, there is no gap-x:

![imagen](https://user-images.githubusercontent.com/6311119/207943489-16fbe2d5-7269-4d8c-a848-2513b19b9dba.png)

with gap-x-2:

![imagen](https://user-images.githubusercontent.com/6311119/207943615-965549f9-7a9a-4c7a-bb79-dc00c732c168.png)

