### PR TITLE
perf: use server namespace to simplify kv querying

### DIFF
--- a/server/shared.ts
+++ b/server/shared.ts
@@ -56,7 +56,7 @@ async function fetchAppInfo(origin: string, server: string) {
 
 export async function getApp(origin: string, server: string) {
   const host = origin.replace(/^https?:\/\//, '').replace(/[^\w\d]/g, '-')
-  const key = `servers:v2:${server}:${host}.json`
+  const key = `servers:v2:${server}:${host}.json`.toLowerCase()
 
   try {
     if (await storage.hasItem(key))

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -55,7 +55,8 @@ async function fetchAppInfo(origin: string, server: string) {
 }
 
 export async function getApp(origin: string, server: string) {
-  const key = `servers:${origin.replace(/[^\w\d]/g, '-')}:${server}.json`
+  const host = origin.replace(/^https?:\/\//, '').replace(/[^\w\d]/g, '-')
+  const key = `servers:v2:${server}:${host}.json`
 
   try {
     if (await storage.hasItem(key))
@@ -70,16 +71,16 @@ export async function getApp(origin: string, server: string) {
 }
 
 export async function deleteApp(server: string) {
-  const keys = (await storage.getKeys('servers:')).filter(k => k.endsWith(`${server}.json`))
+  const keys = (await storage.getKeys(`servers:v2:${server}:`))
   for (const key of keys)
     await storage.removeItem(key)
 }
 
 export async function listServers() {
-  const keys = await storage.getKeys('servers:')
+  const keys = await storage.getKeys('servers:v2:')
   const servers = new Set<string>()
   for await (const key of keys) {
-    const id = key.split(':').pop()!.replace(/\.json$/, '')
+    const id = key.split(':')[2]
     if (id)
       servers.add(id.toLocaleLowerCase())
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because of how we query KV store in unstorage, being able to pass a prefix is important, and this means we can query by host server rather than origin.

It will also reset our oauth data, so 🤷 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
