### PR TITLE
feat: show provider name on small screen preview cards

### DIFF
--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -74,14 +74,7 @@ const providerName = $computed(() => props.card.providerName ? props.card.provid
       ]"
       my-auto
     >
-      <p
-        text-secondary ws-pre-wrap break-all
-        :class="[
-          !card.description || root
-            ? 'line-clamp-1'
-            : 'sm:line-clamp-1',
-        ]"
-      >
+      <p text-secondary ws-pre-wrap break-all line-clamp-1>
         {{ providerName }}
       </p>
       <strong


### PR DESCRIPTION
This PR will show the provider name on small screen preview cards while still maintaining how Explore/News links look.

| before | after |
| --- | --- |
| ![Screenshot 2022-12-16 at 11 00 25 AM](https://user-images.githubusercontent.com/4262489/208073680-a6834bdd-56e2-4a2b-b02a-a39a310566e8.png) | ![Screenshot 2022-12-16 at 11 00 40 AM](https://user-images.githubusercontent.com/4262489/208073732-1d34afe9-b40b-4b5a-919c-b0b9d18eaf7e.png) |
| ![Screenshot 2022-12-16 at 11 02 00 AM](https://user-images.githubusercontent.com/4262489/208073903-b688b977-23e2-4cff-b05b-76d52c9fc175.png) | ![Screenshot 2022-12-16 at 11 01 47 AM](https://user-images.githubusercontent.com/4262489/208073935-80c0f223-452a-4d28-9a80-e0c28f298806.png) |