### PR TITLE
docs: add note about pnpm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Refer also to https://github.com/antfu/contribute.
 
 ## Set up your local development environment
 
-The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). (Note: on Linux in a standard Node 16+ environment, you should follow the instructions to install via Node's `corepack` rather than using the `curl` command.)
+The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/) (Note: on Linux in a standard Node 16+ environment, you should follow the instructions to install via Node's `corepack` rather than using the `curl` command).
 
 To develop and test the Elk package:
 


### PR DESCRIPTION
Per discussion in the discord, it makes sense to install `pnpm` via `corepack` rather than the standalone shell script.