### PR TITLE
fix: autoplay video only when on screen

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -66,12 +66,12 @@ useIntersectionObserver(video, (entries) => {
     return
 
   entries.forEach((entry) => {
-    if (entry.intersectionRatio !== 1)
+    if (entry.intersectionRatio <= 0.75)
       !video.value!.paused && video.value!.pause()
     else
       video.value!.play()
   })
-}, { threshold: 1 })
+}, { threshold: 0.75 })
 </script>
 
 <template>


### PR DESCRIPTION
Maybe we can reduce the threshold, if the video is largen than screen will not autoplay...

Maybe we can reduce it to 0.75 or 0.85.