### PR TITLE
fix: add space between default size and the text default

### DIFF
--- a/components/settings/SettingsFontSize.vue
+++ b/components/settings/SettingsFontSize.vue
@@ -9,7 +9,7 @@ const fontSize = useFontSizeRef()
 <template>
   <select v-model="fontSize">
     <option v-for="size in sizes" :key="size" :value="size" :selected="fontSize === size">
-      {{ `${$t(`settings.interface.size_label.${size}`)}${size === DEFAULT_FONT_SIZE ? $t('settings.interface.default') : ''}` }}
+      {{ `${$t(`settings.interface.size_label.${size}`)} ${size === DEFAULT_FONT_SIZE ? $t('settings.interface.default') : ''}` }}
     </option>
   </select>
 </template>


### PR DESCRIPTION
BEFORE:
![image](https://user-images.githubusercontent.com/2922851/211111024-1fed6cd7-0afc-44e4-9ec0-aa740c99ec88.png)

AFTER:
![image](https://user-images.githubusercontent.com/2922851/211111063-6ff94645-cf3e-4d41-8125-c87fb77a9dd2.png)
