### PR TITLE
fix: re-add extra spacing in threads

### DIFF
--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -60,7 +60,6 @@ onReactivated(() => {
       <div v-if="status" mt--1px pb="50vh">
         <template v-for="comment of context?.ancestors" :key="comment.id">
           <StatusCard
-            class="entryCard"
             :status="comment" :actions="comment.visibility !== 'direct'" context="account"
             :has-older="true" :has-newer="true"
           />
@@ -68,7 +67,6 @@ onReactivated(() => {
 
         <StatusDetails
           ref="main"
-          class="entryCard"
           :status="status"
           command
           style="scroll-margin-top: 60px"
@@ -85,7 +83,6 @@ onReactivated(() => {
 
         <template v-for="(comment, di) of context?.descendants" :key="comment.id">
           <StatusCard
-            class="entryCard"
             :status="comment" :actions="comment.visibility !== 'direct'" context="account"
             :older="context?.descendants[di + 1]" :newer="context?.descendants[di - 1]" :has-newer="di === 0" :main="status"
           />


### PR DESCRIPTION
This is a proposal for a fix to https://github.com/elk-zone/elk/issues/691

**Background**:
I did a PR (https://github.com/elk-zone/elk/pull/616) that removed bottom spacing in threads. It has since then been evident that this spacing had a purpose. Twitter uses something similar to this.

**In this PR**
Edit: Did a massive simplification. Now only re-add a CSS based bottom-padding. Simplicity is preferred in current alpha stage when there are enough moving parts as it is (as pointed out by @patak-dev)

**Testing**
- I have checked Mobile and Desktop. I think this is acceptable.

**Known problem**
- If you go in to a thread, scroll down and click on a post to load a sub-thread, it works fine. If you then go back to the start feed and open the same thread and the same sub-thread again, you will not get the right scroll position. (this is in current app and should be handled in a separate issue/PR)