### PR TITLE
fix: content min-height

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,7 +40,7 @@
         </div>
       </aside>
       <div class="w-full sm:w-600px min-h-screen" border="none sm:l sm:r base">
-        <div min-h-screen>
+        <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
           <slot />
         </div>
         <div sm:hidden sticky left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">


### PR DESCRIPTION
### detail
The height of the content is too long, on the mobile side, because of the nav at the bottom, as shown in the video.

### before
https://user-images.githubusercontent.com/46164858/209180733-9220d827-c8a4-497a-b240-0252f9740779.mp4

### after

https://user-images.githubusercontent.com/46164858/209182815-6922d5fb-21f3-4c51-8c72-14f7682d7fc3.mp4

