### PR TITLE
fix: current nav side on pwa update

### DIFF
--- a/components/nav/NavSideItem.vue
+++ b/components/nav/NavSideItem.vue
@@ -30,8 +30,6 @@ useCommand({
 
 let activeClass = $ref('text-primary')
 onMastoInit(async () => {
-  // eslint-disable-next-line no-console
-  console.log('TEST')
   // TODO: force NuxtLink to reevaluate, we now we are in this route though, so we should force it to active
   // we don't have currentServer defined until later
   activeClass = ''


### PR DESCRIPTION
Should update also for `user-only` entries.

On draft, and so, we can test it changing some entry...

closes #820