### PR TITLE
fix: Add key to DynamicScroller slots to fix account hover

### DIFF
--- a/components/common/CommonPaginator.vue
+++ b/components/common/CommonPaginator.vue
@@ -50,6 +50,7 @@ const { items, prevItems, update, state, endAnchor, error } = usePaginator(pagin
           page-mode
         >
           <slot
+            :key="item[keyProp]"
             :item="item"
             :active="active"
             :older="items[index + 1]"


### PR DESCRIPTION
The lack of the key meant that items weren't getting properly updated while scrolling.

Testing:
- Before change, scrolling and then hovering over an account name/avatar showed the wrong account.
- After change, scrolling and then hovering always showed the correct account.