### PR TITLE
feat: add post deletion confirm dialog

### DIFF
--- a/components/modal/ModalConfirm.vue
+++ b/components/modal/ModalConfirm.vue
@@ -1,29 +1,27 @@
 <script setup lang="ts">
-import type { ConfirmDialogLabels } from '~/types'
+import type { ConfirmDialogChoice, ConfirmDialogLabel } from '~/types'
 
-defineProps<{
-  labels: ConfirmDialogLabels
-}>()
+defineProps<ConfirmDialogLabel>()
 
 const emit = defineEmits<{
-  (e: 'choice', v: boolean): void
+  (evt: 'choice', choice: ConfirmDialogChoice): void
 }>()
 </script>
 
 <template>
   <div flex="~ col" gap-6>
-    <div font-bold text-lg>
-      {{ labels.title }}
+    <div font-bold text-lg text-center>
+      {{ title }}
     </div>
-    <div v-if="labels.description">
-      {{ labels.description }}
+    <div v-if="description">
+      {{ description }}
     </div>
     <div flex justify-end gap-2>
-      <button btn-text @click="emit('choice', false)">
-        {{ labels.cancel }}
+      <button btn-text @click="emit('choice', 'cancel')">
+        {{ cancel || $t('common.confirm_dialog.cancel') }}
       </button>
-      <button btn-solid @click="emit('choice', true)">
-        {{ labels.confirm }}
+      <button btn-solid @click="emit('choice', 'confirm')">
+        {{ confirm || $t('common.confirm_dialog.confirm') }}
       </button>
     </div>
   </div>

--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Status } from 'masto'
+import type { ConfirmDialogChoice } from '~/types'
 import {
-  confirmDialogLabels,
   isCommandPanelOpen,
   isConfirmDialogOpen,
   isEditHistoryDialogOpen,
@@ -39,7 +39,7 @@ const handlePublishClose = () => {
   lastPublishDialogStatus.value = null
 }
 
-const handleConfimChoice = (choice: boolean) => {
+const handleConfirmChoice = (choice: ConfirmDialogChoice) => {
   confirmDialogChoice.value = choice
   isConfirmDialogOpen.value = false
 }
@@ -79,7 +79,7 @@ const handleConfimChoice = (choice: boolean) => {
       <CommandPanel @close="closeCommandPanel()" />
     </ModalDialog>
     <ModalDialog v-model="isConfirmDialogOpen" py-4 px-8 max-w-125>
-      <ModalConfirm :labels="confirmDialogLabels!" @choice="handleConfimChoice" />
+      <ModalConfirm v-if="confirmDialogLabel" v-bind="confirmDialogLabel" @choice="handleConfirmChoice" />
     </ModalDialog>
   </template>
 </template>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -61,19 +61,12 @@ const shareLink = async (status: Status) => {
 }
 
 const deleteStatus = async () => {
-  if (!await openConfirmDialog({
+  if (await openConfirmDialog({
     title: t('menu.delete_confirm.title'),
     confirm: t('menu.delete_confirm.confirm'),
     cancel: t('menu.delete_confirm.cancel'),
-  }))
+  }) !== 'confirm')
     return
-
-  if (process.dev) {
-    // eslint-disable-next-line no-alert
-    const result = confirm('[DEV] Are you sure you want to delete this post?')
-    if (!result)
-      return
-  }
 
   removeCachedStatus(status.id)
   await masto.statuses.remove(status.id)

--- a/composables/dialog.ts
+++ b/composables/dialog.ts
@@ -1,9 +1,9 @@
 import type { Attachment, Status, StatusEdit } from 'masto'
-import type { ConfirmDialogLabels, Draft } from '~/types'
+import type { ConfirmDialogChoice, ConfirmDialogLabel, Draft } from '~/types'
 import { STORAGE_KEY_FIRST_VISIT } from '~/constants'
 
-export const confirmDialogChoice = ref(false)
-export const confirmDialogLabels = ref<ConfirmDialogLabels>()
+export const confirmDialogChoice = ref<ConfirmDialogChoice>()
+export const confirmDialogLabel = ref<ConfirmDialogLabel>()
 
 export const mediaPreviewList = ref<Attachment[]>([])
 export const mediaPreviewIndex = ref(0)
@@ -29,14 +29,14 @@ export function openSigninDialog() {
   isSigninDialogOpen.value = true
 }
 
-export async function openConfirmDialog(labels: ConfirmDialogLabels): Promise<boolean> {
-  confirmDialogLabels.value = labels
-  confirmDialogChoice.value = false
+export async function openConfirmDialog(label: ConfirmDialogLabel | string): Promise<ConfirmDialogChoice> {
+  confirmDialogLabel.value = typeof label === 'string' ? { title: label } : label
+  confirmDialogChoice.value = undefined
   isConfirmDialogOpen.value = true
 
   await until(isConfirmDialogOpen).toBe(false)
 
-  return confirmDialogChoice.value
+  return confirmDialogChoice.value!
 }
 
 export async function openPublishDialog(draftKey = 'dialog', draft?: Draft, overwrite = false): Promise<void> {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -89,7 +89,7 @@
     "confirm_dialog": {
       "cancel": "No",
       "confirm": "Yes",
-      "title": "Are you sure ?"
+      "title": "Are you sure?"
     },
     "end_of_list": "End of the list",
     "error": "ERROR",
@@ -130,8 +130,8 @@
     "delete_and_redraft": "Delete & re-draft",
     "delete_confirm": {
       "cancel": "Cancel",
-      "confirm": "@:menu.delete",
-      "title": "Are you sure you want to delete this post ?"
+      "confirm": "Delete",
+      "title": "Are you sure you want to delete this post?"
     },
     "direct_message_account": "Direct message {0}",
     "edit": "Edit",

--- a/types/index.ts
+++ b/types/index.ts
@@ -65,12 +65,13 @@ export interface Draft {
 }
 export type DraftMap = Record<string, Draft>
 
-export interface ConfirmDialogLabels {
+export interface ConfirmDialogLabel {
   title: string
   description?: string
-  confirm: string
-  cancel: string
+  confirm?: string
+  cancel?: string
 }
+export type ConfirmDialogChoice = 'confirm' | 'cancel'
 
 export interface BuildInfo {
   version: string


### PR DESCRIPTION
Closes #753 

Also adds a "generic" confirmation dialog prompted by a call to `openConfirmDialog()` that takes the prompt labels as parameters and returns `true/false` based on what the user chooses.

The dialog is very simple atm, it may be good to challenge its UX/UI. 
But a good thing with confirmation dialogs is to avoid being "too generic" with choices like "Yes/No" or "Ok/Cancel".
A good practice is to name the `true` action button after what the action does, in this case "Delete".

An optional description can also be passed to emphasizes on consequences the choice can have.