### PR TITLE
fix: use global regex to escape backticks

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -89,7 +89,7 @@ export function parseMastodonHTML(
         const code = htmlToText(raw)
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')
-          .replace(/`/, '&#96;')
+          .replace(/`/g, '&#96;')
         const classes = lang ? ` class="language-${lang}"` : ''
         return `><pre><code${classes}>${code}</code></pre>`
       })


### PR DESCRIPTION
This PR fixes a backtick escaping.

### Additional context

Example: https://main.elk.zone/m.webtoo.ls/@elkdev@universeodon.com/109703907364081699

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
