### PR TITLE
fix: catch exceptions in HTML parser

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -106,8 +106,14 @@ export function convertMastodonHTML(html: string, customEmojis: Record<string, m
 }
 
 export function htmlToText(html: string) {
-  const tree = parse(html)
-  return (tree.children as Node[]).map(n => treeToText(n)).join('').trim()
+  try {
+    const tree = parse(html)
+    return (tree.children as Node[]).map(n => treeToText(n)).join('').trim()
+  }
+  catch (err) {
+    console.error(err)
+    return ''
+  }
 }
 
 export function treeToText(input: Node): string {


### PR DESCRIPTION
Fixes Elk freezing when rendering post that fails to render.

Demo of bug in video in this post: https://github.com/elk-zone/elk/issues/917#issuecomment-1380132738

This doesn't actually fix linked issue, but at least prevents Elk from freezing, so Elk can continue functioning and renders bad content as an empty string. It also logs error to console.