### PR TITLE
fix: push notification click

### DIFF
--- a/service-worker/web-push-notifications.ts
+++ b/service-worker/web-push-notifications.ts
@@ -27,7 +27,7 @@ export const onPush = (event: PushEvent) => {
       data: {
         access_token,
         preferred_locale,
-        url: `/${url}?notification_id=${notification_id}`,
+        url: `/${url}`,
       },
       dir: 'auto',
       icon,


### PR DESCRIPTION
Push notification click opens `notifications/mention` if notification type is `mention`, otherwise opens `notifications` page.

Push notification doesn't have the server and account, only the notification id (push) and the access token: push notification click will redirect to `notifications` or `notifications/mention`.

Check https://discord.com/channels/1044887051155292200/1045743591613534298/1058062934816858113 on discord for more info.

closes #636