### PR TITLE
feat(publish): add hashtag autocomplete

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -56,6 +56,7 @@ const { editor } = useTiptap({
   onPaste: handlePaste,
 })
 
+const characterCount = $computed(() => htmlToText(editor.value?.getHTML() || '').length)
 let isUploading = $ref<boolean>(false)
 let isExceedingAttachmentLimit = $ref<boolean>(false)
 let failed = $ref<FileUploadError[]>([])
@@ -312,8 +313,8 @@ defineExpose({
 
         <div flex-auto />
 
-        <div dir="ltr" pointer-events-none pe-1 pt-2 text-sm tabular-nums text-secondary flex gap-0.5>
-          {{ editor?.storage.characterCount.characters() }}<span text-secondary-light>/</span><span text-secondary-light>{{ characterLimit }}</span>
+        <div dir="ltr" pointer-events-none pe-1 pt-2 text-sm tabular-nums text-secondary flex gap-0.5 :class="{ 'text-rose-500': characterCount > characterLimit }">
+          {{ characterCount ?? 0 }}<span text-secondary-light>/</span><span text-secondary-light>{{ characterLimit }}</span>
         </div>
 
         <CommonTooltip placement="top" :content="$t('tooltip.add_content_warning')">
@@ -347,7 +348,7 @@ defineExpose({
 
         <button
           btn-solid rounded-3 text-sm w-full md:w-fit
-          :disabled="isEmpty || isUploading || (draft.attachments.length === 0 && !draft.params.status)"
+          :disabled="isEmpty || isUploading || (draft.attachments.length === 0 && !draft.params.status) || characterCount > characterLimit"
           @click="publish"
         >
           {{ !draft.editingStatus ? $t('action.publish') : $t('action.save_changes') }}

--- a/composables/tiptap.ts
+++ b/composables/tiptap.ts
@@ -4,7 +4,6 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import Mention from '@tiptap/extension-mention'
-import CharacterCount from '@tiptap/extension-character-count'
 import HardBreak from '@tiptap/extension-hard-break'
 import Bold from '@tiptap/extension-bold'
 import Italic from '@tiptap/extension-italic'
@@ -60,9 +59,6 @@ export function useTiptap(options: UseTiptapOptions) {
         }),
       Placeholder.configure({
         placeholder: placeholder.value,
-      }),
-      CharacterCount.configure({
-        limit: characterLimit.value,
       }),
       CodeBlockShiki,
       Extension.create({


### PR DESCRIPTION
Character count is now based on markdown sent to mastodon, not text content
Now it should match the mastodon
<img width="285" alt="image" src="https://user-images.githubusercontent.com/244174/211103016-9c1ee0c0-a29c-425d-8378-4268e9b49635.png">

Before:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/244174/211102693-baa1acdb-9f16-4ce7-8bc3-7f9a0cdc1ffa.png">
After:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/244174/211102791-be983c80-cb35-4966-b73c-92b2b34e245d.png">

I've also matched the behaviour when you exceed the character count

Ref #639 and #472