### PR TITLE
perf(pwa): exclude shiki from sw precache

### DIFF
--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -14,7 +14,7 @@ export const pwa: VitePWANuxtOptions = {
   manifest: false,
   injectManifest: {
     globPatterns: ['**/*.{js,json,css,html,txt,svg,png,ico,webp,woff,woff2,ttf,eot,otf,wasm,webmanifest}'],
-    globIgnores: ['emojis/**'],
+    globIgnores: ['emojis/**', 'shiki/**'],
   },
   devOptions: {
     enabled: process.env.VITE_DEV_PWA === 'true',

--- a/service-worker/sw.ts
+++ b/service-worker/sw.ts
@@ -36,6 +36,19 @@ if (import.meta.env.PROD)
 
 // only cache pages and external assets on local build + start or in production
 if (import.meta.env.PROD) {
+  // include shiki cache
+  registerRoute(
+    ({ sameOrigin, url }) =>
+      sameOrigin && url.pathname.startsWith('/shiki/'),
+    new StaleWhileRevalidate({
+      cacheName: 'elk-shiki',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+        // 365 days max
+        new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 365 }),
+      ],
+    }),
+  )
   // include emoji icons
   registerRoute(
     ({ sameOrigin, request, url }) =>


### PR DESCRIPTION
This PR exclude `shiki` resources from the service worker precache in all environments: ~7.5MB (raw)