### PR TITLE
fix: publish widget mentions

### DIFF
--- a/components/content/ContentMentionGroup.vue
+++ b/components/content/ContentMentionGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <p flex="~ gap-1" items-center text-sm class="zen-none">
+  <p flex="~ gap-1 wrap" items-center text-sm class="zen-none">
     <span i-ri-arrow-right-line ml--1 text-secondary-light /><slot />
   </p>
 </template>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -133,9 +133,9 @@ defineExpose({
         :class="[isSending ? 'pointer-events-none' : '', isOverDropZone ? '!border-primary' : '']"
       >
         <ContentMentionGroup v-if="draft.mentions?.length && shouldExpanded">
-          <div v-for="m of draft.mentions" :key="m" text-primary>
-            @{{ m }}
-          </div>
+          <button v-for="m, i of draft.mentions" :key="m" text-primary hover:color-red @click="draft.mentions?.splice(i, 1)">
+            {{ acctToShortHandle(m) }}
+          </button>
         </ContentMentionGroup>
 
         <div v-if="draft.params.sensitive">

--- a/composables/masto/account.ts
+++ b/composables/masto/account.ts
@@ -7,10 +7,14 @@ export function getDisplayName(account: mastodon.v1.Account, options?: { rich?: 
   return displayName.replace(/:([\w-]+?):/g, '')
 }
 
+export function acctToShortHandle(acct: string) {
+  return `@${acct.includes('@') ? acct.split('@')[0] : acct}`
+}
+
 export function getShortHandle({ acct }: mastodon.v1.Account) {
   if (!acct)
     return ''
-  return `@${acct.includes('@') ? acct.split('@')[0] : acct}`
+  return toShortHandle(acct)
 }
 
 export function getServerName(account: mastodon.v1.Account) {

--- a/composables/masto/account.ts
+++ b/composables/masto/account.ts
@@ -14,7 +14,7 @@ export function acctToShortHandle(acct: string) {
 export function getShortHandle({ acct }: mastodon.v1.Account) {
   if (!acct)
     return ''
-  return toShortHandle(acct)
+  return acctToShortHandle(acct)
 }
 
 export function getServerName(account: mastodon.v1.Account) {


### PR DESCRIPTION
### Description

https://github.com/elk-zone/elk/commit/9571d7338a824865e3ddad7be52587c657b806ea introduced mentions as separate lines. This PR fixes some issues with the new mentions scheme for the PublishWidget:

- wrap mentions (they were getting out of the widget)
- use short handle (like in the messages)
- click to remove (with basic feedback using red color)

Adding a new mention can be done as usual by including it in the message. We can later improve the UI, but I think we could merge this PR to let users delete mentions until we do.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other