### PR TITLE
fix: refresh wide layout pages broken

### DIFF
--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -1,3 +1,9 @@
+<script setup>
+definePageMeta({
+  wideLayout: true,
+})
+</script>
+
 <template>
   <div min-h-screen flex justify-center items-center>
     <div text-center flex="~ col gap-2" items-center>


### PR DESCRIPTION
Refreshing any setting page (using wide layout) the syles applied on default layout is updated to false.

close #628