### PR TITLE
fix: update cache + timeline when items are updated/deleted

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -36,6 +36,7 @@ const toggleTranslation = async () => {
   isLoading.translation = false
 }
 
+const masto = useMasto()
 const copyLink = async (status: Status) => {
   const url = getStatusPermalinkRoute(status)
   if (url)
@@ -50,9 +51,10 @@ const deleteStatus = async () => {
       return
   }
 
-  await useMasto().statuses.remove(status.id)
+  removeCachedStatus(status.id)
+  await masto.statuses.remove(status.id)
 
-  if (route.name === '@account-status')
+  if (route.name === 'status')
     router.back()
 
   // TODO when timeline, remove this item
@@ -67,7 +69,8 @@ const deleteAndRedraft = async () => {
       return
   }
 
-  const { text } = await useMasto().statuses.remove(status.id)
+  removeCachedStatus(status.id)
+  const { text } = await masto.statuses.remove(status.id)
   openPublishDialog('dialog', await getDraftFromStatus(status, text), true)
 }
 

--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -13,6 +13,9 @@ export function setCached(key: string, value: any, override = false) {
   if (override || !cache.has(key))
     cache.set(key, value)
 }
+function removeCached(key: string) {
+  cache.delete(key)
+}
 
 export function fetchStatus(id: string, force = false): Promise<Status> {
   const server = currentServer.value
@@ -80,6 +83,10 @@ export function useAccountById(id?: string | null) {
 
 export function cacheStatus(status: Status, server = currentServer.value, override?: boolean) {
   setCached(`${server}:status:${status.id}`, status, override)
+}
+
+export function removeCachedStatus(id: string, server = currentServer.value) {
+  removeCached(`${server}:status:${id}`)
 }
 
 export function cacheAccount(account: Account, server = currentServer.value, override?: boolean) {

--- a/composables/masto.ts
+++ b/composables/masto.ts
@@ -79,9 +79,6 @@ export function getAccountRoute(account: Account) {
       server: currentServer.value,
       account: extractAccountHandle(account),
     },
-    state: {
-      account: account as any,
-    },
   })
 }
 export function getAccountFollowingRoute(account: Account) {
@@ -91,9 +88,6 @@ export function getAccountFollowingRoute(account: Account) {
       server: currentServer.value,
       account: extractAccountHandle(account),
     },
-    state: {
-      account: account as any,
-    },
   })
 }
 export function getAccountFollowersRoute(account: Account) {
@@ -102,9 +96,6 @@ export function getAccountFollowersRoute(account: Account) {
     params: {
       server: currentServer.value,
       account: extractAccountHandle(account),
-    },
-    state: {
-      account: account as any,
     },
   })
 }
@@ -116,9 +107,6 @@ export function getStatusRoute(status: Status) {
       server: currentServer.value,
       account: extractAccountHandle(status.account),
       status: status.id,
-    },
-    state: {
-      status: status as any,
     },
   })
 }

--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -20,14 +20,27 @@ export function usePaginator<T>(paginator: Paginator<any, T[]>, stream?: WsEvent
   }
 
   stream?.on(eventType, (status) => {
+    if ('uri' in status)
+      cacheStatus(status, undefined, true)
+
     prevItems.value.unshift(status as any)
   })
 
   // TODO: update statuses
   stream?.on('status.update', (status) => {
+    cacheStatus(status, undefined, true)
+
     const index = items.value.findIndex((s: any) => s.id === status.id)
     if (index >= 0)
       items.value[index] = status as any
+  })
+
+  stream?.on('delete', (id) => {
+    removeCachedStatus(id)
+
+    const index = items.value.findIndex((s: any) => s.id === id)
+    if (index >= 0)
+      items.value.splice(index, 1)
   })
 
   async function loadNext() {

--- a/composables/status.ts
+++ b/composables/status.ts
@@ -33,11 +33,13 @@ export function useStatusActions(props: StatusActionsProps) {
     isLoading[action] = true
     fetchNewStatus().then((newStatus) => {
       Object.assign(status, newStatus)
+      cacheStatus(newStatus, undefined, true)
     }).finally(() => {
       isLoading[action] = false
     })
     // Optimistic update
     status[action] = !status[action]
+    cacheStatus(status, undefined, true)
     if (countField)
       status[countField] += status[action] ? 1 : -1
   }


### PR DESCRIPTION
This addresses the following issues:

 * liking/boosting a post, then clicking on it and not seeing this reflected in the status detail page
 * an update coming in, seeing it updated in timeline, but clicking it and seeing old data
 * deleting a post and still seeing it in the timeline (resolves https://github.com/elk-zone/elk/issues/399)
 * deleting a post from the post page and not being redirected back to 

We still use opportunistic updating for updates, but not for deletes (so it relies on data from the stream) - may be an avenue to improve.