### PR TITLE
fix: re-add back button

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 defineProps<{
-  /**
-   * Show the back button on small screens
-   */
+  /** Show the back button on small screens */
   backOnSmallScreen?: boolean
+  /** Show the back button on both small and big screens */
+  back?: boolean
 }>()
 </script>
 
@@ -16,7 +16,8 @@ defineProps<{
       <div flex justify-between px5 py4>
         <div flex gap-3 items-center overflow-hidden>
           <NuxtLink
-            v-if="backOnSmallScreen" lg:hidden flex="~ gap1" items-center btn-text p-0
+            v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0
+            :class="{ 'lg:hidden': backOnSmallScreen }"
             @click="$router.go(-1)"
           >
             <div i-ri:arrow-left-line />


### PR DESCRIPTION
The back button was removed from some views (by mistake) in this commit:
https://github.com/elk-zone/elk/commit/d09b4deb52b4cd0c73039db91450302ce0515136

This PR brings it back as before, but with respect for what the above mentioned commit wanted to do. The purpose was for small screens to use CSS (instead of JS) when showing/hiding the back button on some views (to avoid hydration errors).

This PR always show the back button if MainContent has the prop `back`. If MainContent has the prop `back-on-small-screen` it will only show the back button on small screens, using CSS.

Maybe @antfu should review these code changes.

(let me know if there is a better way to conditionally add UnoCss arguments to an element. I resorted to using `:class` to get it to work)