### PR TITLE
feat: use square avatar when on own profile

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -70,8 +70,8 @@ const isSelf = $computed(() => currentUser.value?.account.id === account.id)
     <div p4 mt--18 flex flex-col gap-4>
       <div relative>
         <div flex="~ col gap-2 1">
-          <button w-30 h-30 rounded-full border-4 border-bg-base z-2 @click="previewAvatar">
-            <AccountAvatar :account="account" hover:opacity-90 transition-opacity />
+          <button :class="{ 'rounded-full': !isSelf, 'squircle': isSelf }" w-30 h-30 p1 bg-base border-bg-base z-2 @click="previewAvatar">
+            <AccountAvatar :square="isSelf" :account="account" hover:opacity-90 transition-opacity />
           </button>
           <div flex="~ col gap1">
             <div flex justify-between>

--- a/styles/global.css
+++ b/styles/global.css
@@ -232,3 +232,7 @@ footer {
     --at-apply: 'hover:underline';
   }
 }
+
+.squircle {
+  clip-path: url(#avatar-mask);
+}


### PR DESCRIPTION
Use square profile when on your own profile to be more consistent with UI.

Before:
![image](https://user-images.githubusercontent.com/7064956/211740550-30f6473d-77d7-40db-91cf-11b8b15f8942.png)

After:
![image](https://user-images.githubusercontent.com/7064956/211740695-4cc109b6-a23d-4c9e-b406-0d38f597b6ad.png)
