### PR TITLE
Make image in media preview expandable

### DIFF
--- a/components/modal/ModalMediaPreview.vue
+++ b/components/modal/ModalMediaPreview.vue
@@ -74,7 +74,7 @@ onUnmounted(() => locked.value = false)
           v-if="current.description" bg="dark/30" dark:bg="white/10" p="y-1 x-2" rounded-ie-full rounded-full :line-clamp-1="!isDescriptionExpanded"
           ws-pre-wrap break-all :title="current.description" w-full
         >
-          <button text-sm btn-outline py0 px2 text-secondary border-base @click="isDescriptionExpanded = !isDescriptionExpanded">{{ isDescriptionExpanded ? 'Collapse':'Expand' }} {{isDescriptionExpanded}}</button>
+          <button text-sm btn-outline py0 px2 text-secondary border-base @click="isDescriptionExpanded = !isDescriptionExpanded">{{ isDescriptionExpanded ? 'Collapse' : 'Expand' }}</button>
           {{ current.description }}
         </p>
       </div>

--- a/components/modal/ModalMediaPreview.vue
+++ b/components/modal/ModalMediaPreview.vue
@@ -3,6 +3,8 @@ const emit = defineEmits(['close'])
 
 const locked = useScrollLock(document.body)
 
+const isDescriptionExpanded = false
+
 // Use to avoid strange error when directlying assigning to v-model on ModelMediaPreviewCarousel
 const index = mediaPreviewIndex
 
@@ -64,14 +66,15 @@ onUnmounted(() => locked.value = false)
       >
         <div i-ri:close-line text-white />
       </button>
-      <div bg="black/30" dark:bg="white/10" ms-4 my-auto text-white rounded-full flex="~ center" overflow-hidden>
+      <div ms-4 my-auto text-white flex="~ center" :overflow-hidden="!isDescriptionExpanded">
         <div v-if="mediaPreviewList.length > 1" p="y-1 x-2" rounded-r-0 shrink-0>
           {{ index + 1 }} / {{ mediaPreviewList.length }}
         </div>
         <p
-          v-if="current.description" bg="dark/30" dark:bg="white/10" p="y-1 x-2" rounded-ie-full line-clamp-1
+          v-if="current.description" bg="dark/30" dark:bg="white/10" p="y-1 x-2" rounded-ie-full rounded-full :line-clamp-1="!isDescriptionExpanded"
           ws-pre-wrap break-all :title="current.description" w-full
         >
+          <button text-sm btn-outline py0 px2 text-secondary border-base @click="isDescriptionExpanded = !isDescriptionExpanded">{{ isDescriptionExpanded ? 'Collapse':'Expand' }} {{isDescriptionExpanded}}</button>
           {{ current.description }}
         </p>
       </div>


### PR DESCRIPTION
Fix #829

This is WIP currently.

The work to be done:
- [x] Add button to [this element](https://github.com/elk-zone/elk/blob/a6a825e553a4a17a1ae6a2b9d5b64110f0333ddb/components/modal/ModalMediaPreview.vue#L67), which toggles the `overflow-hidden` unocss attribute off/on.
- [x] remove `line-clamp` attribute from [the paragraph tag here](https://github.com/elk-zone/elk/blob/a6a825e553a4a17a1ae6a2b9d5b64110f0333ddb/components/modal/ModalMediaPreview.vue#L72) when that button is clicked. This is adding an overflow hidden.
- [ ] Get the [Alt Text and close button UI](https://github.com/elk-zone/elk/blob/a6a825e553a4a17a1ae6a2b9d5b64110f0333ddb/components/modal/ModalMediaPreview.vue#L67) to be above the [image carousel component's wrapper](https://github.com/elk-zone/elk/blob/a6a825e553a4a17a1ae6a2b9d5b64110f0333ddb/components/modal/ModalMediaPreview.vue#L56) stacking context wise (z-index).
- [ ] Additionally there are some CSS styles for the background applied to [the container](https://github.com/elk-zone/elk/blob/a6a825e553a4a17a1ae6a2b9d5b64110f0333ddb/components/modal/ModalMediaPreview.vue#L67) that wholes the image description, they start to look weird when the overflow and clamp is gone.
- [ ] Need to properly hook up the state to Pinia to make the button function. (may need help on this, Pinia is new to me)
