### PR TITLE
perf: improve perf on rendering long list of replies

### DIFF
--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -23,7 +23,7 @@ const { client } = $(useMasto())
 const { data: context, pending: pendingContext, refresh: refreshContext } = useAsyncData(
   `context:${id}`,
   async () => client.v1.statuses.fetchContext(id),
-  { watch: [isHydrated], immediate: isHydrated.value },
+  { watch: [isHydrated], immediate: isHydrated.value, lazy: true },
 )
 
 const replyDraft = $computed(() => status.value ? getReplyDraft(status.value) : null)
@@ -90,6 +90,7 @@ onReactivated(() => {
           @published="refreshContext()"
         />
 
+        <TimelineSkeleton v-if="pendingContext" />
         <template v-for="(comment, di) of context?.descendants" :key="comment.id">
           <StatusCard
             :status="comment"

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -17,13 +17,13 @@ const publishWidget = ref()
 const { data: status, pending, refresh: refreshStatus } = useAsyncData(
   `status:${id}`,
   () => fetchStatus(id),
-  { watch: [isHydrated], immediate: isHydrated.value },
+  { watch: [isHydrated], immediate: isHydrated.value, default: () => shallowRef() },
 )
 const { client } = $(useMasto())
 const { data: context, pending: pendingContext, refresh: refreshContext } = useAsyncData(
   `context:${id}`,
   async () => client.v1.statuses.fetchContext(id),
-  { watch: [isHydrated], immediate: isHydrated.value, lazy: true },
+  { watch: [isHydrated], immediate: isHydrated.value, lazy: true, default: () => shallowRef() },
 )
 
 const replyDraft = $computed(() => status.value ? getReplyDraft(status.value) : null)

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+// @ts-expect-error missing types
+import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import type { ComponentPublicInstance } from 'vue'
 
 definePageMeta({
@@ -91,16 +93,24 @@ onReactivated(() => {
         />
 
         <TimelineSkeleton v-if="pendingContext" />
-        <template v-for="(comment, di) of context?.descendants" :key="comment.id">
-          <StatusCard
-            :status="comment"
-            context="account"
-            :older="context?.descendants[di + 1]"
-            :newer="context?.descendants[di - 1]"
-            :has-newer="di === 0"
-            :main="status"
-          />
-        </template>
+        <DynamicScroller
+          v-slot="{ item, index, active }"
+          :items="context?.descendants || []"
+          :min-item-size="200"
+          key-field="id"
+          page-mode
+        >
+          <DynamicScrollerItem :item="item" :active="active">
+            <StatusCard
+              :status="item"
+              context="account"
+              :older="context?.descendants[index + 1]"
+              :newer="context?.descendants[index - 1]"
+              :has-newer="index === 0"
+              :main="status"
+            />
+          </DynamicScrollerItem>
+        </DynamicScroller>
       </div>
 
       <StatusNotFound v-else :account="route.params.account as string" :status="id" />

--- a/pages/[[server]]/@[account]/index.vue
+++ b/pages/[[server]]/@[account]/index.vue
@@ -8,7 +8,7 @@ const accountName = $(computedEager(() => toShortHandle(params.account as string
 
 const { t } = useI18n()
 
-const { data: account, pending, refresh } = $(await useAsyncData(() => fetchAccountByHandle(accountName).catch(() => null), { immediate: process.client }))
+const { data: account, pending, refresh } = $(await useAsyncData(() => fetchAccountByHandle(accountName).catch(() => null), { immediate: process.client, default: () => shallowRef() }))
 const relationship = $computed(() => account ? useRelationship(account).value : undefined)
 
 onReactivated(() => {

--- a/pages/[[server]]/tags/[tag].vue
+++ b/pages/[[server]]/tags/[tag].vue
@@ -7,7 +7,7 @@ const params = useRoute().params
 const tagName = $(computedEager(() => params.tag as string))
 
 const { client } = $(useMasto())
-const { data: tag, refresh } = $(await useAsyncData(() => client.v1.tags.fetch(tagName)))
+const { data: tag, refresh } = $(await useAsyncData(() => client.v1.tags.fetch(tagName), { default: () => shallowRef() }))
 
 const paginator = client.v1.timelines.listHashtag(tagName)
 const stream = useStreaming(client => client.v1.stream.streamTagTimeline(tagName))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fetching a lstatus with many replies can take a very long time to render - in my testing, https://elk.zone/mastodon.social/@MarkRuffalo/109638532333776039 took over 10s to fetch from the Mastodon API and then at least as long to render all of the 700+ replies in the DOM.

This PR makes a couple of improvements (including moving to `shallowRef` from `ref` within `useAsyncData`) but the most significant is the switch to using virtual scroller for post replies. It also renders a skeleton when loading the context. In view of past regressions (e.g. on notifications) when adopting virtual scroller, it would be good to have some review and testing before merging.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
