### PR TITLE
fix: shiki fallback language

### DIFF
--- a/composables/shiki.ts
+++ b/composables/shiki.ts
@@ -32,10 +32,11 @@ export function useHightlighter(lang: Lang) {
       .then(() => {
         registeredLang.value.set(lang, true)
       })
-      .catch((e) => {
-        console.error(`[shiki] Failed to load language ${lang}`)
-        console.error(e)
-        registeredLang.value.set(lang, false)
+      .catch(() => {
+        const fallbackLang = 'md'
+        shiki.value?.loadLanguage(fallbackLang).then(() => {
+          registeredLang.value.set(fallbackLang, true)
+        })
       })
     return undefined
   }

--- a/composables/tiptap/shiki.ts
+++ b/composables/tiptap/shiki.ts
@@ -43,7 +43,7 @@ function getDecorations({
   findChildren(doc, node => node.type.name === name)
     .forEach((block) => {
       let from = block.pos + 1
-      const language = block.node.attrs.language || 'text'
+      const language = block.node.attrs.language || 'md'
 
       const shiki = useHightlighter(language)
 

--- a/composables/tiptap/shiki.ts
+++ b/composables/tiptap/shiki.ts
@@ -43,7 +43,7 @@ function getDecorations({
   findChildren(doc, node => node.type.name === name)
     .forEach((block) => {
       let from = block.pos + 1
-      const language = block.node.attrs.language || 'md'
+      const language = block.node.attrs.language
 
       const shiki = useHightlighter(language)
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/22515951/212225502-5a68371a-3a5d-4d8c-b7d5-5378760f2b1c.mov


`Shiki` doesn't seem to provide highlighting for the text [language](https://github.com/shikijs/shiki/blob/main/docs/languages.md), we might be use markdown instead.