### PR TITLE
fix: disable user-select on StatusActionButton component

### DIFF
--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -49,7 +49,7 @@ useCommand({
   <component
     :is="as"
     v-bind="$attrs" ref="el"
-    w-fit flex gap-1 items-center transition-all
+    w-fit flex gap-1 items-center transition-all select-none
     rounded group
     :hover=" !disabled ? hover : undefined"
     focus:outline-none


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Disable selection on `StatusActionButton`. Selection is easily trigger on iOS when doing long press on action buttons like boost.

### Additional context

#1132 #1147 #1219 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
