### PR TITLE
fix: video autoplay

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -80,8 +80,11 @@ const type = $computed(() => {
     <template v-else-if="type === 'gifv'">
       <video
         :poster="attachment.previewUrl"
+        preload="none"
         loop
+        playsinline
         autoplay
+        muted
         border="~ base"
         object-cover
         :width="attachment.meta?.original?.width"


### PR DESCRIPTION
Chrome and Firefox requires `playsinline` and Chrome also requires `muted` to autoplay.

closes #583