### PR TITLE
fix: hide actions panel in status detail when use zen mode

### DIFF
--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -9,6 +9,8 @@ const props = withDefaults(defineProps<{
   actions: true,
 })
 
+const userSettings = useUserSettings()
+
 const status = $computed(() => {
   if (props.status.reblog && props.status.reblog)
     return props.status.reblog
@@ -60,7 +62,7 @@ const isDM = $computed(() => status.visibility === 'direct')
       </div>
     </div>
     <div border="t base" pt-2>
-      <StatusActions v-if="actions" :status="status" details :command="command" />
+      <StatusActions v-if="actions" v-show="!userSettings.zenMode" :status="status" details :command="command" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
When use zen mode, all action panels are hidden except in status detail. Maybe it should have consistent performance.

before: 
![image](https://user-images.githubusercontent.com/73569598/212306314-d7f118ab-fec8-4a2b-9754-8903b6f78b76.png)
after: 
![image](https://user-images.githubusercontent.com/73569598/212306365-66ceed9b-4eca-4db3-9912-1c8c82c49f2d.png)
