### PR TITLE
fix: empty server list throws console error on move

### DIFF
--- a/components/user/UserSignIn.vue
+++ b/components/user/UserSignIn.vue
@@ -94,6 +94,10 @@ function toSelector(server: string) {
   return server.replace(/[^\w-]/g, '-')
 }
 function move(delta: number) {
+  if (filteredServers.length === 0) {
+    autocompleteIndex = 0
+    return
+  }
   autocompleteIndex = ((autocompleteIndex + delta) + filteredServers.length) % filteredServers.length
   document.querySelector(`#${toSelector(filteredServers[autocompleteIndex])}`)?.scrollIntoView(false)
 }


### PR DESCRIPTION
If the server list is empty in UserSignIn page, pressing up/down keyboard arrow throws console error. This PR fixes that.

## Error

![image](https://user-images.githubusercontent.com/28915667/212232655-372143bf-6cce-4e34-aee1-5ad9434924e0.png)
