### PR TITLE
feat: change default server to webtools

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,7 +92,7 @@ export default defineNuxtConfig({
       buildInfo: {} as BuildInfo, // set in build-env module
       pwaEnabled: !isDevelopment || process.env.VITE_DEV_PWA === 'true',
       translateApi: '',
-      defaultServer: 'mas.to',
+      defaultServer: 'm.webtoo.ls',
     },
     storage: {
       driver: isCI ? 'cloudflare' : 'fs',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR changes our default server (ie. when logged out) to webtools rather than `mas.to`. This may dramatically increase load on what is quite a small server, but worth a try.

https://github.com/elk-zone/elk/issues/385

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
