### PR TITLE
fix(ui): translation button loading style issue in light theme

### DIFF
--- a/components/status/StatusTranslation.vue
+++ b/components/status/StatusTranslation.vue
@@ -27,7 +27,7 @@ const toggleTranslation = async () => {
   <div>
     <button
       v-if="isTranslationEnabled && status.language !== languageCode" pl-0 flex="~ center" gap-2
-      :disabled="translating" disabled-bg-transparent btn-text @click="toggleTranslation"
+      :disabled="translating" disabled-bg-transparent btn-text class="disabled-text-$c-text-btn-disabled-deeper" @click="toggleTranslation"
     >
       <span v-if="translating" block animate-spin preserve-3d>
         <span block i-ri:loader-2-fill />

--- a/styles/vars.css
+++ b/styles/vars.css
@@ -19,6 +19,7 @@
 
   --c-bg-btn-disabled: #a1a1a1;
   --c-text-btn-disabled: #fff;
+  --c-text-btn-disabled-deeper: #a1a1a1;
   --c-text-btn: #232323;
 
   --c-success: #67C23A;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is a style fix for #1211 

Loading text color cannot accessible in light theme.

Before:
<img width="369" alt="before" src="https://user-images.githubusercontent.com/49969959/212664491-70216e9a-66d3-4386-ac53-351da8b26799.png">


After

<img width="682" alt="after" src="https://user-images.githubusercontent.com/49969959/212664514-36dc0458-a55d-43f5-afb7-4c4d24875f15.png">



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
