### PR TITLE
feat: implement social previews by redirecting to origin server

### DIFF
--- a/plugins/social.server.ts
+++ b/plugins/social.server.ts
@@ -1,0 +1,16 @@
+import { sendRedirect } from 'h3'
+
+export default defineNuxtPlugin(async (nuxtApp) => {
+  const route = useRoute()
+  if (!route.params.server)
+    return
+
+  const req = nuxtApp.ssrContext!.event.node.req
+  const userAgent = req.headers['user-agent']!
+  if (!userAgent)
+    return
+
+  const isOpenGraphCrawler = /twitterbot|discordbot|facebookexternalhit|googlebot|msnbot|baidu|ahrefsbot|duckduckgo/i.test(userAgent)
+  if (isOpenGraphCrawler)
+    await sendRedirect(nuxtApp.ssrContext!.event, `https:/${route.path}`, 301)
+})


### PR DESCRIPTION
Rather than return a response containing any information about a status/user/server, we can simply redirect to the correct URL of the mastodon instance involved. This instance's `robots.txt`, privacy policy, etc. will then govern the response. However, we still will get the benefit of whatever meta tags that instance provides.

**Discord**

<img width="837" alt="CleanShot 2023-01-14 at 23 42 14@2x" src="https://user-images.githubusercontent.com/28706372/212501878-06386216-38ba-4df7-9946-cf296a288bfe.png">

**Twitter**

<img width="593" alt="CleanShot 2023-01-14 at 23 44 40@2x" src="https://user-images.githubusercontent.com/28706372/212501939-2687ce19-9406-4b07-8a6c-e2a4b31a6c12.png">

**Facebook**

<img width="490" alt="CleanShot 2023-01-14 at 23 43 12@2x" src="https://user-images.githubusercontent.com/28706372/212501904-13745955-1e8a-4f34-8508-ced080509aa2.png">

**Elk**

<img width="594" alt="CleanShot 2023-01-14 at 23 43 46@2x" src="https://user-images.githubusercontent.com/28706372/212501917-e671a4f0-0754-4f60-b815-c86618e315ff.png">

**Mastodon UI**

<img width="569" alt="CleanShot 2023-01-14 at 23 44 10@2x" src="https://user-images.githubusercontent.com/28706372/212501925-a30a38ab-564b-4a8f-933f-8ce2fc55698c.png">

resolves https://github.com/elk-zone/elk/issues/153