### PR TITLE
fix: alt button covers audio play button

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -173,8 +173,8 @@ useIntersectionObserver(video, (entries) => {
         <button
           font-bold text-sm
           :class="isAudio
-            ? 'rounded-full h-15 w-15 px4 py0 btn-outline border-base text-secondary hover:bg-black hover:text-white'
-            : 'rounded-1 bg-black/65 text-white hover:bg-black'"
+            ? 'rounded-full h-15 w-15 btn-outline border-base text-secondary hover:bg-active hover:text-active'
+            : 'rounded-1 bg-black/65 text-white hover:bg-black px1.2 py0.2'"
         >
           <div hidden>
             read {{ attachment.type }} description


### PR DESCRIPTION
fixes #809 

A bit of a quick fix for now. This PR will put the ALT button to the side for audio attachments
Test audio post: https://deploy-preview-911--elk-zone.netlify.app/mstdn.social/@feditips/109644044918079289

Tested video, GIF, and images--they should stay the same (see screenshots at the bottom)

| before | after |
| --- | --- |
| <img width="609" alt="Screenshot 2023-01-09 at 4 36 14 PM" src="https://user-images.githubusercontent.com/4262489/211346643-b3d45631-5c83-4aaf-8fd0-645085ddc548.png"> | <img width="610" alt="Screenshot 2023-01-09 at 4 34 09 PM" src="https://user-images.githubusercontent.com/4262489/211346098-57e02eb1-940c-4d55-ba59-d29e59e1cb84.png"> |
| <img width="605" alt="Screenshot 2023-01-09 at 4 35 23 PM" src="https://user-images.githubusercontent.com/4262489/211346427-b6f3bb87-2828-4e05-bb7a-a6006f391343.png"> | <img width="610" alt="Screenshot 2023-01-09 at 4 34 48 PM" src="https://user-images.githubusercontent.com/4262489/211346253-f751353c-d71d-4366-80ce-b482b3ecd848.png"> |

### Other media types should stay the same

Video: https://deploy-preview-911--elk-zone.netlify.app/mas.to/@ayodev/109660045793754684
<img width="607" alt="Screenshot 2023-01-09 at 4 58 25 PM" src="https://user-images.githubusercontent.com/4262489/211351676-eaf71102-c1e4-4e1f-8895-a75b6734720c.png">

GIF: https://deploy-preview-911--elk-zone.netlify.app/mas.to/@ayodev/109660075909387316
<img width="602" alt="Screenshot 2023-01-09 at 4 59 56 PM" src="https://user-images.githubusercontent.com/4262489/211352035-c0df351b-cbdf-4d14-b393-f87462fa0f31.png">

Image: https://deploy-preview-911--elk-zone.netlify.app/fosstodon.org/@viteconf/109659720641159906
<img width="595" alt="Screenshot 2023-01-09 at 5 00 26 PM" src="https://user-images.githubusercontent.com/4262489/211352163-2139241a-b287-4351-88c8-a43f885c3d3c.png">

