### PR TITLE
perf: exclude pwa web manifests from sw precache

### DIFF
--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -13,8 +13,8 @@ export const pwa: VitePWANuxtOptions = {
   includeManifestIcons: false,
   manifest: false,
   injectManifest: {
-    globPatterns: ['**/*.{js,json,css,html,txt,svg,png,ico,webp,woff,woff2,ttf,eot,otf,wasm,webmanifest}'],
-    globIgnores: ['emojis/**', 'shiki/**'],
+    globPatterns: ['**/*.{js,json,css,html,txt,svg,png,ico,webp,woff,woff2,ttf,eot,otf,wasm}'],
+    globIgnores: ['emojis/**', 'shiki/**', 'manifest**.webmanifest'],
   },
   devOptions: {
     enabled: process.env.VITE_DEV_PWA === 'true',

--- a/service-worker/sw.ts
+++ b/service-worker/sw.ts
@@ -3,7 +3,7 @@
 import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching'
 import { NavigationRoute, registerRoute } from 'workbox-routing'
 import { CacheableResponsePlugin } from 'workbox-cacheable-response'
-import { StaleWhileRevalidate } from 'workbox-strategies'
+import { NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
 
 import { onNotificationClick, onPush } from './web-push-notifications'
@@ -37,6 +37,19 @@ if (import.meta.env.PROD)
 
 // only cache pages and external assets on local build + start or in production
 if (import.meta.env.PROD) {
+  // include webmanifest cache
+  registerRoute(
+    ({ request, sameOrigin }) =>
+      sameOrigin && request.destination === 'manifest',
+    new NetworkFirst({
+      cacheName: 'elk-webmanifest',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+        // we only need a few entries
+        new ExpirationPlugin({ maxEntries: 100 }),
+      ],
+    }),
+  )
   // include shiki cache
   registerRoute(
     ({ sameOrigin, url }) =>


### PR DESCRIPTION
### Description

We're preparing language country variants and then web manifest number will increase, this PR excludes these files from being precached in the service worker: added route entry in the service worker using network first strategy to allow work offline.

### Additional context

Once `nuxt-i18n` module adds the ability to reuse base locale, we'll start adding country variants: for example, just for spanish country variants there will be 19 new files (19 new web manifests + 19 dark web manifest variants).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
