### PR TITLE
feat: dark theme on samsung internet browser

### DIFF
--- a/composables/dark.ts
+++ b/composables/dark.ts
@@ -1,2 +1,13 @@
-export const isDark = useDark()
+const dark = useDark()
+
+const samsungBrowser = isSamsungBrowser()
+
+export const isDark = computed(() => dark.value && !samsungBrowser)
 export const toggleDark = useToggle(isDark)
+
+function isSamsungBrowser() {
+  if (typeof window === 'undefined')
+    return false
+
+  return navigator.userAgent.match(/SamsungBrowser/i)
+}


### PR DESCRIPTION
It seems Samsung browser applies css filters when using dark theme: https://eu.community.samsung.com/t5/mobile-apps-services/samsung-internet-browser-invert-colors-on-dark-mode/td-p/5042118

This PR is a test changing `isDark` on `dark.ts`  module.