### PR TITLE
fix: Actually use "DM sans" font in the UI

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,7 +13,7 @@ const showUserPicker = logicAnd(
 </script>
 
 <template>
-  <div h-full>
+  <div h-full font-sans>
     <main flex w-full mxa lg:max-w-80rem>
       <aside class="hidden sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
         <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

---
Right now `DM sans` is referenced in the source code but never applied. This PR adds "font-sans" in the default layout.

Before (on macos) : 
![CleanShot 2023-01-15 at 19 28 26@2x](https://user-images.githubusercontent.com/8012430/212559969-21ea0850-28a3-422b-adc8-85acc09b29d0.png)

After (with DM sans) : 
![CleanShot 2023-01-15 at 19 28 16@2x](https://user-images.githubusercontent.com/8012430/212559984-9bc0a209-8ca3-4a57-bf39-44cb4a20732e.png)

(Another solution is the remove any reference to DM sans and use the os default ui font.)

Related to  #1170 #1179 #1182 

