### PR TITLE
fix: prevent rounded background when avatar is square

### DIFF
--- a/components/account/AccountBigAvatar.vue
+++ b/components/account/AccountBigAvatar.vue
@@ -11,7 +11,7 @@ defineProps<{
 </script>
 
 <template>
-  <div :key="account.avatar" v-bind="$attrs" rounded-full bg-base w-54px h-54px flex items-center justify-center>
+  <div :key="account.avatar" v-bind="$attrs" :rounded-full="!square" :bg-base="!square" w-54px h-54px flex items-center justify-center>
     <AccountAvatar :account="account" w-48px h-48px :square="square" />
   </div>
 </template>


### PR DESCRIPTION
follow up on  #808

issue:
![CleanShot 2023-01-05 at 22 40 58](https://user-images.githubusercontent.com/28706372/210893940-dee9ec21-f0a0-43f0-a49c-84cec3c42648.png)
