### PR TITLE
perf: mock semver import

### DIFF
--- a/mocks/semver.ts
+++ b/mocks/semver.ts
@@ -1,5 +1,7 @@
-export const lt = null
-export const gt = null
-export const gte = null
-export const satisfies = null
-export const SemVer = null
+import proxy from 'unenv/runtime/mock/proxy'
+
+export const lt = proxy
+export const gt = proxy
+export const gte = proxy
+export const satisfies = proxy
+export const SemVer = proxy

--- a/mocks/semver.ts
+++ b/mocks/semver.ts
@@ -1,0 +1,5 @@
+export const lt = null
+export const gt = null
+export const gte = null
+export const satisfies = null
+export const SemVer = null

--- a/mocks/semver.ts
+++ b/mocks/semver.ts
@@ -4,4 +4,4 @@ export const lt = proxy
 export const gt = proxy
 export const gte = proxy
 export const satisfies = proxy
-export const SemVer = proxy
+export class SemVer {}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,9 +1,12 @@
+import { createResolver } from '@nuxt/kit'
 import Inspect from 'vite-plugin-inspect'
 import { isCI, isDevelopment } from 'std-env'
 import { isPreview } from './config/env'
 import { i18n } from './config/i18n'
 import { pwa } from './config/pwa'
 import type { BuildInfo } from './types'
+
+const { resolve } = createResolver(import.meta.url)
 
 export default defineNuxtConfig({
   typescript: {
@@ -44,6 +47,7 @@ export default defineNuxtConfig({
   alias: {
     'querystring': 'rollup-plugin-node-polyfills/polyfills/qs',
     'change-case': 'scule',
+    'semver': resolve('./mocks/semver'),
   },
   imports: {
     dirs: [


### PR DESCRIPTION
this cuts 30kB of unused `semver` from the client-side bundle