### PR TITLE
fix: back button was not displayed on lg screen

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -17,7 +17,7 @@ defineProps<{
       <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }">
         <div flex gap-3 items-center overflow-hidden py2>
           <NuxtLink
-            v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 lg:hidden
+            v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
             :aria-label="$t('nav.back')"
             @click="$router.go(-1)"
           >


### PR DESCRIPTION
When the page width is less than 1280 pixels and larger than 1024 pixels, the back button does not appear. 
Because the back button is set with the lg:hidden style inconsistent with the trigger width of sidebar shrinkage (sidebar shrinks at less than 1280px)