### PR TITLE
fix: `ModalDialog` component has focus error in `:use-v-if="false"` mode.

### DIFF
--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -62,7 +62,7 @@ const elDialogMain = ref<HTMLDivElement>()
 const elDialogRoot = ref<HTMLDivElement>()
 
 const { activate } = useFocusTrap(elDialogRoot, {
-  immediate: true,
+  immediate: false,
   allowOutsideClick: true,
   clickOutsideDeactivates: true,
   escapeDeactivates: true,
@@ -137,9 +137,9 @@ export default {
 </script>
 
 <template>
-  <Teleport to="body" @transitionend="trapFocusDialog">
+  <Teleport to="body">
     <!-- Dialog component -->
-    <Transition name="dialog-visible">
+    <Transition name="dialog-visible" @transitionend="trapFocusDialog">
       <div
         v-if="isVIf"
         v-show="isVShow"


### PR DESCRIPTION
`ModalDialog` component has focus error in `:use-v-if="false"` mode.

![image](https://user-images.githubusercontent.com/19204772/208930229-956e6bab-8256-43f6-a0f3-2af4eeb4c5e4.png)
