### PR TITLE
fix: disallow all indexing on canary site and indexing of auth-only pages in prod

### DIFF
--- a/public-staging/robots.txt
+++ b/public-staging/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,23 @@
 User-agent: *
 Allow: /
+
+# Disallow authenticated pages
+
+Disallow /intent
+Disallow /settings
+Disallow /blocks
+Disallow /bookmarks
+Disallow /compose
+Disallow /conversations
+Disallow /domain_blocks
+Disallow /favourites
+Disallow /home
+Disallow /mutes
+Disallow /notifications
+Disallow /pinned
+Disallow /search
+Disallow /settings
+Disallow /share-target
+
+# Wait 1 second between successive requests.
+Crawl-delay: 1


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This explicitly disallows pages that require auth from being crawled. The server routes should all be redirected following https://github.com/elk-zone/elk/pull/1144, which means once search engines update, we should only have one page indexed.

### Additional context

https://duckduckgo.com/?t=ffab&q=site%3Amain.elk.zone&ia=web
https://duckduckgo.com/?t=ffab&q=site%3Aelk.zone&ia=web

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
