### PR TITLE
feat: StackBlitz code block expansion

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -6,7 +6,7 @@ const { status, context } = defineProps<{
   context?: mastodon.v2.FilterContext | 'details'
 }>()
 
-const isDM = $computed(() => status.visibility === 'direct')
+const isDM = $computed(() => false) // status.visibility === 'direct')
 const isDetails = $computed(() => context === 'details')
 
 // Content Filter logic

--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -6,7 +6,7 @@ const { status, context } = defineProps<{
   context?: mastodon.v2.FilterContext | 'details'
 }>()
 
-const isDM = $computed(() => false) // status.visibility === 'direct')
+const isDM = $computed(() => status.visibility === 'direct')
 const isDetails = $computed(() => context === 'details')
 
 // Content Filter logic

--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -16,6 +16,6 @@ const gitHubCards = $(usePreferences('experimentalGitHubCards'))
 
 <template>
   <StatusPreviewGitHub v-if="gitHubCards && providerName === 'GitHub'" :card="card" />
-  <StatusPreviewStackBlitz v-else-if="gitHubCards && providerName === 'stackblitz.com'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+  <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName === 'stackblitz.com'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
   <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>

--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -15,7 +15,7 @@ const gitHubCards = $(usePreferences('experimentalGitHubCards'))
 </script>
 
 <template>
-  <StatusPreviewGitHub v-if="gitHubCards && providerName === 'GitHub'" :card="card" />
+  <LazyStatusPreviewGitHub v-if="gitHubCards && providerName === 'GitHub'" :card="card" />
   <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName === 'stackblitz.com'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
   <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>

--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -9,74 +9,13 @@ const props = defineProps<{
   root?: boolean
 }>()
 
-// mastodon's default max og image width
-const ogImageWidth = 400
-
-const alt = $computed(() => `${props.card.title} - ${props.card.title}`)
-const isSquare = $computed(() => (
-  props.smallPictureOnly
-  || props.card.width === props.card.height
-  || Number(props.card.width || 0) < ogImageWidth
-  || Number(props.card.height || 0) < ogImageWidth / 2
-))
 const providerName = $computed(() => props.card.providerName ? props.card.providerName : new URL(props.card.url).hostname)
 
 const gitHubCards = $(usePreferences('experimentalGitHubCards'))
-
-// TODO: handle card.type: 'photo' | 'video' | 'rich';
-const cardTypeIconMap: Record<mastodon.v1.PreviewCardType, string> = {
-  link: 'i-ri:profile-line',
-  photo: 'i-ri:image-line',
-  video: 'i-ri:play-line',
-  rich: 'i-ri:profile-line',
-}
 </script>
 
 <template>
   <StatusPreviewGitHub v-if="gitHubCards && providerName === 'GitHub'" :card="card" />
-  <NuxtLink
-    v-else
-    block
-    of-hidden
-    :to="card.url"
-    bg-card
-    hover:bg-active
-    :class="{
-      'flex': isSquare,
-      'p-4': root,
-      'rounded-lg': !root,
-    }"
-    target="_blank"
-    external
-  >
-    <div
-      v-if="card.image"
-      flex flex-col
-      display-block of-hidden
-      :class="{
-        'sm:(min-w-32 w-32 h-32) min-w-24 w-24 h-24': isSquare,
-        'w-full aspect-[1.91]': !isSquare,
-        'rounded-lg': root,
-      }"
-    >
-      <CommonBlurhash
-        :blurhash="card.blurhash"
-        :src="card.image"
-        :width="card.width"
-        :height="card.height"
-        :alt="alt"
-        w-full h-full object-cover
-      />
-    </div>
-    <div
-      v-else
-      min-w-24 w-24 h-24 sm="min-w-32 w-32 h-32" bg="slate-500/10" flex justify-center items-center
-      :class="[
-        root ? 'rounded-lg' : '',
-      ]"
-    >
-      <div :class="cardTypeIconMap[card.type]" w="30%" h="30%" text-secondary />
-    </div>
-    <StatusPreviewCardInfo :p="isSquare ? 'x-4' : '4'" :root="root" :card="card" :provider="providerName" />
-  </NuxtLink>
+  <StatusPreviewStackBlitz v-else-if="gitHubCards && providerName === 'stackblitz.com'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+  <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>

--- a/components/status/StatusPreviewCardNormal.vue
+++ b/components/status/StatusPreviewCardNormal.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import type { mastodon } from 'masto'
+
+const props = defineProps<{
+  card: mastodon.v1.PreviewCard
+  /** For the preview image, only the small image mode is displayed */
+  smallPictureOnly?: boolean
+  /** When it is root card in the list, not appear as a child card */
+  root?: boolean
+}>()
+
+// mastodon's default max og image width
+const ogImageWidth = 400
+
+const alt = $computed(() => `${props.card.title} - ${props.card.title}`)
+const isSquare = $computed(() => (
+  props.smallPictureOnly
+  || props.card.width === props.card.height
+  || Number(props.card.width || 0) < ogImageWidth
+  || Number(props.card.height || 0) < ogImageWidth / 2
+))
+const providerName = $computed(() => props.card.providerName ? props.card.providerName : new URL(props.card.url).hostname)
+
+// TODO: handle card.type: 'photo' | 'video' | 'rich';
+const cardTypeIconMap: Record<mastodon.v1.PreviewCardType, string> = {
+  link: 'i-ri:profile-line',
+  photo: 'i-ri:image-line',
+  video: 'i-ri:play-line',
+  rich: 'i-ri:profile-line',
+}
+</script>
+
+<template>
+  <NuxtLink
+    block
+    of-hidden
+    :to="card.url"
+    bg-card
+    hover:bg-active
+    :class="{
+      'flex': isSquare,
+      'p-4': root,
+      'rounded-lg': !root,
+    }"
+    target="_blank"
+    external
+  >
+    <div
+      v-if="card.image"
+      flex flex-col
+      display-block of-hidden
+      :class="{
+        'sm:(min-w-32 w-32 h-32) min-w-24 w-24 h-24': isSquare,
+        'w-full aspect-[1.91]': !isSquare,
+        'rounded-lg': root,
+      }"
+    >
+      <CommonBlurhash
+        :blurhash="card.blurhash"
+        :src="card.image"
+        :width="card.width"
+        :height="card.height"
+        :alt="alt"
+        w-full h-full object-cover
+      />
+    </div>
+    <div
+      v-else
+      min-w-24 w-24 h-24 sm="min-w-32 w-32 h-32" bg="slate-500/10" flex justify-center items-center
+      :class="[
+        root ? 'rounded-lg' : '',
+      ]"
+    >
+      <div :class="cardTypeIconMap[card.type]" w="30%" h="30%" text-secondary />
+    </div>
+    <StatusPreviewCardInfo :p="isSquare ? 'x-4' : '4'" :root="root" :card="card" :provider="providerName" />
+  </NuxtLink>
+</template>

--- a/components/status/StatusPreviewStackBlitz.vue
+++ b/components/status/StatusPreviewStackBlitz.vue
@@ -50,6 +50,7 @@ const vnodeCode = $computed(() => {
     w-full
     rounded-lg
     overflow-hidden
+    pb-2
   >
     <div whitespace-pre-wrap break-words>
       <span v-if="vnodeCode" class="content-rich line-compact" dir="auto">
@@ -62,7 +63,6 @@ const vnodeCode = $computed(() => {
       bg-card
       w-full
       justify-center
-      rounded="bl-lg br-lg"
       p-3
       pb-4
     >
@@ -74,10 +74,8 @@ const vnodeCode = $computed(() => {
           Open
         </NuxtLink>
       </div>
-      <div flex justify-between>
-        <p font-bold flex gap-1>
-          <span text-primary>{{ meta.project }}</span><span> - StackBlitz</span>
-        </p>
+      <div flex font-bold gap-2>
+        <span text-primary>{{ meta.project }}</span><span flex text-secondary><span flex items-center><svg h-5 width="22.27" height="32" viewBox="0 0 256 368"><path fill="currentColor" d="M109.586 217.013H0L200.34 0l-53.926 150.233H256L55.645 367.246l53.927-150.233z" /></svg></span><span>StackBlitz</span></span>
       </div>
     </div>
   </div>

--- a/components/status/StatusPreviewStackBlitz.vue
+++ b/components/status/StatusPreviewStackBlitz.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { mastodon } from 'masto'
+
+const props = defineProps<{
+  card: mastodon.v1.PreviewCard
+  /** For the preview image, only the small image mode is displayed */
+  smallPictureOnly?: boolean
+  /** When it is root card in the list, not appear as a child card */
+  root?: boolean
+}>()
+
+interface Meta {
+  code?: string
+  file?: string
+  lines?: string
+}
+
+const meta = $computed(() => {
+  const { description } = props.card
+  const meta = description.match(/.+\n\nCode Snippet from (.+), lines ([\w-]+)\n\n(.+)/s)
+  const file = meta?.[1]
+  const lines = meta?.[2]
+  const code = meta?.[3]
+  const info = $ref<Meta>({
+    file,
+    lines,
+    code,
+  })
+  return info
+})
+
+const vnodeCode = $computed(() => {
+  if (!meta.code)
+    return null
+  const vnode = contentToVNode(`<p>\`\`\`${meta.file?.split('.')?.[1] ?? ''}\n${meta.code}\n\`\`\`\</p>`, {
+    markdown: true,
+  })
+  return vnode
+})
+</script>
+
+<template>
+  <div
+    v-if="meta.code"
+    flex flex-col
+    display-block of-hidden
+    w-full
+    justify-center
+  >
+    <div
+      flex flex-col
+      display-block of-hidden
+      bg-card
+      w-full
+      justify-center
+      rounded-lg
+      p-3
+    >
+      <div flex justify-between>
+        <p font-bold>
+          {{ card.title }}
+        </p>
+        <NuxtLink external target="_blank" btn-solid py-0 px-2 :to="card.url">
+          Open
+        </NuxtLink>
+      </div>
+
+      <div flex justify-between>
+        <p flex gap-1>
+          <span>Code Snippet from</span><span>{{ meta.file }}</span><span text-secondary>{{ `(Lines ${meta.lines})` }}</span>
+        </p>
+      </div>
+    </div>
+    <div whitespace-pre-wrap break-words rounded-lg>
+      <span v-if="vnodeCode" class="content-rich line-compact" dir="auto">
+        <component :is="vnodeCode" />
+      </span>
+    </div>
+  </div>
+  <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+</template>

--- a/components/status/StatusPreviewStackBlitz.vue
+++ b/components/status/StatusPreviewStackBlitz.vue
@@ -13,18 +13,21 @@ interface Meta {
   code?: string
   file?: string
   lines?: string
+  project?: string
 }
 
 const meta = $computed(() => {
   const { description } = props.card
   const meta = description.match(/.+\n\nCode Snippet from (.+), lines ([\w-]+)\n\n(.+)/s)
   const file = meta?.[1]
-  const lines = meta?.[2]
+  const lines = meta?.[2].replaceAll('N', '')
   const code = meta?.[3]
+  const project = props.card.title?.replace(' - StackBlitz', '')
   const info = $ref<Meta>({
     file,
     lines,
     code,
+    project,
   })
   return info
 })
@@ -42,40 +45,51 @@ const vnodeCode = $computed(() => {
 <template>
   <div
     v-if="meta.code"
-    flex flex-col
+    flex flex-col gap-1
     display-block of-hidden
     w-full
-    justify-center
+    rounded-lg
+    overflow-hidden
   >
+    <div whitespace-pre-wrap break-words>
+      <span v-if="vnodeCode" class="content-rich line-compact" dir="auto">
+        <component :is="vnodeCode" />
+      </span>
+    </div>
     <div
       flex flex-col
       display-block of-hidden
       bg-card
       w-full
       justify-center
-      rounded-lg
+      rounded="bl-lg br-lg"
       p-3
+      pb-4
     >
       <div flex justify-between>
-        <p font-bold>
-          {{ card.title }}
+        <p flex gap-1>
+          <span>Code Snippet from</span><span>{{ meta.file }}</span><span text-secondary>{{ `- Lines ${meta.lines}` }}</span>
         </p>
         <NuxtLink external target="_blank" btn-solid py-0 px-2 :to="card.url">
           Open
         </NuxtLink>
       </div>
-
       <div flex justify-between>
-        <p flex gap-1>
-          <span>Code Snippet from</span><span>{{ meta.file }}</span><span text-secondary>{{ `(Lines ${meta.lines})` }}</span>
+        <p font-bold flex gap-1>
+          <span text-primary>{{ meta.project }}</span><span> - StackBlitz</span>
         </p>
       </div>
-    </div>
-    <div whitespace-pre-wrap break-words rounded-lg>
-      <span v-if="vnodeCode" class="content-rich line-compact" dir="auto">
-        <component :is="vnodeCode" />
-      </span>
     </div>
   </div>
   <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>
+
+<style scoped>
+.content-rich p {
+  margin-top: 0;
+}
+.code-block {
+  margin-top: 0;
+  border-radius: 0;
+}
+</style>


### PR DESCRIPTION
### Description

StackBlitz added the code in the meta description when sharing a URL with `L1-L3` (highlight code in a playground)

https://stackblitz.com/edit/node?file=index.js%3AL1-L3

This would allow us to render the code using shiki instead of using a social image and have a snippet where you can click to see it working in a playground.

The design is still in progress, sending the PR to test and start playing

![image](https://user-images.githubusercontent.com/583075/212779443-88c3b69b-4b54-4694-ae37-dabeee7c7d54.png)

![image](https://user-images.githubusercontent.com/583075/212779463-d1cb6320-4675-4d7f-94ec-d6b25d875b11.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other