### PR TITLE
fix: multiple push notifications susbscriptions on multiple account servers

### DIFF
--- a/components/notification/NotificationPreferences.client.vue
+++ b/components/notification/NotificationPreferences.client.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { PushSubscriptionError } from '~/composables/push-notifications/types'
+
 defineProps<{ show?: boolean }>()
 
 const {
@@ -76,8 +78,13 @@ const doSubscribe = async () => {
     }
   }
   catch (err) {
-    console.error(err)
-    subscribeError = t('settings.notifications.push_notifications.subscription_error.request_error')
+    if (err instanceof PushSubscriptionError) {
+      subscribeError = t(`settings.notifications.push_notifications.subscription_error.${err.code}`)
+    }
+    else {
+      console.error(err)
+      subscribeError = t('settings.notifications.push_notifications.subscription_error.request_error')
+    }
     showSubscribeError = true
   }
   finally {

--- a/composables/push-notifications/types.ts
+++ b/composables/push-notifications/types.ts
@@ -24,3 +24,12 @@ export interface CustomEmojisInfo {
   lastUpdate: number
   emojis: mastodon.v1.CustomEmoji[]
 }
+
+export type PushSubscriptionErrorCode = 'too_many_registrations'
+export class PushSubscriptionError extends Error {
+  code: PushSubscriptionErrorCode
+  constructor(code: PushSubscriptionErrorCode, message?: string) {
+    super(message)
+    this.code = code
+  }
+}

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -239,7 +239,7 @@
           "permission_denied": "Permission denied: enable notifications in your browser.",
           "request_error": "An error occurred while requesting the subscription, try again and if the error persists, please report the issue to the Elk repository.",
           "title": "Could not subscribe to push notifications",
-          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
+          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications service for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
         },
         "undo_settings": "Undo changes",
         "unsubscribe": "Disable push notifications",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -238,7 +238,8 @@
           "clear_error": "Clear error",
           "permission_denied": "Permission denied: enable notifications in your browser.",
           "request_error": "An error occurred while requesting the subscription, try again and if the error persists, please report the issue to the Elk repository.",
-          "title": "Could not subscribe to push notifications"
+          "title": "Could not subscribe to push notifications",
+          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
         },
         "undo_settings": "Undo changes",
         "unsubscribe": "Disable push notifications",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -302,7 +302,8 @@
           "clear_error": "Clear error",
           "permission_denied": "Permission denied: enable notifications in your browser.",
           "request_error": "An error occurred while requesting the subscription, try again and if the error persists, please report the issue to the Elk repository.",
-          "title": "Could not subscribe to push notifications"
+          "title": "Could not subscribe to push notifications",
+          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
         },
         "title": "Push notifications settings",
         "undo_settings": "Undo changes",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -303,7 +303,7 @@
           "permission_denied": "Permission denied: enable notifications in your browser.",
           "request_error": "An error occurred while requesting the subscription, try again and if the error persists, please report the issue to the Elk repository.",
           "title": "Could not subscribe to push notifications",
-          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
+          "too_many_registrations": "Due to browser limitations, Elk cannot use the push notifications service for multiple accounts on different servers. You should unsubscribe from push notifications on another accounts and try again."
         },
         "title": "Push notifications settings",
         "undo_settings": "Undo changes",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -294,7 +294,8 @@
           "clear_error": "Limpiar error",
           "permission_denied": "Permiso denegado: habilita las notificaciones en tu navegador.",
           "request_error": "Se produjo un error al solicitar la suscripción, inténtalo de nuevo y si el error persiste, notifica la incidencia en el repositorio de Elk.",
-          "title": "No se pudo suscribir a las notificaciones push"
+          "title": "No se pudo suscribir a las notificaciones push",
+          "too_many_registrations": "Debido a las limitaciones del navegador, Elk no puede habilitar las notificaciones push para múltiples cuentas en diferentes servidores. Deberá cancelar las subscripciones a notificaciones push en las otras cuentas e intentarlo de nuevo."
         },
         "title": "Ajustes de notificaciones push",
         "undo_settings": "Deshacer cambios",


### PR DESCRIPTION
This PR doesn't solve the problem, just handle the error with a custom error message and the hint (we need to add push notifications proxy on Elk server, a lot of work to be done):

![imagen](https://user-images.githubusercontent.com/6311119/212323030-47cf3a60-9820-49b2-b74d-5ee9d0e7ead0.png)

closes #999