### PR TITLE
fix(styling): make PWA update notification fit screen on mobile

### DIFF
--- a/components/PWAPrompt.client.vue
+++ b/components/PWAPrompt.client.vue
@@ -15,7 +15,7 @@ const { close, needRefresh, updateServiceWorker } = usePWA()
     z11
     fixed
     bottom-14 md:bottom-0 right-0
-    m-2 p-4 w-100
+    m-2 p-4 w-100 max-w-fit
     bg-base border="~ base"
     rounded
     text-left


### PR DESCRIPTION
currently on mobile the update notification does not always fit the screen and sometimes overflows to the left
this fixes that