### PR TITLE
feat: reduce line-height for posts

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -84,6 +84,7 @@ body {
 }
 
 .content-rich {
+  line-height: calc(4 / 3 * 1em);
   overflow-wrap: break-word;
 
   a {


### PR DESCRIPTION
Continuation of:
- #533

Font Size preference was later added by:
- https://github.com/elk-zone/elk/commit/41ef1873798ec4096a475760c42fc480cfc10ad9
- https://github.com/elk-zone/elk/commit/b40832a7ebf4835c4a1051a4862092cf2b4c2d62

This PR modifies the `line-height` to align with other platforms. For the default font size of 15px, previously it was 21.75px and now it is 20px. The diff is small but it makes a big difference visually and in how much content we can fit on the screen

Before
<img width="628" alt="image" src="https://user-images.githubusercontent.com/583075/209473278-fbf72449-9fbd-4abd-b0f4-a236f64455d0.png">

After
<img width="628" alt="image" src="https://user-images.githubusercontent.com/583075/209473303-4f7cf2e8-7984-4668-a546-c984a85f61b2.png">

Doing this one as a PR so we have a deployment later for reference