### PR TITLE
fix: mobile secondry text break

### DIFF
--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -75,7 +75,10 @@ useHeadFixed({
         <div :class="visibility.icon" />
       </CommonTooltip>
       <div v-if="status.application?.name">
-        &middot; {{ status.application?.name }}
+        &middot;
+      </div>
+      <div v-if="status.application?.name">
+        {{ status.application?.name }}
       </div>
     </div>
     <StatusActions :status="status" details :command="command" border="t base" pt-2 />


### PR DESCRIPTION
related to https://github.com/elk-zone/elk/issues/507

maybe this is better?
<img width="580" alt="截屏2022-12-22 19 57 33" src="https://user-images.githubusercontent.com/46164858/209130317-a4ce7126-8b81-47c7-a612-043ccf7b02d1.png">
