### PR TITLE
feat(search): :sparkles: show hashtag stats and chart in autocomplete

### DIFF
--- a/components/search/HashtagInfo.vue
+++ b/components/search/HashtagInfo.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-defineProps<{ hashtag: any }>()
+import type { History, Tag } from 'masto'
+
+const { hashtag } = defineProps<{ hashtag: Tag }>()
+
+const totalTrend = $computed(() =>
+  hashtag.history?.reduce((total: number, item) => total + (Number(item.accounts) || 0), 0),
+)
 </script>
 
 <template>
@@ -11,9 +17,10 @@ defineProps<{ hashtag: any }>()
       <span>
         {{ hashtag.name }}
       </span>
-      <span text-xs text-secondary>
-        {{ hashtag.following ? 'Following' : 'Not Following' }}
-      </span>
+      <CommonTrending :history="hashtag.history" text-xs text-secondary truncate />
+    </div>
+    <div v-if="totalTrend" w-12 h-12 flex place-items-center place-content-center ml-auto>
+      <CommonTrendingCharts :history="hashtag.history" text-xs text-secondary />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/244174/210627569-094ced31-f4c0-413a-ac54-ec16d2a6db7f.png)
After:
![image](https://user-images.githubusercontent.com/244174/210627496-c27a6e42-cf73-47cc-9bf7-d772edb3f0c0.png)

Resolves: #60