### PR TITLE
fix: duplicate boder in status detail

### DIFF
--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -57,7 +57,7 @@ onReactivated(() => {
 <template>
   <MainContent back>
     <template v-if="!pending">
-      <div v-if="status" min-h-100vh>
+      <div v-if="status" min-h-100vh mt--1px>
         <template v-if="context">
           <template v-for="comment of context?.ancestors" :key="comment.id">
             <StatusCard :status="comment" context="account" border="t base" :show-reply-to="false" />


### PR DESCRIPTION
Resolve it looks like `2px`.
<img width="723" alt="image" src="https://user-images.githubusercontent.com/42139754/209463030-000ef6d9-9b0f-4506-9d95-d7d4f3a07f7e.png">
