### PR TITLE
fix(nuxt): use `unshift` on `publicAssets` on env module

### DIFF
--- a/modules/build-env.ts
+++ b/modules/build-env.ts
@@ -25,9 +25,9 @@ export default defineNuxtModule({
     nuxt.hook('nitro:config', (config) => {
       config.publicAssets = config.publicAssets || []
       if (env === 'dev')
-        config.publicAssets.push({ dir: resolve('../public-dev') })
+        config.publicAssets.unshift({ dir: resolve('../public-dev') })
       else if (env === 'canary' || env === 'preview' || !isCI)
-        config.publicAssets.push({ dir: resolve('../public-staging') })
+        config.publicAssets.unshift({ dir: resolve('../public-staging') })
     })
   },
 })


### PR DESCRIPTION
On dev server Elk is brown, applying this change Elk is green, seems to not be working with netlifly adapter.