### PR TITLE
feat: in image alt, render clickable links and rich content

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -73,7 +73,7 @@ const vnode = $computed(() => {
   // https://stackoverflow.com/a/37462442
   // https://stephencharlesweiss.com/regex-markdown-link
   const regexMarkdownFind = /(?:__|[*#])|\[(.*?)\]\(.*?\)/g
-  const regexMarkdownExtract = /!?\[([^\]]*)?\]\(((https?:\/\/)?[A-Za-z0-9\:\/\. ]+)(\"(.+)\")?\)/gm
+  const regexMarkdownExtract = /!?\[([^\]]*)?\]\(((https?:\/\/)?[-a-zA-Z0-9()@:%_\+.~#?&//=\/]+)(\"(.+)\")?\)/gm
 
   let matches = [...description.matchAll(regexMarkdownFind)]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/elk-zone/elk/issues/1267
Closes https://github.com/elk-zone/elk/pull/1270

Demo: https://deploy-preview-1285--elk-zone.netlify.app/universeodon.com/@elkdev/109709332257865291

This PR makes links in Image Alt description clickable and renders rich content like *emphasis* and **bold**.

![Screenshot showing how this PR works](https://user-images.githubusercontent.com/16903044/213131079-a30442e7-94b8-4c2f-867d-a6fa8350da7b.png)

### Additional context

> e.g. is there anything you'd like reviewers to focus on?

I've tried to break it with various kinds of URLs and will continue to try to do so, but I'll feel more comfortable if more fuzzing is done to see if any URLs break the regex and maybe create an exception.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
