### PR TITLE
feat(search): select first result on enter press

### DIFF
--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -37,17 +37,19 @@ const shift = (delta: number) => index.value = (index.value + delta % results.va
 
 const activate = () => {
   const currentIndex = index.value
-  index.value = -1
 
   if (query.value.length === 0)
     return
 
-  (document.activeElement as HTMLElement).blur()
-
-  // Disable until search page is implemented
-  if (currentIndex === -1)
+  // Disable redirection until search page is implemented
+  if (currentIndex === -1) {
+    index.value = 0
     // router.push(`/search?q=${query.value}`)
     return
+  }
+
+  (document.activeElement as HTMLElement).blur()
+  index.value = -1
 
   router.push(results.value[currentIndex].to)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Select the first search result when <kbd>Enter</kbd> is pressed, instead of closing the search results.

This is especially useful on mobile devices, since browsers (at least Firefox on Android) only emit text events when a non-letter key is pressed. Actually, using the <kbd>Enter</kbd> key will close the search results instead of performing the search.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
