### PR TITLE
fix: fixed the style bug when toggle the dark mode

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -90,7 +90,6 @@ const isDM = $computed(() => status.visibility === 'direct')
     ref="el"
     relative flex flex-col gap-1 pl-3 pr-4 pt-1
     class="pb-1.5"
-    transition-100
     :class="{ 'hover:bg-active': hover, 'border-t border-base': newer && !directReply }"
     tabindex="0"
     focus:outline-none focus-visible:ring="2 primary"


### PR DESCRIPTION
When toggle the dark mode causes the post to have obvious black-and-white line problems.

## Before

![CleanShot 2023-01-04 at 17 26 34](https://user-images.githubusercontent.com/6118824/210525337-ae13633c-23df-464e-a34d-54952e4cbffb.gif)

## After

![CleanShot 2023-01-04 at 17 27 51](https://user-images.githubusercontent.com/6118824/210525497-8741ace8-b2cc-4439-90f9-6d960be92105.gif)
