### PR TITLE
fix: small "show more" button, a11y issue

### DIFF
--- a/components/status/StatusSpoiler.vue
+++ b/components/status/StatusSpoiler.vue
@@ -11,10 +11,10 @@ watchEffect(() => {
 
 <template>
   <div v-if="enabled" flex flex-col items-start>
-    <div class="content-rich" px-4 pb-2 text-center text-secondary w-full border="~ base" border-0 border-b-dotted border-b-3 mt-2>
+    <div class="content-rich" px-4 pb-2.5 text-center text-secondary w-full border="~ base" border-0 border-b-dotted border-b-3 mt-2>
       <slot name="spoiler" />
     </div>
-    <div flex="~ gap-1 center" w-full mt="-3.5">
+    <div flex="~ gap-1 center" w-full mt="-4.5">
       <button btn-text px-2 py-1 bg-base flex="~ center gap-2" :class="showContent ? '' : 'filter-saturate-0 hover:filter-saturate-100'" @click="toggleContent()">
         <div v-if="showContent" i-ri:eye-line />
         <div v-else i-ri:eye-close-line />


### PR DESCRIPTION
fixes #550

This PR will make the content warning and  "show more" button bigger

| before | after |
| --- | --- |
| <img width="608" alt="Screenshot 2022-12-26 at 6 34 22 PM" src="https://user-images.githubusercontent.com/4262489/209572075-de971252-5b94-468f-9117-4bd70b7a3199.png"> | <img width="607" alt="Screenshot 2022-12-26 at 6 34 36 PM" src="https://user-images.githubusercontent.com/4262489/209572090-fda30a05-0ae2-4cfa-ac10-0be6d7f38e32.png"> |