### PR TITLE
feat: support showing who favorited and boosted a status

### DIFF
--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -5,6 +5,7 @@ import {
   isCommandPanelOpen,
   isConfirmDialogOpen,
   isEditHistoryDialogOpen,
+  isFavouritedBoostedByDialogOpen,
   isMediaPreviewOpen,
   isPreviewHelpOpen,
   isPublishDialogOpen,
@@ -43,6 +44,10 @@ const handleConfirmChoice = (choice: ConfirmDialogChoice) => {
   confirmDialogChoice.value = choice
   isConfirmDialogOpen.value = false
 }
+
+const handleFavouritedBoostedByClose = () => {
+  isFavouritedBoostedByDialogOpen.value = false
+}
 </script>
 
 <template>
@@ -80,6 +85,13 @@ const handleConfirmChoice = (choice: ConfirmDialogChoice) => {
     </ModalDialog>
     <ModalDialog v-model="isConfirmDialogOpen" py-4 px-8 max-w-125>
       <ModalConfirm v-if="confirmDialogLabel" v-bind="confirmDialogLabel" @choice="handleConfirmChoice" />
+    </ModalDialog>
+    <ModalDialog
+      v-model="isFavouritedBoostedByDialogOpen"
+      max-w-180
+      @close="handleFavouritedBoostedByClose"
+    >
+      <StatusFavouritedBoostedBy />
     </ModalDialog>
   </template>
 </template>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -111,6 +111,10 @@ async function editStatus() {
     editingStatus: status,
   }, true)
 }
+
+const showFavoritedAndBoostedBy = () => {
+  openFavoridedBoostedByDialog(status.id)
+}
 </script>
 
 <template>
@@ -161,6 +165,13 @@ async function editStatus() {
             @click="toggleBookmark()"
           />
         </template>
+
+        <CommonDropdownItem
+          :text="$t('menu.show_favourited_and_boosted_by')"
+          icon="i-ri:hearts-line"
+          :command="command"
+          @click="showFavoritedAndBoostedBy()"
+        />
 
         <CommonDropdownItem
           :text="$t('menu.copy_link_to_post')"

--- a/components/status/StatusFavouritedBoostedBy.vue
+++ b/components/status/StatusFavouritedBoostedBy.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { favouritedBoostedByStatusId } from '~/composables/dialog'
+
+const type = ref<'favourited-by' | 'boosted-by'>('favourited-by')
+
+function load() {
+  return useMasto().v1.statuses[type.value === 'favourited-by' ? 'listFavouritedBy' : 'listRebloggedBy'](favouritedBoostedByStatusId.value!)
+}
+
+const paginator = $computed(() => load())
+
+function showFavouritedBy() {
+  type.value = 'favourited-by'
+}
+
+function showRebloggedBy() {
+  type.value = 'boosted-by'
+}
+
+const { t } = useI18n()
+const tabs = [
+  {
+    name: 'favourited-by',
+    display: t('status.favourited_by'),
+    onClick: showFavouritedBy,
+  },
+  {
+    name: 'boosted-by',
+    display: t('status.boosted_by'),
+    onClick: showRebloggedBy,
+  },
+]
+</script>
+
+<template>
+  <div flex w-full items-center lg:text-lg of-x-auto scrollbar-hide>
+    <template
+      v-for="option in tabs"
+      :key="option.name"
+    >
+      <div
+        relative flex flex-auto cursor-pointer sm:px6 px2 rounded transition-all
+        tabindex="1"
+        hover:bg-active transition-100
+        @click="option.onClick"
+      >
+        <span
+          ws-nowrap mxa sm:px2 sm:py3 xl:pb4 xl:pt5 py2 text-center border-b-3
+          :class="option.name === type ? 'border-primary op100 text-base' : 'border-transparent text-secondary-light hover:text-secondary op50'"
+        >{{
+          option.display
+        }}</span>
+      </div>
+    </template>
+  </div>
+  <AccountPaginator :key="`paginator-${type}`" :paginator="paginator" />
+</template>

--- a/composables/dialog.ts
+++ b/composables/dialog.ts
@@ -22,8 +22,11 @@ export const isEditHistoryDialogOpen = ref(false)
 export const isPreviewHelpOpen = ref(isFirstVisit.value)
 export const isCommandPanelOpen = ref(false)
 export const isConfirmDialogOpen = ref(false)
+export const isFavouritedBoostedByDialogOpen = ref(false)
 
 export const lastPublishDialogStatus = ref<mastodon.v1.Status | null>(null)
+
+export const favouritedBoostedByStatusId = ref<string | null>(null)
 
 export function openSigninDialog() {
   isSigninDialogOpen.value = true
@@ -60,6 +63,11 @@ export async function openPublishDialog(draftKey = 'dialog', draft?: Draft, over
   isPublishDialogOpen.value = true
 
   await until(isPublishDialogOpen).toBe(false)
+}
+
+export async function openFavoridedBoostedByDialog(statusId: string) {
+  isFavouritedBoostedByDialogOpen.value = true
+  favouritedBoostedByStatusId.value = statusId
 }
 
 if (isPreviewHelpOpen.value) {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -146,6 +146,7 @@
     "open_in_original_site": "Open in original site",
     "pin_on_profile": "Pin on profile",
     "share_post": "Share this post",
+    "show_favourited_and_boosted_by": "Show who favourited and boosted",
     "show_reblogs": "Show boosts from {0}",
     "show_untranslated": "Show untranslated",
     "toggle_theme": {
@@ -346,7 +347,9 @@
     "uploading": "Uploading..."
   },
   "status": {
+    "boosted_by": "Boosted By",
     "edited": "Edited {0}",
+    "favourited_by": "Favorited By",
     "filter_hidden_phrase": "Filtered by",
     "filter_removed_phrase": "Removed by filter",
     "filter_show_anyway": "Show anyway",


### PR DESCRIPTION
This PR allows listing the users who favorited/boosted a status.

Both Twitter and the main Mastodon client duplicate the inline like/reblog menu, once to show the numbers (and as a link to show the users list), and once as the actual like/reblog action button:

![Twitter](https://user-images.githubusercontent.com/7000710/211207878-0533ec3d-fc72-4a53-9e4c-971e1014381d.png)
![Elk](https://user-images.githubusercontent.com/7000710/211207880-5c300481-b919-4a8d-b789-ae9bf7350a84.png)


To keep the Elk UI cleaner, I instead added an entry to the actions menu that allows listing the accounts who favorited/boosted:

![New item in the status menu](https://user-images.githubusercontent.com/7000710/211208119-7241915c-4b35-4ded-8be9-6ca372ecc472.png)


This is how the list looks:
![Accounts list](https://user-images.githubusercontent.com/7000710/211207897-06a5738f-a65d-4c3a-9e84-3b02d312e95e.png)

Fixes #512