### PR TITLE
fix: image thumbnail position

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -35,9 +35,12 @@ const aspectRatio = computed(() => {
 })
 
 const objectPosition = computed(() => {
-  return [attachment.meta?.focus?.x, attachment.meta?.focus?.y]
-    .map(v => v ? `${v * 100}%` : '50%')
-    .join(' ')
+  const focusX = attachment.meta?.focus?.x || 0
+  const focusY = attachment.meta?.focus?.y || 0
+  const x = ((focusX / 2) + 0.5) * 100
+  const y = ((focusY / -2) + 0.5) * 100
+
+  return `${x}% ${y}%`
 })
 
 const typeExtsMap = {


### PR DESCRIPTION
Was browsing federated timeline and found image with wrong thumbnail position. https://elk.zone/fosstodon.org/@TikToc@noagendasocial.com/109624621486581737
This happens if `attachment.meta.focus.x` or `.y` is 1.
I have copied focus.x(y) calculations from the main Mastodon repo.

Before:

![image](https://user-images.githubusercontent.com/2339406/210340531-7596d633-896e-4d98-b739-e4e3911f20e0.png)

After:

![image](https://user-images.githubusercontent.com/2339406/210340618-476eeb46-8d69-4ff5-a3d3-7426d3fbceee.png)
