### PR TITLE
Support rendering local-only posts from Hometown

### DIFF
--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -118,12 +118,13 @@ const reply = () => {
       />
     </div>
 
-    <div
-      v-if="status.localOnly"
-      class="i-ri:link-unlink-m local-only"
-      flex-none
-      text-secondary
-    />
+    <CommonTooltip v-if="status.localOnly" :content="$t('action.local_only')" placement="bottom">
+      <div
+        class="i-ri:link-unlink-m local-only"
+        flex-none
+        text-secondary
+      />
+    </CommonTooltip>
   </div>
 </template>
 

--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -105,7 +105,7 @@ const reply = () => {
       </StatusActionButton>
     </div>
 
-    <div flex-none>
+    <div :class="status.localOnly ? 'flex-1' : 'flex-none'">
       <StatusActionButton
         :content="$t('action.bookmark')"
         color="text-yellow" hover="text-yellow" group-hover="bg-yellow/10"
@@ -117,5 +117,18 @@ const reply = () => {
         @click="toggleBookmark()"
       />
     </div>
+
+    <div
+      v-if="status.localOnly"
+      class="i-ri:link-unlink-m local-only"
+      flex-none
+      text-secondary
+    />
   </div>
 </template>
+
+<style>
+.local-only {
+  margin: 0.5em;
+}
+</style>

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -53,6 +53,7 @@
     "favourite": "Favorite",
     "favourite_count": "{0}",
     "favourited": "Favorited",
+    "local_only": "Local only",
     "more": "More",
     "next": "Next",
     "prev": "Prev",


### PR DESCRIPTION
This checks the ActivityPub object for any given status in a timeline to see if it has a `localOnly` property. If it does and it is set to true, then a local-only icon is displayed in the `StatusAction` bar.

(There will be a future pr for writing local only posts.)

Hovering the mouse over the icon does not change the cursor to a "pointer" indicator, and there is no hover action, so it does not look like a button, basically. The tooltip says "Local only" in `en-us`.

I have designed this to mimic the current Hometown layout and behavior. On Hometown a feed will look like this:

![image](https://user-images.githubusercontent.com/266454/210279548-263e3c5f-d38d-4bf8-92a5-37d83d0ac8b2.png)

And in this pull request I make Elk do this:

![image](https://user-images.githubusercontent.com/266454/210279572-7905f9bd-9059-4c75-9669-68ebab073a28.png)

Of course, feel free to change up the behavior and design as you like, it's your app. But this is a starting reference point with Hometown parity (and of course, if you like it as-is, then great).