### PR TITLE
fix: exclude unreviewed hashtags from autocomplete

### DIFF
--- a/composables/tiptap/suggestion.ts
+++ b/composables/tiptap/suggestion.ts
@@ -29,7 +29,13 @@ export const HashtagSuggestion: Partial<SuggestionOptions> = {
     if (query.length === 0)
       return []
 
-    const paginator = useMasto().v2.search({ q: query, type: 'hashtags', limit: 25, resolve: true })
+    const paginator = useMasto().v2.search({
+      q: query,
+      type: 'hashtags',
+      limit: 25,
+      resolve: false,
+      excludeUnreviewed: true,
+    })
     const results = await paginator.next()
 
     return results.value.hashtags


### PR DESCRIPTION
This greatly improves relevancy of hashtag autocomplete results

Before:
![screenshot_2023-01-08_14-53-45_099268919](https://user-images.githubusercontent.com/2339406/211197095-9a00cda4-552c-4a47-b8b2-21451b15c791.png)

After:
![screenshot_2023-01-08_14-53-02_573021641](https://user-images.githubusercontent.com/2339406/211197097-ae160ac3-b536-4894-990c-0cf32e2b8f08.png)
