### PR TITLE
feat(ui): highlight pick you server message in sign in form

### DIFF
--- a/components/user/UserSignIn.vue
+++ b/components/user/UserSignIn.vue
@@ -177,7 +177,7 @@ onClickOutside($$(input), () => {
       <div i-ri:lightbulb-line me-1 />
       <span>
         <i18n-t keypath="user.tip_no_account">
-          <NuxtLink href="https://joinmastodon.org/servers" target="_blank" external hover="underline text-primary">{{ $t('user.tip_register_account') }}</NuxtLink>
+          <NuxtLink href="https://joinmastodon.org/servers" target="_blank" external class="text-primary" hover="underline">{{ $t('user.tip_register_account') }}</NuxtLink>
         </i18n-t>
       </span>
     </div>


### PR DESCRIPTION
The `Pick you server and register` message is not highlighted. It does not look like a link and does not grab attention until hovered.

This PR highlights it by default.

### Before

![image](https://user-images.githubusercontent.com/28915667/212095368-91406e28-4cfb-486c-b710-7eb35ed160dc.png)


### After

![image](https://user-images.githubusercontent.com/28915667/212095212-a5331d52-c750-4ffe-99f5-c1d58ce3e686.png)
