### PR TITLE
chore: webtoo.ls as default server

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -94,7 +94,8 @@ export default defineNuxtConfig({
       pwaEnabled: !isDevelopment || process.env.VITE_DEV_PWA === 'true',
       // We use LibreTranslate(https://github.com/LibreTranslate/LibreTranslate) as our default translation server #76
       translateApi: '',
-      defaultServer: 'mas.to',
+      // Use the instance where Elk has its Mastodon account as the default
+      defaultServer: 'webtoo.ls',
     },
     storage: {
       driver: isCI ? 'cloudflare' : 'fs',

--- a/tests/__snapshots__/content-rich.test.ts.snap
+++ b/tests/__snapshots__/content-rich.test.ts.snap
@@ -43,7 +43,7 @@ exports[`content-rich > code frame 2 1`] = `
     ><a
       class=\\"u-url mention\\"
       rel=\\"nofollow noopener noreferrer\\"
-      to=\\"/mas.to/@antfu\\"
+      to=\\"/webtoo.ls/@antfu\\"
     ></a
   ></span>
   Testing<br />
@@ -61,11 +61,11 @@ exports[`content-rich > custom emoji 1`] = `
 <picture alt=\\":nuxt:\\" class=\\"custom-emoji\\" data-emoji-id=\\"nuxt\\"
   ><source
     srcset=\\"
-      https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/static/c96ba3cb0e0e1eac.png
+      https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png
     \\"
     media=\\"(prefers-reduced-motion: reduce)\\" />
   <img
-    src=\\"https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/original/c96ba3cb0e0e1eac.png\\"
+    src=\\"https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png\\"
     alt=\\":nuxt:\\"
 /></picture>
 "
@@ -137,7 +137,7 @@ exports[`content-rich > link + mention 1`] = `
     ><a
       class=\\"u-url mention\\"
       rel=\\"nofollow noopener noreferrer\\"
-      to=\\"/mas.to/@vitest\\"
+      to=\\"/webtoo.ls/@vitest\\"
     ></a
   ></span>
   (migrated from chai+mocha)

--- a/tests/__snapshots__/html-parse.test.ts.snap
+++ b/tests/__snapshots__/html-parse.test.ts.snap
@@ -25,7 +25,7 @@ exports[`html-parse > code frame 2 > html 1`] = `
 "<p>
   <span class=\\"h-card\\"
     ><a
-      href=\\"https://mas.to/@antfu\\"
+      href=\\"https://webtoo.ls/@antfu\\"
       class=\\"u-url mention\\"
       rel=\\"nofollow noopener noreferrer\\"
       target=\\"_blank\\"
@@ -51,11 +51,11 @@ exports[`html-parse > custom emoji > html 1`] = `
 <picture alt=\\":nuxt:\\" class=\\"custom-emoji\\" data-emoji-id=\\"nuxt\\"
   ><source
     srcset=\\"
-      https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/static/c96ba3cb0e0e1eac.png
+      https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png
     \\"
     media=\\"(prefers-reduced-motion: reduce)\\" />
   <img
-    src=\\"https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/original/c96ba3cb0e0e1eac.png\\"
+    src=\\"https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png\\"
     alt=\\":nuxt:\\"
 /></picture>
 "
@@ -121,7 +121,7 @@ exports[`html-parse > link + mention > html 1`] = `
   we’re now using
   <span class=\\"h-card\\"
     ><a
-      href=\\"https://mas.to/@vitest\\"
+      href=\\"https://webtoo.ls/@vitest\\"
       class=\\"u-url mention\\"
       rel=\\"nofollow noopener noreferrer\\"
       target=\\"_blank\\"

--- a/tests/content-rich.test.ts
+++ b/tests/content-rich.test.ts
@@ -13,7 +13,7 @@ describe('content-rich', () => {
 
   it('link + mention', async () => {
     // https://fosstodon.org/@ayo/109383002937620723
-    const { formatted } = await render('<p>Happy 🤗 we’re now using <span class="h-card"><a href="https://mas.to/@vitest" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>vitest</span></a></span> (migrated from chai+mocha) <a href="https://github.com/ayoayco/astro-reactive-library/pull/203" rel="nofollow noopener noreferrer" target="_blank"><span class="invisible">https://</span><span class="ellipsis">github.com/ayoayco/astro-react</span><span class="invisible">ive-library/pull/203</span></a></p>')
+    const { formatted } = await render('<p>Happy 🤗 we’re now using <span class="h-card"><a href="https://webtoo.ls/@vitest" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>vitest</span></a></span> (migrated from chai+mocha) <a href="https://github.com/ayoayco/astro-reactive-library/pull/203" rel="nofollow noopener noreferrer" target="_blank"><span class="invisible">https://</span><span class="ellipsis">github.com/ayoayco/astro-react</span><span class="invisible">ive-library/pull/203</span></a></p>')
     expect(formatted).toMatchSnapshot()
   })
 
@@ -49,8 +49,8 @@ describe('content-rich', () => {
       emojis: {
         nuxt: {
           shortcode: 'nuxt',
-          url: 'https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/original/c96ba3cb0e0e1eac.png',
-          staticUrl: 'https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/static/c96ba3cb0e0e1eac.png',
+          url: 'https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png',
+          staticUrl: 'https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png',
           visibleInPicker: true,
         },
       },
@@ -59,13 +59,13 @@ describe('content-rich', () => {
   })
 
   it('code frame', async () => {
-    // https://mas.to/@antfu/109396489827394721
+    // https://webtoo.ls/@antfu/109396489827394721
     const { formatted } = await render('<p>Testing code block</p><p>```ts<br />import { useMouse, usePreferredDark } from &#39;@vueuse/core&#39;</p><p>// tracks mouse position<br />const { x, y } = useMouse()</p><p>// is the user prefers dark theme<br />const isDark = usePreferredDark()<br />```</p>')
     expect(formatted).toMatchSnapshot()
   })
 
   it('code frame 2', async () => {
-    const { formatted } = await render('<p><span class=\"h-card\"><a href=\"https://mas.to/@antfu\" class=\"u-url mention\">@<span>antfu</span></a></span> Testing<br />```ts<br />const a = hello<br />```</p>')
+    const { formatted } = await render('<p><span class=\"h-card\"><a href=\"https://webtoo.ls/@antfu\" class=\"u-url mention\">@<span>antfu</span></a></span> Testing<br />```ts<br />const a = hello<br />```</p>')
     expect(formatted).toMatchSnapshot()
   })
 

--- a/tests/html-parse.test.ts
+++ b/tests/html-parse.test.ts
@@ -12,7 +12,7 @@ describe('html-parse', () => {
 
   it('link + mention', async () => {
     // https://fosstodon.org/@ayo/109383002937620723
-    const { formatted, serializedText } = await render('<p>Happy 🤗 we’re now using <span class="h-card"><a href="https://mas.to/@vitest" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>vitest</span></a></span> (migrated from chai+mocha) <a href="https://github.com/ayoayco/astro-reactive-library/pull/203" rel="nofollow noopener noreferrer" target="_blank"><span class="invisible">https://</span><span class="ellipsis">github.com/ayoayco/astro-react</span><span class="invisible">ive-library/pull/203</span></a></p>')
+    const { formatted, serializedText } = await render('<p>Happy 🤗 we’re now using <span class="h-card"><a href="https://webtoo.ls/@vitest" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>vitest</span></a></span> (migrated from chai+mocha) <a href="https://github.com/ayoayco/astro-reactive-library/pull/203" rel="nofollow noopener noreferrer" target="_blank"><span class="invisible">https://</span><span class="ellipsis">github.com/ayoayco/astro-react</span><span class="invisible">ive-library/pull/203</span></a></p>')
     expect(formatted).toMatchSnapshot('html')
     expect(serializedText).toMatchSnapshot('text')
   })
@@ -21,8 +21,8 @@ describe('html-parse', () => {
     const { formatted, serializedText } = await render('Daniel Roe :nuxt:', {
       nuxt: {
         shortcode: 'nuxt',
-        url: 'https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/original/c96ba3cb0e0e1eac.png',
-        staticUrl: 'https://media.mas.to/masto-public/cache/custom_emojis/images/000/288/667/static/c96ba3cb0e0e1eac.png',
+        url: 'https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png',
+        staticUrl: 'https://media.webtoo.ls/custom_emojis/images/000/000/366/original/73330dfc9dda4078.png',
         visibleInPicker: true,
       },
     })
@@ -37,14 +37,14 @@ describe('html-parse', () => {
   })
 
   it('code frame', async () => {
-    // https://mas.to/@antfu/109396489827394721
+    // https://webtoo.ls/@antfu/109396489827394721
     const { formatted, serializedText } = await render('<p>Testing code block</p><p>```ts<br />import { useMouse, usePreferredDark } from &#39;@vueuse/core&#39;</p><p>// tracks mouse position<br />const { x, y } = useMouse()</p><p>// is the user prefers dark theme<br />const isDark = usePreferredDark()<br />```</p>')
     expect(formatted).toMatchSnapshot('html')
     expect(serializedText).toMatchSnapshot('text')
   })
 
   it('code frame 2', async () => {
-    const { formatted, serializedText } = await render('<p><span class=\"h-card\"><a href=\"https://mas.to/@antfu\" class=\"u-url mention\">@<span>antfu</span></a></span> Testing<br />```ts<br />const a = hello<br />```</p>')
+    const { formatted, serializedText } = await render('<p><span class=\"h-card\"><a href=\"https://webtoo.ls/@antfu\" class=\"u-url mention\">@<span>antfu</span></a></span> Testing<br />```ts<br />const a = hello<br />```</p>')
     expect(formatted).toMatchSnapshot('html')
     expect(serializedText).toMatchSnapshot('text')
   })

--- a/tests/permalinks.test.ts
+++ b/tests/permalinks.test.ts
@@ -5,12 +5,12 @@ const validPermalinks = [
   'https://m1as-social34.to.social/@elk',
   'https://m1as-social34.to.social/@elk22/123',
   'https://m1as-social34.to.social/@elk22/objects/123',
-  'mas.to/@elk',
+  'webtoo.ls/@elk',
 ]
 
 const invalidPermalinks = [
-  'https://mas.to',
-  'https://mas.to/elk/123',
+  'https://webtoo.ls',
+  'https://webtoo.ls/elk/123',
 ]
 
 describe('permalinks', () => {


### PR DESCRIPTION
### Description

Use webtoo.ls instead of mas.to as default server, as the content shown by default in the local timeline, is more related to Elk (since its account and the accounts of many of the team members are on it).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [x] Other