### PR TITLE
fix(#480): keep content warning when editing a status

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -85,7 +85,7 @@ async function editStatus() {
   openPublishDialog(`edit-${status.id}`, {
     ...await getDraftFromStatus(status),
     editingStatus: status,
-  })
+  }, true)
 }
 </script>
 

--- a/composables/statusDrafts.ts
+++ b/composables/statusDrafts.ts
@@ -11,6 +11,8 @@ export function getDefaultDraft(options: Partial<Draft['params'] & Omit<Draft, '
     visibility = 'public',
     attachments = [],
     initialText = '',
+    sensitive = false,
+    spoilerText = '',
   } = options
 
   return {
@@ -18,6 +20,8 @@ export function getDefaultDraft(options: Partial<Draft['params'] & Omit<Draft, '
       status,
       inReplyToId,
       visibility,
+      sensitive,
+      spoilerText,
     },
     attachments,
     initialText,
@@ -30,6 +34,8 @@ export async function getDraftFromStatus(status: Status, text?: null | string): 
     mediaIds: status.mediaAttachments.map(att => att.id),
     visibility: status.visibility,
     attachments: status.mediaAttachments,
+    sensitive: status.sensitive,
+    spoilerText: status.spoilerText,
   })
 }
 


### PR DESCRIPTION
This fixes #480 

I also set the edit action to overwrite the draft state from local storage, as, without that, we could have outdated (without content warning) drafts forever. Not sure if the behavior should be reverted at some point, I personally don't see anything wrong with always overwriting when clicking edit.