### PR TITLE
chore: move docs redirect into `_redirects`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,10 +8,3 @@
   to = "https://discord.gg/vAZSDU9J"
   status = 301
   force = true
-
-# Redirect to the docs
-[[redirects]]
-  from = "/docs"
-  to = "https://docs.elk.zone/"
-  status = 200
-  force = true

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/docs/* https://docs.elk.zone/:splat 200


### PR DESCRIPTION
Allows us to access with something like https://main.elk.zone/docs.

Previously the nuxt-generated `_redirects` file was overriding our `netlify.toml` settings.