### PR TITLE
fix: sanitize HTML from Mastodon servers

### DIFF
--- a/tests/__snapshots__/content-rich.test.ts.snap
+++ b/tests/__snapshots__/content-rich.test.ts.snap
@@ -1,5 +1,12 @@
 // Vitest Snapshot v1
 
+exports[`content-rich > JavaScript hrefs get removed 1`] = `
+"<p>
+  <a href=\\"#\\" rel=\\"nofollow noopener noreferrer\\" target=\\"_blank\\">click me</a>
+</p>
+"
+`;
+
 exports[`content-rich > code frame 1`] = `
 "<p>Testing code block</p><p><pre lang=\\"ts\\">import { useMouse, usePreferredDark } from &#39;@vueuse/core&#39;
 // tracks mouse position
@@ -10,7 +17,13 @@ const isDark = usePreferredDark()</pre></p>"
 
 exports[`content-rich > code frame 2 1`] = `
 "<p>
-  <span class=\\"h-card\\"><a class=\\"u-url mention\\" to=\\"/mas.to/@antfu\\"></a></span>
+  <span class=\\"h-card\\"
+    ><a
+      class=\\"u-url mention\\"
+      rel=\\"nofollow noopener noreferrer\\"
+      to=\\"/mas.to/@antfu\\"
+    ></a
+  ></span>
   Testing<br />
   <pre lang=\\"ts\\">const a = hello</pre>
 </p>
@@ -60,5 +73,10 @@ exports[`content-rich > link + mention 1`] = `
     ><span class=\\"invisible\\">ive-library/pull/203</span></a
   >
 </p>
+"
+`;
+
+exports[`content-rich > script tags get removed 1`] = `
+"<p></p>
 "
 `;

--- a/tests/__snapshots__/html-parse.test.ts.snap
+++ b/tests/__snapshots__/html-parse.test.ts.snap
@@ -23,7 +23,11 @@ const isDark = usePreferredDark()
 exports[`html-parse > code frame 2 > html 1`] = `
 "<p>
   <span class=\\"h-card\\"
-    ><a href=\\"https://mas.to/@antfu\\" class=\\"u-url mention\\"
+    ><a
+      href=\\"https://mas.to/@antfu\\"
+      class=\\"u-url mention\\"
+      rel=\\"nofollow noopener noreferrer\\"
+      target=\\"_blank\\"
       >@<span>antfu</span></a
     ></span
   >


### PR DESCRIPTION
This pull request implements steps to sanitize the HTML content received from external Mastodon servers. This is done by: 
 * implementing a  function for running multiple (synchronous) transformations on ultrahtml node trees
 * creating a transformation that allows only a rather narrow selection of incoming HTML elements and attributes
 * converting existing HTML string transformations to HTML tree transformations, to avoid accidentally introducing new places to inject unsanitized HTML content

# Background

Mastodon servers send many types of content as HTML strings. The official Mastodon server takes care to sanitize the HTML content before sending, stripping away script tags and other elements that might cause havoc if injected as-is to the browser context. However, this relies on the Mastodon server being a benevolent entity, and implementing the sanitization steps properly.

This might not always be the case, however. One historical example of a non-malicious server accidentally allowing bypassing HTML sanitization, leading to potential password compromise, can be found in the article ["Stealing passwords from infosec Mastodon - without bypassing CSP"](https://portswigger.net/research/stealing-passwords-from-infosec-mastodon-without-bypassing-csp) by [Gareth Heyes](https://twitter.com/garethheyes).

The following scenario 
 * The user uses Elk to log in to two servers, server A and server B.
 * Server A gets compromised (or is bought by a volatile multi-billionaire, or just installs an extension that has some issues with sanitizing content like in the article linked above).
 * Server A's API starts sending HTML content that contains bad data, such as `<script>` elements.
 * The scripts get run in Elk's execution context (Elk's Content-Security-Policy allows inline scripts), allowing the script author free rein, e.g. to exfiltrate the user's server B secrets.

Currently Elk doesn't seem to sanitize the HTML input in all cases. This can be demonstrated by simulating a Mastodon server that sends unsanitary HTML content. On the Elk page, open the Chrome inspector, and paste the following code the the console:

```js
const p = JSON.parse; JSON.parse = function(x, ...args) { x = x.replace("content\":\"", "content\":\"<script>alert(1)</script>"); const z = p(x, ...args); return z; };
```

When Elk next loads new content and displays it, alert dialogs will get shown.

# Implementation

The idea behind these changes is to parse the HTML string data into a tree as soon as possible and remove potential bad incoming HTML elements from the tree. Then further transformations can be performed on the tree in a bit more controlled environment. Operating on the tree as much as possible can also hopefully avoid tricky HTML string transformation corner cases.

The main engine is the `transformSync` function that takes in an ultrahtml node, and runs an array of transformation functions to every node in the tree. Each transformation in the array is run to completion before the next is started.

A transformation function receives a node, with its children already transformed. The function can then return 0-n nodes that replace the original node in the tree. For convenience the function can also return strings that get converted to text nodes on the fly. Returning null (or an empty array) effectively removes the original node from the tree.

The main sanitation transform is implemented in the `sanitize` function. The function is configured with an object containing the tags that are still allowed to stay in the tree. All other elements get dropped. Each allowed tag also gets an object describing the attributes that are kept, and functions for transforming those attributes (or dropping them). All other attributes get dropped.

The selection of allowed elements and their attributes in incoming HTML data is rather narrow at the moment. It mainly follows the steps in the Mastodon server codebase (https://github.com/mastodon/mastodon/blob/17f79082b098e05b68d6f0d38fabb3ac121879a9/lib/sanitize_ext/sanitize_config.rb). There are some deviations, like allowing limited `<code>` and `<pre>` elements to enable Markdown code blocks. Relative links are also allowed, as they seem to be used elsewhere.

The sanitation transform is followed by `replaceUnicodeEmoji`, `formatMarkdown`, and `replaceCustomEmoji` transforms. I decided to convert those steps to operate on the parsed HTML tree instead of HTML strings, hoping it would help to avoid possible further HTML injection vulnerabilities in the future.

It should be noted that there's still one transform that operates on raw HTML strings: the code block support (implemented in the beginning of `parseMastodonHTML`). I couldn't fit it to the tree transform model without making it quite complex, so I figured it might be ok to leave it as-is. The sanitation step is run _after_ it, after all, which should take care of potential injections.

# Notes

 * The tests are updated accordingly.
 * The markdown parser is not using _exactly_ the same algorithm as previously. The new implementation tries each formatting regex in turn to find the first possible match, and then recursively process that content. The previous implementation first processed all the matches for the first regex, then all matches for the second regex, and so on. In practice this difference will most likely be small.
