### PR TITLE
feat: avoid reordering pagination border effects

### DIFF
--- a/components/common/CommonPaginator.vue
+++ b/components/common/CommonPaginator.vue
@@ -10,6 +10,7 @@ const {
   keyProp = 'id',
   virtualScroller = false,
   eventType = 'update',
+  buffer = 10,
   preprocess,
 } = defineProps<{
   paginator: Paginator<T[], O>
@@ -17,6 +18,10 @@ const {
   virtualScroller?: boolean
   stream?: Promise<WsEvents>
   eventType?: 'notification' | 'update'
+  // When preprocess is used, buffer is the number of items that will be hidden
+  // until the next pagination to avoid border effect between pages when reordering
+  // and grouping items
+  buffer?: number
   preprocess?: (items: T[]) => any[]
 }>()
 

--- a/components/status/edit/StatusEditHistory.vue
+++ b/components/status/edit/StatusEditHistory.vue
@@ -13,12 +13,13 @@ const showHistory = (edit: mastodon.v1.StatusEdit) => {
 }
 const timeAgoOptions = useTimeAgoOptions()
 
+// TODO: rework, this is only reversing the first page of edits
 const reverseHistory = (items: mastodon.v1.StatusEdit[]) =>
   [...items].reverse()
 </script>
 
 <template>
-  <CommonPaginator :paginator="paginator" key-prop="createdAt" :preprocess="reverseHistory">
+  <CommonPaginator :paginator="paginator" key-prop="createdAt" :preprocess="reverseHistory" :buffer="0">
     <template #default="{ items, item, index }">
       <CommonDropdownItem
         px="0.5"

--- a/components/timeline/TimelineHome.vue
+++ b/components/timeline/TimelineHome.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const paginator = useMasto().v1.timelines.listHome()
+const paginator = useMasto().v1.timelines.listHome({ limit: 30 })
 const stream = useMasto().v1.stream.streamUser()
 onBeforeUnmount(() => stream?.then(s => s.disconnect()))
 </script>

--- a/components/timeline/TimelinePaginator.vue
+++ b/components/timeline/TimelinePaginator.vue
@@ -4,12 +4,13 @@ import { DynamicScrollerItem } from 'vue-virtual-scroller'
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 import type { Paginator, WsEvents, mastodon } from 'masto'
 
-const { paginator, stream, account } = defineProps<{
+const { paginator, stream, account, buffer = 10 } = defineProps<{
   paginator: Paginator<mastodon.v1.Status[], mastodon.v1.ListAccountStatusesParams>
   stream?: Promise<WsEvents>
   context?: mastodon.v2.FilterContext
   account?: mastodon.v1.Account
   preprocess?: (items: mastodon.v1.Status[]) => mastodon.v1.Status[]
+  buffer?: number
 }>()
 
 const { formatNumber } = useHumanReadableNumber()
@@ -21,7 +22,7 @@ const showOriginSite = $computed(() =>
 </script>
 
 <template>
-  <CommonPaginator v-bind="{ paginator, stream, preprocess }" :virtual-scroller="virtualScroller">
+  <CommonPaginator v-bind="{ paginator, stream, preprocess, buffer }" :virtual-scroller="virtualScroller">
     <template #updater="{ number, update }">
       <button py-4 border="b base" flex="~ col" p-3 w-full text-primary font-bold @click="update">
         {{ $t('timeline.show_new_items', number, { named: { v: formatNumber(number) } }) }}

--- a/components/timeline/TimelinePublic.vue
+++ b/components/timeline/TimelinePublic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const paginator = useMasto().v1.timelines.listPublic()
+const paginator = useMasto().v1.timelines.listPublic({ limit: 30 })
 const stream = useMasto().v1.stream.streamPublicTimeline()
 onBeforeUnmount(() => stream.then(s => s.disconnect()))
 </script>

--- a/components/timeline/TimelinePublicLocal.vue
+++ b/components/timeline/TimelinePublicLocal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const paginator = useMasto().v1.timelines.listPublic({ local: true })
+const paginator = useMasto().v1.timelines.listPublic({ limit: 30, local: true })
 const stream = useMasto().v1.stream.streamCommunityTimeline()
 onBeforeUnmount(() => stream.then(s => s.disconnect()))
 </script>

--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -6,6 +6,7 @@ export function usePaginator<T, P>(
   stream?: Promise<WsEvents>,
   eventType: 'notification' | 'update' = 'update',
   preprocess: (items: T[]) => T[] = (items: T[]) => items,
+  buffer = 10,
 ) {
   const state = ref<PaginatorState>(isMastoInitialised.value ? 'idle' : 'loading')
   const items = ref<T[]>([])
@@ -62,8 +63,10 @@ export function usePaginator<T, P>(
       const result = await paginator.next()
 
       if (result.value?.length) {
-        nextItems.value = preprocess(result.value) as any
-        items.value.push(...nextItems.value)
+        const preprocessedItems = preprocess([...nextItems.value, ...result.value]) as any
+        const itemsToShowCount = preprocessedItems.length - buffer
+        nextItems.value = preprocessedItems.slice(itemsToShowCount)
+        items.value.push(...preprocessedItems.slice(0, itemsToShowCount))
         state.value = 'idle'
       }
       else {
@@ -108,7 +111,6 @@ export function usePaginator<T, P>(
   return {
     items,
     prevItems,
-    nextItems,
     update,
     state,
     error,

--- a/pages/[[server]]/@[account]/index/index.vue
+++ b/pages/[[server]]/@[account]/index/index.vue
@@ -8,7 +8,7 @@ const { t } = useI18n()
 
 const account = await fetchAccountByHandle(handle)
 
-const paginator = useMasto().v1.accounts.listStatuses(account.id, { excludeReplies: true })
+const paginator = useMasto().v1.accounts.listStatuses(account.id, { limit: 30, excludeReplies: true })
 
 if (account) {
   useHeadFixed({


### PR DESCRIPTION
We now have two ways of grouping:

1. how we reorder the timeline: we preprocess chunks of new items. This is good because there aren't reorderings as you scroll, the con is that we miss some possible reordering in the borders of pagination

2. how we group notifications: we do the grouping every time there are new items. This triggers reorderings as you scroll, and also have an issue with some combos of notifications requiring 8 pagination calls to fulfill a page if we group too much.

Let's move everything to 1., but change the way we do pagination and preprocessing to:
a. We over-fetch. Let's say 30 items, preprocess them, then only show the first 20. 
b. When we hit the border, we fetch 30 more, we process the ~10 we didn't show + the new ones, and again only show all minus 10. That way we have the benefits of avoiding reordering/regrouping, but we avoid most pagination border issues

This PR implements 1+(a+b) for reordering. In a future PR, I'll move the notifications from 2 to 1.