### PR TITLE
fix: make attachement removal button static & more visible #1067

### DIFF
--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -31,7 +31,7 @@ const toggleApply = () => {
         v-if="removable"
         :aria-label="$t('attachment.remove_label')"
         class="bg-black/75 hover:bg-red/75"
-        text-white px2 py2 rounded-5 cursor-pointer
+        text-white px2 py2 rounded-full cursor-pointer
         @click="$emit('remove')"
       >
         <div i-ri:close-line text-3 :class="[isHydrated && isSmallScreen ? 'text-6' : 'text-3']" />

--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -30,7 +30,8 @@ const toggleApply = () => {
       <div
         v-if="removable"
         :aria-label="$t('attachment.remove_label')"
-        class="bg-black/75 text-white px2 py2 rounded-5 cursor-pointer"
+        class="bg-black/75 hover:bg-red/75"
+        text-white px2 py2 rounded-5 cursor-pointer
         @click="$emit('remove')"
       >
         <div i-ri:close-line text-3 :class="[isHydrated && isSmallScreen ? 'text-6' : 'text-3']" />

--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -30,9 +30,7 @@ const toggleApply = () => {
       <div
         v-if="removable"
         :aria-label="$t('attachment.remove_label')"
-        hover:bg="gray/40" transition-100 p-1 rounded-5 cursor-pointer
-        :class="[isHydrated && isSmallScreen ? '' : 'op-0 group-hover:op-100hover:']"
-        mix-blend-difference
+        class="bg-black/75 text-white px2 py2 rounded-5 cursor-pointer"
         @click="$emit('remove')"
       >
         <div i-ri:close-line text-3 :class="[isHydrated && isSmallScreen ? 'text-6' : 'text-3']" />


### PR DESCRIPTION
The black background makes it a lot more obvious, and let's always leave it there rather than requiring a mouseover. Added the translated text as an aria-label for screenreaders/a11y, because "X" isn't super descriptive.

<!-- Thank you for contributing! -->

### Description

This takes a chainsaw to the existing image deletion button in the PublishAttachement component, but.. It's currently really hard to find/see, as described in #1067 and #1283.  It also makes it stylishly consistent w/ the Edit button.

This fixes #1067. Tested on both my laptop (firefox 102) and my phone (android 11).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
