### PR TITLE
fix: remove history state fallback + asyncdata

### DIFF
--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -15,7 +15,7 @@ const publishWidget = ref()
 
 const { data: status, pending, refresh: refreshStatus } = useAsyncData(
   `status:${id}`,
-  async () => (window.history.state?.status as Status | undefined) ?? await fetchStatus(id),
+  () => fetchStatus(id),
   { watch: [isMastoInitialised], immediate: isMastoInitialised.value },
 )
 const masto = useMasto()

--- a/pages/[[server]]/@[account]/index/index.vue
+++ b/pages/[[server]]/@[account]/index/index.vue
@@ -9,16 +9,13 @@ definePageMeta({ name: 'account-index' })
 
 const { t } = useI18n()
 
-const { data: account } = await useAsyncData(`account:${handle}`, async () => (
-  window.history.state?.account as Account | undefined)
-    ?? await fetchAccountByHandle(handle),
-)
+const account = await fetchAccountByHandle(handle)
 
-const paginator = useMasto().accounts.iterateStatuses(account.value!.id, { excludeReplies: true })
+const paginator = useMasto().accounts.iterateStatuses(account.id, { excludeReplies: true })
 
 if (account) {
   useHeadFixed({
-    title: () => `${t('account.posts')} | ${getDisplayName(account.value!)} (@${account.value!.acct})`,
+    title: () => `${t('account.posts')} | ${getDisplayName(account)} (@${account.acct})`,
   })
 }
 </script>

--- a/pages/[[server]]/@[account]/index/media.vue
+++ b/pages/[[server]]/@[account]/index/media.vue
@@ -7,16 +7,13 @@ const { t } = useI18n()
 const params = useRoute().params
 const handle = $(computedEager(() => params.account as string))
 
-const { data: account } = await useAsyncData(`account:${handle}`, async () => (
-  window.history.state?.account as Account | undefined)
-    ?? await fetchAccountByHandle(handle),
-)
+const account = await fetchAccountByHandle(handle)
 
-const paginator = useMasto().accounts.iterateStatuses(account.value!.id, { onlyMedia: true, excludeReplies: false })
+const paginator = useMasto().accounts.iterateStatuses(account.id, { onlyMedia: true, excludeReplies: false })
 
 if (account) {
   useHeadFixed({
-    title: () => `${t('tab.media')} | ${getDisplayName(account.value!)} (@${account.value!.acct})`,
+    title: () => `${t('tab.media')} | ${getDisplayName(account)} (@${account.acct})`,
   })
 }
 </script>

--- a/pages/[[server]]/@[account]/index/with_replies.vue
+++ b/pages/[[server]]/@[account]/index/with_replies.vue
@@ -7,16 +7,13 @@ const { t } = useI18n()
 const params = useRoute().params
 const handle = $(computedEager(() => params.account as string))
 
-const { data: account } = await useAsyncData(`account:${handle}`, async () => (
-  window.history.state?.account as Account | undefined)
-    ?? await fetchAccountByHandle(handle),
-)
+const account = await fetchAccountByHandle(handle)
 
-const paginator = useMasto().accounts.iterateStatuses(account.value!.id, { excludeReplies: false })
+const paginator = useMasto().accounts.iterateStatuses(account.id, { excludeReplies: false })
 
 if (account) {
   useHeadFixed({
-    title: () => `${t('tab.posts_with_replies')} | ${getDisplayName(account.value!)} (@${account.value!.acct})`,
+    title: () => `${t('tab.posts_with_replies')} | ${getDisplayName(account)} (@${account.acct})`,
   })
 }
 </script>


### PR DESCRIPTION
We previously removed route `state` in favour of the LRU cache and this removes the state test.

As we're already caching the status, etc., I'm not sure I see a value to using `useAsyncData` in this context, and there's a potential increase in memory + additional cache key to worry about.