### PR TITLE
fix: adjust background of account name when it's a link

### DIFF
--- a/components/account/AccountInlineInfo.vue
+++ b/components/account/AccountInlineInfo.vue
@@ -12,7 +12,7 @@ const { link = true, avatar = true } = defineProps<{
   <AccountHoverWrapper :account="account">
     <NuxtLink
       :to="link ? getAccountRoute(account) : undefined"
-      :class="link ? 'text-link-rounded ms-0 ps-0' : ''"
+      :class="link ? 'text-link-rounded -ml-1.8rem pl-1.8rem rtl-(ml0 pl-0.5rem -mr-1.8rem pr-1.8rem)' : ''"
       min-w-0 flex gap-2 items-center
     >
       <AccountAvatar v-if="avatar" :account="account" w-5 h-5 />


### PR DESCRIPTION
I see a small UI issue on avatar on avatar account name background:

## BEFORE:
<img width="784" alt="Capture d’écran 2023-01-13 à 11 03 16" src="https://user-images.githubusercontent.com/2922851/212293490-0e7caea5-3c2e-4d15-8605-183e15b744c5.png">

### RTL

<img width="642" alt="Capture d’écran 2023-01-13 à 11 03 40" src="https://user-images.githubusercontent.com/2922851/212293521-f711d6ce-dec0-4336-b210-da2c2f7ff0bc.png">

## AFTER:
<img width="868" alt="Capture d’écran 2023-01-13 à 11 02 54" src="https://user-images.githubusercontent.com/2922851/212293445-475665ea-e3c9-4433-ab54-c96ae50f3101.png">

### RTL
<img width="747" alt="Capture d’écran 2023-01-13 à 11 01 51" src="https://user-images.githubusercontent.com/2922851/212293373-f65d1224-50f3-4148-bd39-af406a4a7547.png">