### PR TITLE
fix: remove line-clamp from signatures in notifications

### DIFF
--- a/components/account/AccountBigCard.vue
+++ b/components/account/AccountBigCard.vue
@@ -46,7 +46,6 @@ defineOptions({
       <div v-if="account.note" max-h-100 overflow-y-auto>
         <ContentRich
           :content="account.note" :emojis="account.emojis"
-          line-clamp-2
         />
       </div>
       <!-- Follow info -->


### PR DESCRIPTION
Fixes https://github.com/elk-zone/elk/issues/646

It needs to be looked at later with different solution. Also later need to check every `line-clamp` usage in components with Safari.