### PR TITLE
fix: non-showing hashtag charts

### DIFF
--- a/components/common/CommonTrendingCharts.vue
+++ b/components/common/CommonTrendingCharts.vue
@@ -19,11 +19,12 @@ const historyNum = $computed(() => {
 })
 
 const sparklineEl = $ref<SVGSVGElement>()
+const sparklineFn = typeof sparkline !== 'function' ? (sparkline as any).default : sparkline
 
 watch([$$(historyNum), $$(sparklineEl)], ([historyNum, sparklineEl]) => {
   if (!sparklineEl)
     return
-  sparkline(sparklineEl, historyNum)
+  sparklineFn(sparklineEl, historyNum)
 })
 </script>
 


### PR DESCRIPTION
Charts on the hashtags page are not shown because of the following error:

<img width="483" alt="Screen Shot 2023-01-12 at 23 13 18" src="https://user-images.githubusercontent.com/26363017/212171649-0ab2bff5-1664-4141-8269-fd3c38160a2a.png">

This issue does not occur in developer mode because of differences how default imports work when code with a `<script setup>` block is compiled and not

<details>
  <summary>How it looks after (both in developer and production modes)</summary>
  <img width="483" alt="Screen Shot 2023-01-12 at 23 34 31" src="https://user-images.githubusercontent.com/26363017/212175634-8f1567fb-be4c-4506-a9e3-8d90109846f3.png">
</details>