### PR TITLE
chore: reduce bundle size for Tauri target

### DIFF
--- a/modules/tauri/index.ts
+++ b/modules/tauri/index.ts
@@ -47,7 +47,6 @@ export default defineNuxtModule({
       await rm('.output/public/apple-touch-icon.png')
       await rm('.output/public/elk-og.png')
       await rm('.output/public/favicon.ico')
-      await rm('.output/public/logo.svg')
       await rm('.output/public/pwa-192x192.png')
       await rm('.output/public/pwa-512x512.png')
       await rm('.output/public/robots.txt')

--- a/modules/tauri/index.ts
+++ b/modules/tauri/index.ts
@@ -1,3 +1,4 @@
+import { rm } from 'fs/promises'
 import { addImports, addPlugin, createResolver, defineNuxtModule, useNuxt } from '@nuxt/kit'
 
 export default defineNuxtModule({
@@ -13,6 +14,9 @@ export default defineNuxtModule({
 
     if (nuxt.options.dev)
       nuxt.options.ssr = false
+
+    nuxt.options.pwa.disable = true
+    nuxt.options.sourcemap.client = false
 
     nuxt.options.alias = {
       ...nuxt.options.alias,
@@ -36,5 +40,17 @@ export default defineNuxtModule({
 
     addPlugin(resolve('./runtime/logging.client'))
     addPlugin(resolve('./runtime/nitro.client'))
+
+    // cleanup files copied from the public folder that we don't need
+    nuxt.hook('close', async () => {
+      await rm('.output/public/_redirects')
+      await rm('.output/public/apple-touch-icon.png')
+      await rm('.output/public/elk-og.png')
+      await rm('.output/public/favicon.ico')
+      await rm('.output/public/logo.svg')
+      await rm('.output/public/pwa-192x192.png')
+      await rm('.output/public/pwa-512x512.png')
+      await rm('.output/public/robots.txt')
+    })
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,8 +28,8 @@ export default defineNuxtConfig({
     '~/modules/purge-comments',
     '~/modules/setup-components',
     '~/modules/build-env',
-    '~/modules/pwa/index', // change to '@vite-pwa/nuxt' once released and remove pwa module
     '~/modules/tauri/index',
+    '~/modules/pwa/index', // change to '@vite-pwa/nuxt' once released and remove pwa module
   ],
   experimental: {
     payloadExtraction: false,


### PR DESCRIPTION
This PR:
1. Disables the PWA module for Tauri builds (since it's not needed anyway)
2. Cleans up files copied from the `public` folder that aren't needed in an app setting either