### PR TITLE
fix: change display from standalone to fullscreen

### DIFF
--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -15,5 +15,5 @@
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "display": "fullscreen"
 }


### PR DESCRIPTION
Using PWA, I still have the notification bar in white with Firefox on Android 13 over a OnePlus phone.

I see in the doc the standalone is showing the status bar, fullscreen

[Docs from MDN](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen):

> **display**: Specifies how the app should be displayed. To make it feel like a distinct app (and not just a web page), you should choose a value such as fullscreen (no UI is shown at all) or standalone (very similar, but system-level UI elements such as the status bar might be visible).