### PR TITLE
fix(i18n): update zh-CN built_at translation for rationality

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -162,7 +162,7 @@
     "blocked_domains": "已拉黑的域名",
     "blocked_users": "已拉黑的用户",
     "bookmarks": "书签",
-    "built_at": "于 {0}构建",
+    "built_at": "构建于 {0}",
     "conversations": "私信",
     "explore": "探索",
     "favourites": "喜欢",


### PR DESCRIPTION
before: ![image](https://user-images.githubusercontent.com/73569598/212287982-ecc50d97-a626-432e-9cc2-43cd1063e4cc.png)
after: ![image](https://user-images.githubusercontent.com/73569598/212287938-cbec8a2c-799f-4dfb-88a1-e5d5fc1d8b42.png)
other
