### PR TITLE
fix(i18n): add missing translation

### DIFF
--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -25,7 +25,7 @@ const description = ref(props.attachment.description ?? '')
     <div absolute right-2 top-2>
       <div
         v-if="removable"
-        aria-label="Remove attachment"
+        :aria-label="$t('attachment.remove_label')"
         hover:bg="gray/40" transition-100 p-1 rounded-5 cursor-pointer
         :class="[isHydrated.value && isSmallScreen ? '' : 'op-0 group-hover:op-100hover:']"
         mix-blend-difference
@@ -36,7 +36,7 @@ const description = ref(props.attachment.description ?? '')
     </div>
     <div absolute right-2 bottom-2>
       <button class="bg-black/75" text-white px2 py1 rounded-2 @click="isEditDialogOpen = true">
-        Edit
+        {{ $t('action.edit') }}
       </button>
     </div>
     <ModalDialog
@@ -48,16 +48,16 @@ const description = ref(props.attachment.description ?? '')
       <div flex gap-5>
         <div flex flex-col gap-2 justify-between>
           <h1 id="edit-attachment" font-bold>
-            Description
+            {{ $t('attachment.edit_title') }}
           </h1>
           <div flex flex-col gap-2>
             <textarea v-model="description" p-3 w-100 h-50 bg-base rounded-2 border-strong border-1 />
             <button btn-outline @click="$emit('setDescription', description)">
-              Apply
+              {{ $t('action.apply') }}
             </button>
           </div>
           <button btn-outline @click="isEditDialogOpen = false">
-            Close
+            {{ $t('action.close') }}
           </button>
         </div>
         <StatusAttachment :attachment="attachment" w-full />

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -31,12 +31,14 @@
     "unmute": "Unmute"
   },
   "action": {
+    "apply": "Apply",
     "bookmark": "Bookmark",
     "bookmarked": "Bookmarked",
     "boost": "Boost",
     "boosted": "Boosted",
     "close": "Close",
     "compose": "Compose",
+    "edit": "Edit",
     "enter_app": "Enter App",
     "favourite": "Favourite",
     "favourited": "Favourited",
@@ -53,6 +55,10 @@
   "app_desc_short": "A nimble Mastodon web client",
   "app_logo": "Elk Logo",
   "app_name": "Elk",
+  "attachment": {
+    "edit_title": "Description",
+    "remove_label": "Remove attachment"
+  },
   "command": {
     "activate": "Activate",
     "complete": "Complete",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -31,12 +31,14 @@
     "unmute": "Dejar de silenciar"
   },
   "action": {
+    "apply": "Aplicar",
     "bookmark": "Añadir marcador",
     "bookmarked": "Guardado como marcador",
     "boost": "Retootear",
     "boosted": "Retooteado",
     "close": "Cerrar",
     "compose": "Redactar",
+    "edit": "Editar",
     "enter_app": "Entrar",
     "favourite": "Favorito",
     "favourited": "Marcado como favorito",
@@ -50,9 +52,13 @@
     "switch_account": "Cambiar cuenta",
     "vote": "Votar"
   },
-  "app_desc_short": "Un cliente Mastodon hecho con 🧡",
+  "app_desc_short": "Un ágil cliente web de Mastodon",
   "app_logo": "Logotipo de Elk",
   "app_name": "Elk",
+  "attachment": {
+    "edit_title": "Descripción",
+    "remove_label": "Eliminar archivo adjunto"
+  },
   "command": {
     "activate": "Activar",
     "complete": "Completar",


### PR DESCRIPTION
Removed literal text on publish attachment sfc and added missing entries (included for en-US and es-ES).

This PR also removes the emogi heart from app title on es-ES.

/cc @mrcego @patak-dev nimble traducido cómo ágil, entiendo que es correcto..