### PR TITLE
feat: notify me when followed account posts

### DIFF
--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -41,6 +41,12 @@ const toggleReblogs = async () => {
   const showingReblogs = !relationship?.showingReblogs
   relationship = await masto.v1.accounts.follow(account.id, { reblogs: showingReblogs })
 }
+
+const toggleNotify = async () => {
+  const subscribedToNotifications = !relationship?.notifying
+
+  relationship = await masto.v1.accounts.follow(account.id, { notify: subscribedToNotifications })
+}
 </script>
 
 <template>
@@ -62,6 +68,23 @@ const toggleReblogs = async () => {
 
       <template v-if="currentUser">
         <template v-if="!isSelf">
+          <template v-if="relationship!.following">
+            <CommonDropdownItem
+              v-if="!relationship?.notifying"
+              :text="$t('menu.notifying_account_on', [`@${account.acct}`])"
+              icon="i-ri:notification-line"
+              :command="command"
+              @click="toggleNotify"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.notifying_account_off', [`@${account.acct}`])"
+              icon="i-ri:notification-off-line"
+              :command="command"
+              @click="toggleNotify"
+            />
+          </template>
+
           <CommonDropdownItem
             :text="$t('menu.mention_account', [`@${account.acct}`])"
             icon="i-ri:at-line"

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -143,6 +143,8 @@
     "mention_account": "Mention {0}",
     "mute_account": "Mute {0}",
     "mute_conversation": "Mute this post",
+    "notifying_account_off": "Disable notifications for {0}",
+    "notifying_account_on": "Enable notifications for {0}",
     "open_in_original_site": "Open in original site",
     "pin_on_profile": "Pin on profile",
     "share_post": "Share this post",


### PR DESCRIPTION
**Objective**
Add the ability to subscribe to alerts for a followed account when they post something new.

Fix #538 

I utilized similar phrasing as other commands in the list. It is the official Mastodon terminology. 

Other phrase options I considered:

* "Enable alerts for {0}" / "Disable alerts for {0}"
* "Enable notifications" / "Disable notifications"
* "Enable alerts" / "Disable alerts"
* "Notify me when {0} posts" / "Stop notifying me when {0} posts" (official phrase from Mastodon)

**Enable action presented when notifications are currently off**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/6627582/212002418-1f920b53-fa42-4425-97c6-14c7e2aaccf7.png">

**Disable action presented when notifications are currently active**
<img width="300" alt="Disabled State" src="https://user-images.githubusercontent.com/6627582/212002036-2e872382-e45d-43aa-bf99-4c7d76c18a6a.png">
