### PR TITLE
perf: remove semver dependency and skip version checks

### DIFF
--- a/composables/users.ts
+++ b/composables/users.ts
@@ -44,14 +44,13 @@ export const useUsers = () => users
 export const characterLimit = computed(() => currentInstance.value?.configuration.statuses.maxCharacters ?? DEFAULT_POST_CHARS_LIMIT)
 
 async function loginTo(user?: Omit<UserLogin, 'account'> & { account?: AccountCredentials }) {
-  const config = useRuntimeConfig()
   const route = useRoute()
   const router = useRouter()
   const server = user?.server || route.params.server as string || publicServer.value
   const masto = await loginMasto({
     url: `https://${server}`,
     accessToken: user?.token,
-    disableVersionCheck: !!config.public.disableVersionCheck,
+    disableVersionCheck: true,
     // Suppress warning of `masto/fetch` usage
     disableExperimentalWarning: true,
   })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,8 @@ export default defineNuxtConfig({
     'querystring': 'rollup-plugin-node-polyfills/polyfills/qs',
     'masto/fetch': 'masto/fetch',
     'masto': 'masto/fetch',
+    'change-case': 'scule',
+    'semver': 'unenv/runtime/mock/empty',
   },
   vite: {
     define: {
@@ -84,10 +86,6 @@ export default defineNuxtConfig({
       env: isCI ? isPreview ? 'staging' : 'production' : 'local',
       pwaEnabled: !isDevelopment || process.env.VITE_DEV_PWA === 'true',
       translateApi: '',
-      // Masto uses Mastodon version checks to see what features are enabled.
-      // Mastodon alternatives like GoToSocial will always fail these checks, so
-      // provide a way to disable them.
-      disableVersionCheck: false,
     },
     storage: {
       driver: isCI ? 'cloudflare' : 'fs',


### PR DESCRIPTION
**previous**
1540    .output/public/_nuxt/
448     .output/public/_nuxt/entry.js

**[upgrading to latest masto](https://github.com/elk-zone/elk/pull/506)**
1516    .output/public/_nuxt/
424     .output/public/_nuxt/entry.js

**stubbing semver** (this PR)
1484    .output/public/_nuxt/
392     .output/public/_nuxt/entry.js