### PR TITLE
feat(ui): opening the details page with the reply button

### DIFF
--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -24,13 +24,11 @@ const { formatHumanReadableNumber, formatNumber, forSR } = useHumanReadableNumbe
 const reply = () => {
   if (!checkLogin())
     return
-  if (details) {
+  if (details)
     focusEditor()
-  }
-  else {
-    const { key, draft } = getReplyDraft(status)
-    openPublishDialog(key, draft())
-  }
+
+  else
+    navigateTo({ path: getStatusRoute(status).href, state: { focusReply: true } })
 }
 </script>
 

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -49,6 +49,11 @@ const focusEditor = () => {
 
 provide('focus-editor', focusEditor)
 
+watch(publishWidget, () => {
+  if (window.history.state.focusReply)
+    focusEditor()
+})
+
 onReactivated(() => {
   // Silently update data when reentering the page
   // The user will see the previous content first, and any changes will be updated to the UI when the request is completed


### PR DESCRIPTION
Now the reply button navigates to the details page and focuses on the editor instead of opening a popup, which should improve the experience or replying to threads.
It was proposed by @patak-dev [on discord](https://discord.com/channels/1044887051155292200/1045711701359743098/1060971747454763101)