### PR TITLE
refactor: use github avatar

### DIFF
--- a/components/help/HelpPreview.vue
+++ b/components/help/HelpPreview.vue
@@ -32,7 +32,7 @@ const emit = defineEmits<{
     <p flex="~ gap-2 wrap" mxa>
       <template v-for="team of teams" :key="team.github">
         <a :href="`https://github.com/sponsors/${team.github}`" target="_blank" rounded-full transition duration-300 border="~ transparent" hover="scale-105 border-primary">
-          <img :src="`https://github.com/${team.github}.png?size=64`" :alt="team.display" rounded-full w-15 h-15 height="60" width="60">
+          <img :src="`https://github.com/${team.github}.png?size=60`" :alt="team.display" rounded-full w-15 h-15 height="60" width="60">
         </a>
       </template>
     </p>

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -91,7 +91,7 @@ const handleShowCommit = () => {
         external target="_blank"
       >
         <template #icon>
-          <img :src="`https://github.com/${team.github}.png?size=64`" :alt="team.display" rounded-full w-8 h-8 height="32" width="32">
+          <img :src="`https://github.com/${team.github}.png?size=100`" :alt="team.display" rounded-full w-8 h-8 height="32" width="32">
         </template>
       </SettingsItem>
     </template>


### PR DESCRIPTION
I changed to GitHub avatar back (with image size), since @patak-dev 's Twitter avatar is gray...