### PR TITLE
fix: Remove redundant refresh in usePaginator

### DIFF
--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -103,7 +103,6 @@ export function usePaginator<T>(
         )
           loadNext()
       },
-      { immediate: false },
     )
   }
 


### PR DESCRIPTION
While looking into #601, I noticed that going to home -> Explore -> Notifications would cause 2 a duplicate api call on both Explore and Notifications page:
![image](https://user-images.githubusercontent.com/10719325/209898095-6308e44f-4afd-47d2-baae-d28154d412bb.png)

Changing the `immediate` option to `false` appears to have fixed this:
![image](https://user-images.githubusercontent.com/10719325/209897998-a1109aaa-7dd8-4716-88d8-f622e444c011.png)

Based on my testing, it looks like `immediate` is not required because we have enough watches to trigger loading data when needed.

**Note:** `Hashtags` and `For you` still have this issue of two duplicate API calls because they don't use the paginator. I looked at fixing it in this PR, but it wasn't super clear how to fix it (I tinkered with it a bit, but it's getting late, and I thought this fix would be valuable by itself.)

### Testing
- Browsed from home -> Explore -> Notifications, data loaded correctly, with 1 api call each
- Data still loads on a hard-refresh on each of these pages
- Tested on everything I could find that uses pagination, and everything seems to refresh data normally with this change