### PR TITLE
feat: add account field icon for 'Language(s)'

### DIFF
--- a/composables/icons.ts
+++ b/composables/icons.ts
@@ -14,6 +14,8 @@ export const accountFieldIcons: Record<string, string> = Object.fromEntries(Obje
   Home: 'i-ri:home-2-line',
   Instagram: 'i-ri:instagram-line',
   Joined: 'i-ri:user-add-line',
+  Language: 'i-ri:translate-2',
+  Languages: 'i-ri:translate-2',
   LinkedIn: 'i-ri:linkedin-box-fill',
   Location: 'i-ri:map-pin-2-line',
   Mastodon: 'i-ri:mastodon-line',


### PR DESCRIPTION
This is useful for people posting in multiple languages on their account, which many people would list under a "Languages" metadata entry.

Before:
![image](https://user-images.githubusercontent.com/19366641/210284524-f4ca96d4-2c1f-4d33-92f6-2068323404ce.png)

After:
![image](https://user-images.githubusercontent.com/19366641/210284795-5df99400-5e60-4b5b-8d59-edf6e55923e6.png)