### PR TITLE
fix: top and bottom padding of small preview card on mobile

### DIFF
--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -54,7 +54,7 @@ const cardTypeIconMap: Record<mastodon.v1.PreviewCardType, string> = {
       flex flex-col
       display-block of-hidden
       :class="{
-        'sm:(min-w-32 w-32 h-32) min-w-22 w-22 h-22': isSquare,
+        'sm:(min-w-32 w-32 h-32) min-w-24 w-24 h-24': isSquare,
         'w-full aspect-[1.91]': !isSquare,
         'rounded-lg': root,
       }"
@@ -70,13 +70,13 @@ const cardTypeIconMap: Record<mastodon.v1.PreviewCardType, string> = {
     </div>
     <div
       v-else
-      min-w-22 w-22 h-22 sm="min-w-32 w-32 h-32" bg="slate-500/10" flex justify-center items-center
+      min-w-24 w-24 h-24 sm="min-w-32 w-32 h-32" bg="slate-500/10" flex justify-center items-center
       :class="[
         root ? 'rounded-lg' : '',
       ]"
     >
       <div :class="cardTypeIconMap[card.type]" w="30%" h="30%" text-secondary />
     </div>
-    <StatusPreviewCardInfo :root="root" :card="card" :provider="providerName" />
+    <StatusPreviewCardInfo :p="isSquare ? 'x-4' : '4'" :root="root" :card="card" :provider="providerName" />
   </NuxtLink>
 </template>

--- a/components/status/StatusPreviewCardInfo.vue
+++ b/components/status/StatusPreviewCardInfo.vue
@@ -12,7 +12,7 @@ defineProps<{
 
 <template>
   <div
-    px-4 max-h-2xl
+    max-h-2xl
     flex flex-col
     my-auto
     :class="[


### PR DESCRIPTION
Fix for the thumbnail appears not filling up the height of the small preview cards on mobile

| before | after |
| --- | --- |
| <img width="458" alt="Screenshot 2023-01-11 at 5 04 12 PM" src="https://user-images.githubusercontent.com/4262489/211856512-b8810bda-d31c-453a-85b9-2815aeec3e72.png"> | <img width="449" alt="Screenshot 2023-01-11 at 5 04 22 PM" src="https://user-images.githubusercontent.com/4262489/211856517-8ea3448c-8d55-4207-967e-975e183f2f54.png"> |
