### PR TITLE
feat: add writing language preference

### DIFF
--- a/components/settings/SettingsLanguage.vue
+++ b/components/settings/SettingsLanguage.vue
@@ -2,14 +2,17 @@
 import type { ComputedRef } from 'vue'
 import type { LocaleObject } from '#i18n'
 
-const userSettings = useUserSettings()
+const props = defineProps<{
+  language?: string
+}>()
+const model = useVModel(props, 'language')
 
 const { locales } = useI18n() as { locales: ComputedRef<LocaleObject[]> }
 </script>
 
 <template>
-  <select v-model="userSettings.language">
-    <option v-for="item in locales" :key="item.code" :value="item.code" :selected="userSettings.language === item.code">
+  <select v-model="model">
+    <option v-for="item in locales" :key="item.code" :value="item.code" :selected="props.language === item.code">
       {{ item.name }}
     </option>
   </select>

--- a/composables/settings/definition.ts
+++ b/composables/settings/definition.ts
@@ -17,6 +17,7 @@ export interface UserSettings {
   colorMode?: ColorMode
   fontSize: FontSize
   language: string
+  writingLanguage: string
   zenMode: boolean
 }
 
@@ -29,6 +30,7 @@ export function getDefaultLanguage(languages: string[]) {
 export function getDefaultUserSettings(locales: string[]): UserSettings {
   return {
     language: getDefaultLanguage(locales),
+    writingLanguage: getDefaultLanguage(locales),
     fontSize: DEFAULT_FONT_SIZE,
     zenMode: false,
     preferences: {},

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -269,7 +269,8 @@
     },
     "language": {
       "display_language": "Display Language",
-      "label": "Language"
+      "label": "Language",
+      "writing_language": "Writing Language"
     },
     "notifications": {
       "label": "Notifications",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -262,7 +262,8 @@
     },
     "language": {
       "display_language": "Langue d'affichage",
-      "label": "Langue"
+      "label": "Langue",
+      "writing_language": "Langue d'écriture"
     },
     "notifications": {
       "label": "Notifications",

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -4,6 +4,8 @@ const { t } = useI18n()
 useHeadFixed({
   title: () => `${t('settings.language.label')} | ${t('nav.settings')}`,
 })
+
+const userSettings = useUserSettings()
 </script>
 
 <template>
@@ -16,7 +18,11 @@ useHeadFixed({
     <div p6>
       <label space-y-2>
         <p font-medium>{{ $t('settings.language.display_language') }}</p>
-        <SettingsLanguage select-settings />
+        <SettingsLanguage v-model:language="userSettings.language" select-settings />
+      </label>
+      <label space-y-2>
+        <p font-medium>{{ $t('settings.language.writing_language') }}</p>
+        <SettingsLanguage v-model:language="userSettings.writingLanguage" select-settings />
       </label>
     </div>
   </MainContent>

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -15,7 +15,7 @@ const userSettings = useUserSettings()
         <span>{{ $t('settings.language.label') }}</span>
       </div>
     </template>
-    <div p6>
+    <div p6 flex="~ col gap6">
       <label space-y-2>
         <p font-medium>{{ $t('settings.language.display_language') }}</p>
         <SettingsLanguage v-model:language="userSettings.language" select-settings />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Add the option of writing language to use.
![image](https://user-images.githubusercontent.com/2922851/212573717-aed4ccfc-b582-4b51-bcc7-7c5b3409f9c4.png)

When a new message is composed, it will apply the writing language as language of the toot.

An issue could make the language not well applied when the composer has been already shown before the writing language change. See #1199 

### Additional context
Not sure if the way of passing vModel.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
