### PR TITLE
Fix timeago

### DIFF
--- a/composables/i18n.ts
+++ b/composables/i18n.ts
@@ -63,7 +63,7 @@ export const useTimeAgoOptions = (short = false): UseTimeAgoOptions<false> => {
   const prefix = short ? 'short_' : ''
 
   return {
-    rounding: 'floor',
+    rounding: 'ceil',
     showSecond: !short,
     updateInterval: short ? 60_000 : 1_000,
     messages: {


### PR DESCRIPTION
I noticed on posts from between 45-60 minutes ago the time was rounded to `0h` instead of `1h`.  This config change fixes that, but maybe it is worth checking if there's an issue with https://vueuse.org/core/usetimeago/ @antfu 

<img width="999" alt="CleanShot 2022-12-20 at 02 08 36@2x" src="https://user-images.githubusercontent.com/6642554/208558175-6bbff3f8-4697-42db-953a-29087c0dffef.png">
