### PR TITLE
style: add space between media attachment and preview card

### DIFF
--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -50,6 +50,7 @@ const visibility = $computed(() => STATUS_VISIBILITIES.find(v => v.value === sta
           :card="status.card"
           :class="status.visibility === 'direct' ? 'pb4' : ''"
           :small-picture-only="status.mediaAttachments?.length > 0"
+          mt-2
         />
       </StatusSpoiler>
     </div>


### PR DESCRIPTION
small PR to add a margin-top of the preview card in `StatusDetail` component

| before | after |
|---|---|
| ![Screenshot 2022-12-16 at 9 11 45 AM](https://user-images.githubusercontent.com/4262489/208053240-3e156f9f-d551-4787-8cb0-825b708f6f87.png) | ![Screenshot 2022-12-16 at 9 10 05 AM](https://user-images.githubusercontent.com/4262489/208053099-96861355-6e9c-47f9-953b-4d9c339b928b.png) |
