### PR TITLE
fix: mobile header and footer prevent flicker on ios safari

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -8,9 +8,9 @@ defineProps<{
 </script>
 
 <template>
-  <div relative>
+  <div relative mobile-padding-top sm:pt-0>
     <div
-      sticky top-0 z10
+      fixed sm:sticky w-full top-0 z10
       border="b base" bg-base
     >
       <div flex justify-between px5 py4>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,11 +40,11 @@ const wideLayout = computed(() => route.meta.wideLayout ?? false)
           </slot>
         </div>
       </aside>
-      <div class="w-full min-h-screen" :class="wideLayout ? 'lg:w-full sm:w-600px' : 'sm:w-600px'" sm:border-l sm:border-r border-base>
+      <div class="w-full min-h-screen" :class="wideLayout ? 'lg:w-full sm:w-600px' : 'sm:w-600px'" sm:border-l sm:border-r border-base mobile-padding-bottom sm:pb-0>
         <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
           <slot />
         </div>
-        <div sm:hidden sticky left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
+        <div sm:hidden fixed w-full left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
           <CommonOfflineChecker :small-screen="isHydrated.value" />
           <NavBottom v-if="isHydrated.value" />
         </div>

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -101,5 +101,7 @@ export default defineConfig({
       return res
     }],
     ['box-shadow-outline', { 'box-shadow': '0 0 0 1px var(--c-primary)' }],
+    ['mobile-padding-top', { 'padding-top': 'calc(4rem + 1px)' }], // in sm screen size header is fixed (instead of sticky) and parent have this padding, to prevent flickering in iOS Safari
+    ['mobile-padding-bottom', { 'padding-bottom': '3.5rem' }], // in sm screen size footer is fixed (instead of sticky) and parent have this padding, to prevent flickering in iOS Safari
   ],
 })


### PR DESCRIPTION
When using Elk on my iPhone 11 (iOS 16.1.1) I have seen the header and footer flickering (blinking in and out) when navigating.

I could reproduce the same thing on my computer on a simulated iPhone 13 (iOS 15.2).

After some investigation I found that iOS Safari has problems with the position:sticky on the header and footer. It sometimes takes a split-second for the "stickyness" to take effect. I have seen iOS struggle with position:sticky on other sites I have worked on, so this seemed familiar.

Video demonstrating the problem:
https://user-images.githubusercontent.com/6213424/210077203-54f4e6a0-3d54-490b-8a0b-c9bb56cf3045.mov

The solution I have used before is to use `position:fixed` instead (and apply a padding to the parent) to get the same result, but iOS Safari is better at handling this.

Video demonstrating using `position:fixed` instead:
https://user-images.githubusercontent.com/6213424/210077477-6404850f-abc9-43e3-ac56-338493dea5a5.mov

This PR switches to using `position:fixed`, only on small screens. The UX will be better for us iPhone users. You can decide if you want this or not. 

Might be a good idea to double check the preview of this PR on an Android.
