### PR TITLE
fix: update `m.webtoo.ls/@elk` links to open in Elk

### DIFF
--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -64,7 +64,7 @@ function toggleDark() {
       </template>
     </div>
     <div>
-      <a href="https://m.webtoo.ls/@elk" target="_blank">Mastodon</a> &middot; <a href="https://chat.elk.zone" target="_blank">Discord</a> &middot; <a href="https://github.com/elk-zone" target="_blank">GitHub</a>
+      <a href="/m.webtoo.ls/@elk" target="_blank">Mastodon</a> &middot; <a href="https://chat.elk.zone" target="_blank">Discord</a> &middot; <a href="https://github.com/elk-zone" target="_blank">GitHub</a>
     </div>
   </footer>
 </template>

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -56,7 +56,7 @@ const handleShowCommit = () => {
     <SettingsItem
       text="Mastodon"
       icon="i-ri:mastodon-line"
-      to="https://m.webtoo.ls/@elk"
+      to="/m.webtoo.ls/@elk"
       external target="_blank"
     />
     <SettingsItem


### PR DESCRIPTION
This PR updates the links to Elk's Mastodon profile to open directly in Elk, rather than in the default m.webtoo.ls client. It already happened to me twice in a few days to first click on the link in the right sidebar, then go back to Elk and manually search for the `@elk` profile :sweat_smile: 

There is a third link that already opens in Elk: https://github.com/elk-zone/elk/blob/269fc30afda2a8f9ee3c7820855f641ba0954d91/components/help/HelpPreview.vue#L25