### PR TITLE
feat: avatar on posts improvements

### DIFF
--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -17,7 +17,7 @@ defineOptions({
 <template>
   <component :is="as" flex gap-3 v-bind="$attrs">
     <AccountHoverWrapper :disabled="!hoverCard" :account="account" shrink-0>
-      <AccountAvatar :account="account" w-52px h-52px p-2px />
+      <AccountAvatar :account="account" account-avatar-normal />
     </AccountHoverWrapper>
     <div flex="~ col" shrink overflow-hidden justify-center leading-none>
       <div flex="~" gap-2>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -195,7 +195,7 @@ defineExpose({
 
     <div flex gap-4 flex-1>
       <NuxtLink :to="getAccountRoute(currentUser.account)">
-        <AccountAvatar :account="currentUser.account" w-52px h-52px p-2px />
+        <AccountAvatar :account="currentUser.account" account-avatar-normal />
       </NuxtLink>
       <!-- This `w-0` style is used to avoid overflow problems in flex layouts，so don't remove it unless you know what you're doing -->
       <div

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -85,8 +85,7 @@ const isSelf = $computed(() => status.account.id === currentUser.value?.account.
         </template>
         <AccountHoverWrapper :account="status.account">
           <NuxtLink :to="getAccountRoute(status.account)" rounded-full>
-            <!-- 50px === 48px + 2px of border -->
-            <AccountAvatar :account="status.account" w-52px h-52px :class="showRebloggedByAvatarOnAvatar ? 'mt-11px border-2 border-bg-base' : 'p-2px mt-3px'" />
+            <AccountAvatar :account="status.account" account-avatar-normal :class="showRebloggedByAvatarOnAvatar ? 'mt-11px ' : 'mt-3px'" />
           </NuxtLink>
         </AccountHoverWrapper>
         <div v-if="connectReply" w-full h-full flex justify-center>

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
       'flex-v-center': 'items-center',
       'flex-h-center': 'justify-center',
       'bg-hover-overflow': 'relative z-0 transition-colors duration-250 after-content-empty after:(absolute inset--2px bg-transparent rounded-lg z--1 transition-colors duration-250) hover:after:(bg-active)',
+
+      // account
+      'account-avatar-normal': 'w-54px h-54px border-3 border-bg-base',
     },
   ],
   presets: [


### PR DESCRIPTION
This PR makes avatars in posts sizes independent of the font size, and always 48px

It also inverts the avatar on avatar to show fully the avatar of the poster, because the avatar of the user that reblogged is known already. It also makes more sense to me conceptually that the re-poster is in the background. It isn't the main character.

Before:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/583075/209481739-0890d838-9452-4375-9147-bbbaed7beede.png">

After:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/583075/209481744-4e768cde-6223-4800-96f3-77b7a4e8d4cf.png">
