### PR TITLE
fix: allow logout without push notifications

### DIFF
--- a/composables/users.ts
+++ b/composables/users.ts
@@ -183,6 +183,9 @@ export function getUsersIndexByUserId(userId: string) {
 }
 
 export async function removePushNotificationData(user: UserLogin, fromSWPushManager = true) {
+  if (!user.pushSubscription)
+    return
+
   // clear push subscription
   user.pushSubscription = undefined
   const { acct } = user.account


### PR DESCRIPTION
currently in a preview environment you can't log out - and I assume the same is true when you've signed in but not enabled push notifications