### PR TITLE
feat: support all HTML elements allowed by Glitch

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -35,12 +35,35 @@ const sanitizer = sanitize({
   code: {
     class: filterClasses(/^language-\w+$/),
   },
-  // other elements supported in glitch
-  h1: {},
-  ol: {},
-  ul: {},
-  li: {},
+  // Other elements supported in glitch, as seen in
+  // https://github.com/glitch-soc/mastodon/blob/13227e1dafd308dfe1a3effc3379b766274809b3/lib/sanitize_ext/sanitize_config.rb#L75
+  abbr: {
+    title: keep,
+  },
+  del: {},
+  blockquote: {
+    cite: filterHref(),
+  },
+  b: {},
+  strong: {},
+  u: {},
+  sub: {},
+  sup: {},
+  i: {},
   em: {},
+  h1: {},
+  h2: {},
+  h3: {},
+  h4: {},
+  h5: {},
+  ul: {},
+  ol: {
+    start: keep,
+    reversed: keep,
+  },
+  li: {
+    value: keep,
+  },
 })
 
 /**
@@ -253,6 +276,10 @@ function filterClasses(allowed: RegExp) {
 
     return c.split(/\s/g).filter(cls => allowed.test(cls)).join(' ')
   }
+}
+
+function keep(value: string | undefined) {
+  return value
 }
 
 function set(value: string) {

--- a/tests/__snapshots__/content-rich.test.ts.snap
+++ b/tests/__snapshots__/content-rich.test.ts.snap
@@ -92,7 +92,7 @@ exports[`content-rich > handles formatting from servers 1`] = `
 <p></p>
 <ul>
   <li>This is an indented bulleted list (not just asterisks).</li>
-  <li></li>
+  <li><strong>This line is bold.</strong></li>
   <li><em>This line is italic.</em></li>
 </ul>
 <ol>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pull request adds support for the rest of the HTML elements that glitch-soc allows. Some of the elements (like `<em>`) were already supported. This pull request fills up the roster with the rest of the elements based on https://github.com/glitch-soc/mastodon/blob/13227e1dafd308dfe1a3effc3379b766274809b3/lib/sanitize_ext/sanitize_config.rb.

The post pictured in issue #1230 looks like this after applying this change:

<img width="619" alt="Screenshot 2023-01-16 at 19 33 37" src="https://user-images.githubusercontent.com/19776768/212737455-7ec21d50-6942-46df-a792-28751e3d982b.png">

Some elements, like `<blockquote>`, are now kept in the DOM, but their are essentially unstyled. This is probably best solved by someone who - unlike me - has a some styling skills 🙂

The test snapshot for one test needed to be updated, as `<strong>` elements are now allowed.

Closes #1230.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
