### PR TITLE
fix: empty code blocks

### DIFF
--- a/composables/masto/statusDrafts.ts
+++ b/composables/masto/statusDrafts.ts
@@ -83,7 +83,7 @@ export const isEmptyDraft = (draft: Draft | null | undefined) => {
     return true
   const { params, attachments } = draft
   const status = params.status || ''
-  const text = htmlToText(status).trim().replace(/^(@\S+\s?)+/, '').trim()
+  const text = htmlToText(status).trim().replace(/^(@\S+\s?)+/, '').replaceAll(/```/g, '').trim()
 
   return (text.length === 0)
     && attachments.length === 0


### PR DESCRIPTION
fix #977 

I went for the `replaceAll` strategy in the `isEmptyDraft` helper since it felt like you should not be able to publish an empty code block in a toot even if you have a non empty one somewhere else in your message.

Feel free to give feedback on this.