### PR TITLE
fix: Focus search input style on safari

### DIFF
--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -52,7 +52,7 @@ const activate = () => {
 
 <template>
   <div ref="el" relative px4 py2 group>
-    <div bg-base border="~ base" h10 rounded-full flex="~ row" items-center relative outline-primary outline-1 focus-within:outline>
+    <div bg-base border="~ base" h10 rounded-full flex="~ row" items-center relative focus-within:box-shadow-outline>
       <div i-ri:search-2-line mx4 absolute pointer-events-none text-secondary mt="1px" />
       <input
         ref="input"

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -103,5 +103,6 @@ export default defineConfig({
       res += `\n${res.replace('{scrollbar-width:none;}', '::-webkit-scrollbar{display: none;}')}`
       return res
     }],
+    ['box-shadow-outline', { 'box-shadow': '0 0 0 1px var(--c-primary)' }],
   ],
 })


### PR DESCRIPTION
Closes #606

Using box-shadow instead of outline when doing focus styling, to work around a Safari bug (https://bugs.webkit.org/show_bug.cgi?id=20807). In the future, when the Safari bug is fixed, we can revert to using an outline again.

<img width="695" alt="Screenshot 2022-12-28 at 16 42 02" src="https://user-images.githubusercontent.com/6213424/209836947-9e8e42bd-d647-4661-82d3-e15e0bcd16cb.png">

I defined a new keyword in UnoCss to match the same style of applying css as before. Please correct me if there is a better way of doing this in UnoCss.

