### PR TITLE
fix: prevent HTML injections to code blocks

### DIFF
--- a/components/content/ContentCode.vue
+++ b/components/content/ContentCode.vue
@@ -4,7 +4,7 @@ const props = defineProps<{
   lang?: string
 }>()
 
-const raw = computed(() => decodeURIComponent(props.code).replace(/&#39;/g, '\''))
+const raw = $computed(() => decodeURIComponent(props.code).replace(/&#39;/g, '\''))
 
 const langMap: Record<string, string> = {
   js: 'javascript',
@@ -13,7 +13,7 @@ const langMap: Record<string, string> = {
 }
 
 const highlighted = computed(() => {
-  return props.lang ? highlightCode(raw.value, (langMap[props.lang] || props.lang) as any) : raw.value
+  return props.lang ? highlightCode(raw, (langMap[props.lang] || props.lang) as any) : raw
 })
 </script>
 

--- a/components/content/ContentCode.vue
+++ b/components/content/ContentCode.vue
@@ -4,7 +4,7 @@ const props = defineProps<{
   lang?: string
 }>()
 
-const raw = $computed(() => decodeURIComponent(props.code).replace(/&#39;/g, '\''))
+const raw = computed(() => decodeURIComponent(props.code).replace(/&#39;/g, '\''))
 
 const langMap: Record<string, string> = {
   js: 'javascript',
@@ -13,10 +13,11 @@ const langMap: Record<string, string> = {
 }
 
 const highlighted = computed(() => {
-  return props.lang ? highlightCode(raw, (langMap[props.lang] || props.lang) as any) : raw
+  return props.lang ? highlightCode(raw.value, (langMap[props.lang] || props.lang) as any) : raw.value
 })
 </script>
 
 <template>
-  <pre class="code-block" v-html="highlighted" />
+  <pre v-if="lang" class="code-block" v-html="highlighted" />
+  <pre v-else class="code-block">{{ raw }}</pre>
 </template>

--- a/composables/shiki.ts
+++ b/composables/shiki.ts
@@ -48,10 +48,22 @@ export function useShikiTheme() {
   return useColorMode().value === 'dark' ? 'vitesse-dark' : 'vitesse-light'
 }
 
+const HTML_ENTITIES = {
+  '<': '&lt;',
+  '>': '&gt;',
+  '&': '&amp;',
+  '\'': '&apos;',
+  '"': '&quot;',
+} as Record<string, string>
+
+function escapeHtml(text: string) {
+  return text.replace(/[<>&'"]/g, ch => HTML_ENTITIES[ch])
+}
+
 export function highlightCode(code: string, lang: Lang) {
   const shiki = useHightlighter(lang)
   if (!shiki)
-    return code
+    return escapeHtml(code)
 
   return shiki.codeToHtml(code, {
     lang,

--- a/tests/__snapshots__/content-rich.test.ts.snap
+++ b/tests/__snapshots__/content-rich.test.ts.snap
@@ -1,9 +1,36 @@
 // Vitest Snapshot v1
 
-exports[`content-rich > block with backticks 1`] = `"<p><pre>[(\`number string) (\`tag string)]</pre></p>"`;
+exports[`content-rich > block with backticks 1`] = `"<p><pre class=\\"code-block\\">[(\`number string) (\`tag string)]</pre></p>"`;
+
+exports[`content-rich > block with injected html, with a known language 1`] = `
+"<pre>
+        <code class=\\"language-js\\">
+          &lt;a href=&quot;javascript:alert(1)&quot;&gt;click me&lt;/a&gt;
+        </code>
+      </pre>
+"
+`;
+
+exports[`content-rich > block with injected html, with an unknown language 1`] = `
+"<pre>
+        <code class=\\"language-xyzzy\\">
+          &lt;a href=&quot;javascript:alert(1)&quot;&gt;click me&lt;/a&gt;
+        </code>
+      </pre>
+"
+`;
+
+exports[`content-rich > block with injected html, without language 1`] = `
+"<pre>
+        <code>
+          &lt;a href=&quot;javascript:alert(1)&quot;&gt;click me&lt;/a&gt;
+        </code>
+      </pre>
+"
+`;
 
 exports[`content-rich > code frame 1`] = `
-"<p>Testing code block</p><p></p><p><pre lang=\\"ts\\">import { useMouse, usePreferredDark } from &#39;@vueuse/core&#39;
+"<p>Testing code block</p><p></p><p><pre class=\\"code-block\\">import { useMouse, usePreferredDark } from &apos;@vueuse/core&apos;
 // tracks mouse position
 const { x, y } = useMouse()
 // is the user prefers dark theme
@@ -20,14 +47,14 @@ exports[`content-rich > code frame 2 1`] = `
     ></a
   ></span>
   Testing<br />
-  <pre lang=\\"ts\\">const a = hello</pre>
+  <pre class=\\"code-block\\">const a = hello</pre>
 </p>
 "
 `;
 
-exports[`content-rich > code frame empty 1`] = `"<p><pre></pre><br></p>"`;
+exports[`content-rich > code frame empty 1`] = `"<p><pre class=\\"code-block\\"></pre><br></p>"`;
 
-exports[`content-rich > code frame no lang 1`] = `"<p><pre>hello world</pre><br>no lang</p>"`;
+exports[`content-rich > code frame no lang 1`] = `"<p><pre class=\\"code-block\\">hello world</pre><br>no lang</p>"`;
 
 exports[`content-rich > custom emoji 1`] = `
 "Daniel Roe
@@ -75,7 +102,7 @@ exports[`content-rich > handles formatting from servers 1`] = `
 exports[`content-rich > handles html within code blocks 1`] = `
 "<p>
   HTML block code:<br />
-  <pre lang=\\"html\\">
+  <pre class=\\"code-block\\">
 &lt;span class=&quot;icon--noto icon--noto--1st-place-medal&quot;&gt;&lt;/span&gt;
 &lt;span class=&quot;icon--noto icon--noto--2nd-place-medal-medal&quot;&gt;&lt;/span&gt;</pre
   >

--- a/tests/content-rich.test.ts
+++ b/tests/content-rich.test.ts
@@ -136,6 +136,39 @@ describe('content-rich', () => {
       "
     `)
   })
+
+  it ('block with injected html, without language', async () => {
+    const { formatted } = await render(`
+      <pre>
+        <code>
+          &lt;a href="javascript:alert(1)">click me&lt;/a>
+        </code>
+      </pre>
+    `)
+    expect(formatted).toMatchSnapshot()
+  })
+
+  it ('block with injected html, with an unknown language', async () => {
+    const { formatted } = await render(`
+      <pre>
+        <code class="language-xyzzy">
+          &lt;a href="javascript:alert(1)">click me&lt;/a>
+        </code>
+      </pre>
+    `)
+    expect(formatted).toMatchSnapshot()
+  })
+
+  it ('block with injected html, with a known language', async () => {
+    const { formatted } = await render(`
+      <pre>
+        <code class="language-js">
+          &lt;a href="javascript:alert(1)">click me&lt;/a>
+        </code>
+      </pre>
+    `)
+    expect(formatted).toMatchSnapshot()
+  })
 })
 
 async function render(content: string, options?: ContentParseOptions) {
@@ -173,23 +206,11 @@ vi.mock('~/composables/dialog.ts', () => {
   return {}
 })
 
-vi.mock('~/components/content/ContentCode.vue', () => {
+vi.mock('shiki-es', async (importOriginal) => {
+  const mod = await importOriginal()
   return {
-    default: defineComponent({
-      props: {
-        code: {
-          type: String,
-          required: true,
-        },
-        lang: {
-          type: String,
-        },
-      },
-      setup(props) {
-        const raw = computed(() => decodeURIComponent(props.code).replace(/&#39;/g, '\''))
-        return () => h('pre', { lang: props.lang }, raw.value)
-      },
-    }),
+    ...(mod as any),
+    setCDN() {},
   }
 })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
     'process.client': 'true',
   },
   plugins: [
-    Vue(),
+    Vue({
+      reactivityTransform: true,
+    }),
     AutoImport({
       dts: false,
       imports: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pull request fixes a raw HTML injection vector. A Mastodon post payload that contains HTML that looks enough like a code block can bypass HTML sanitation. This is fixed by:
 * not directly injecting unescaped HTML content in the ContentCode.vue component
 * escaping code conten in shiki.ts when the requested language is not found or has not been loaded yet

Visiting the page https://elk.zone/bob.pwniverse.io/@jviide/109692653165280776 demonstrates how a message crafted on a normal, non-attacker-controlled instance (running the [Mastodon Glitch Edition](https://glitch-soc.github.io/docs/)) can paint over the whole Elk UI and run arbitrary code in e.g. click handlers.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

There are two points of code that must be protected. The first one is the ContentCode.vue component. If the language is not given, then the component injects the code content as-is with the v-html directive. This is fixed by adding the code content to DOM as normal text in such situations.

The other place is usually available for a much shorter time, but should be addressed anyway in `~/composables/shiki.ts`. When the shiki module & language information has not yet been bootstrapped, the `useHighlighter` function returns `undefined`. In such cases the `highlightCode` function (used by the ContentCode component) returns the content as-is, which in turn is injected as-is with v-html by the ContentCode component. This is addressed by escaping the unformatted content in `highlightCode`.

---

I added three tests for these cases into the `content-rich.test.ts` test file. To facilitate those tests I removed the mock for ContentCode component, and added a small mock for the shiki-es module that disables the CDN functionality, making testing it a bit easier. I also removed the reactivity transform use from ContentCode to get the tests work after removing the component mock.

These changes required updating the test snapshots for the said file.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
