### PR TITLE
fix: make translate button visually less distracting

### DIFF
--- a/components/status/StatusTranslation.vue
+++ b/components/status/StatusTranslation.vue
@@ -26,7 +26,7 @@ const toggleTranslation = async () => {
 <template>
   <div>
     <button
-      v-if="isTranslationEnabled && status.language !== languageCode" pl-0 flex="~ center" gap-2
+      v-if="isTranslationEnabled && status.language !== languageCode" p-0 flex="~ center" gap-2 text-sm
       :disabled="translating" disabled-bg-transparent btn-text class="disabled-text-$c-text-btn-disabled-deeper" @click="toggleTranslation"
     >
       <span v-if="translating" block animate-spin preserve-3d>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR makes the translate button's text size & spacing smaller to make it less stand out and less distracting visually.

| before | after |
| -------|-----|
| <img width="300" src="https://media.discordapp.net/attachments/1045711701359743098/1064674548139687987/image.png"> |  <img width="300" alt="image" src="https://user-images.githubusercontent.com/1430856/212826338-649eb49f-f6d7-44e9-b8bb-b290c842bd1f.png"> |

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

As I pointed out on [Discord](https://discord.com/channels/1044887051155292200/1045711701359743098/1064674548345225387), the current translate button is a bit too large and visually distracting. Keep it the same size as mention groups, which is `text-sm`, would be more ideal.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
