### PR TITLE
fix: post length should account for draft mentions

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -61,7 +61,17 @@ const { editor } = useTiptap({
   },
   onPaste: handlePaste,
 })
-const characterCount = $computed(() => htmlToText(editor.value?.getHTML() || '').length)
+const characterCount = $computed(() => {
+  let length = htmlToText(editor.value?.getHTML() || '').length
+
+  if (draft.mentions)
+    length += draft.mentions.map(mention => {
+      const [handle] = mention.split('@')
+      return '@' + handle
+    }).join(' ').length + 1
+
+  return length
+})
 
 async function handlePaste(evt: ClipboardEvent) {
   const files = evt.clipboardData?.files

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -65,6 +65,7 @@ const characterCount = $computed(() => {
   let length = htmlToText(editor.value?.getHTML() || '').length
 
   if (draft.mentions)
+    // + 1 is needed as mentions always need a space seperator at the end
     length += draft.mentions.map(mention => {
       const [handle] = mention.split('@')
       return '@' + handle


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- I noticed that when replying to a post, the character count doesn't account for draft mentions. As such you'll appear to be within the character limit but you're not. So, the request gets sent but of course fails without an obvious reason for the end user.

Draft mentions as in these

![image](https://user-images.githubusercontent.com/22969497/212576834-a07e2a7b-b792-40c6-9222-16911fedfe89.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide related snapshots or videos.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
