### PR TITLE
feat: inline some mentions to reduce spacing

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -469,6 +469,7 @@ function transformCollapseMentions(status?: mastodon.v1.Status, inReplyToStatus?
       return node
     const mentions: (Node | undefined)[] = []
     const children = node.children as Node[]
+    let trimContentStart: (() => void) | undefined
     for (const child of children) {
       // mention
       if (isMention(child)) {
@@ -480,8 +481,11 @@ function transformCollapseMentions(status?: mastodon.v1.Status, inReplyToStatus?
       }
       // other content, stop collapsing
       else {
-        if (child.type === TEXT_NODE)
-          child.value = child.value.trimStart()
+        if (child.type === TEXT_NODE) {
+          trimContentStart = () => {
+            child.value = child.value.trimStart()
+          }
+        }
         // remove <br> after mention
         if (child.name === 'br')
           mentions.push(undefined)
@@ -495,6 +499,7 @@ function transformCollapseMentions(status?: mastodon.v1.Status, inReplyToStatus?
     let mentionsCount = 0
     let contextualMentionsCount = 0
     let removeNextSpacing = false
+
     const contextualMentions = mentions.filter((mention) => {
       if (!mention)
         return false
@@ -508,24 +513,30 @@ function transformCollapseMentions(status?: mastodon.v1.Status, inReplyToStatus?
         mentionsCount++
         if (inReplyToStatus) {
           const mentionHandle = getMentionHandle(mention)
-          if (inReplyToStatus.account.acct === mentionHandle || inReplyToStatus.mentions.some(m => m.acct === mentionHandle))
+          if (inReplyToStatus.account.acct === mentionHandle || inReplyToStatus.mentions.some(m => m.acct === mentionHandle)) {
+            removeNextSpacing = true
             return false
+          }
         }
         contextualMentionsCount++
       }
       return true
-    })
+    }) as Node[]
 
     // We have a special case for single mentions that are part of a reply.
     // We already have the replying to badge in this case or the status is connected to the previous one.
     // This is needed because the status doesn't included the in Reply to handle, only the account id.
     // But this covers the majority of cases.
     const showMentions = !(contextualMentionsCount === 0 || (mentionsCount === 1 && status?.inReplyToAccountId))
+    const grouped = contextualMentionsCount > 2
+    if (grouped)
+      trimContentStart?.()
 
     const contextualChildren = children.slice(mentions.length)
+    const mentionNodes = showMentions ? (grouped ? [h('mention-group', null, ...contextualMentions)] : contextualMentions) : []
     return {
       ...node,
-      children: showMentions ? [h('mention-group', null, ...contextualMentions), ...contextualChildren] : contextualChildren,
+      children: [...mentionNodes, ...contextualChildren],
     }
   }
 }

--- a/tests/__snapshots__/html-parse.test.ts.snap
+++ b/tests/__snapshots__/html-parse.test.ts.snap
@@ -92,25 +92,6 @@ exports[`html-parse > empty > html 1`] = `""`;
 
 exports[`html-parse > empty > text 1`] = `""`;
 
-exports[`html-parse > hide mentions in context > html 1`] = `
-"<p>
-  <mention-group
-    ><span class=\\"h-card\\"
-      ><a
-        href=\\"/@haoqun@webtoo.ls\\"
-        class=\\"u-url mention\\"
-        rel=\\"nofollow noopener noreferrer\\"
-        target=\\"_blank\\"
-        >@<span>haoqun</span></a
-      ></span
-    ></mention-group
-  >Great to see this happening
-</p>
-"
-`;
-
-exports[`html-parse > hide mentions in context > text 1`] = `"@haoqunGreat to see this happening"`;
-
 exports[`html-parse > html entities > html 1`] = `
 "<p>Hello &lt;World /&gt;.</p>
 "
@@ -161,50 +142,3 @@ exports[`html-parse > link + mention > html 1`] = `
 `;
 
 exports[`html-parse > link + mention > text 1`] = `"Happy 🤗 we’re now using @vitest (migrated from chai+mocha) https://github.com/ayoayco/astro-reactive-library/pull/203"`;
-
-exports[`html-parse > mentions without context > html 1`] = `
-"<p>
-  <mention-group
-    ><span class=\\"h-card\\"
-      ><a
-        href=\\"/@haoqun@webtoo.ls\\"
-        class=\\"u-url mention\\"
-        rel=\\"nofollow noopener noreferrer\\"
-        target=\\"_blank\\"
-        >@<span>haoqun</span></a
-      ></span
-    ></mention-group
-  >Great to see this happening
-</p>
-"
-`;
-
-exports[`html-parse > mentions without context > text 1`] = `"@haoqunGreat to see this happening"`;
-
-exports[`html-parse > show mentions in context > html 1`] = `
-"<p>
-  <mention-group
-    ><span class=\\"h-card\\"
-      ><a
-        href=\\"/@haoqun@webtoo.ls\\"
-        class=\\"u-url mention\\"
-        rel=\\"nofollow noopener noreferrer\\"
-        target=\\"_blank\\"
-        >@<span>haoqun</span></a
-      ></span
-    >
-    <span class=\\"h-card\\"
-      ><a
-        href=\\"/@antfu@webtoo.ls\\"
-        class=\\"u-url mention\\"
-        rel=\\"nofollow noopener noreferrer\\"
-        target=\\"_blank\\"
-        >@<span>antfu</span></a
-      ></span
-    ></mention-group
-  >Great to see this happening
-</p>
-"
-`;
-
-exports[`html-parse > show mentions in context > text 1`] = `"@haoqun @antfuGreat to see this happening"`;

--- a/tests/content-rich.test.ts
+++ b/tests/content-rich.test.ts
@@ -91,21 +91,21 @@ describe('content-rich', () => {
     })
     expect(formatted).toMatchInlineSnapshot(`
       "<p>
-        <mention-group
-          ><span class=\\"h-card\\"
-            ><a
-              class=\\"u-url mention\\"
-              rel=\\"nofollow noopener noreferrer\\"
-              to=\\"/m.webtoo.ls/@elk\\"
-            ></a
-          ></span>
-          <span class=\\"h-card\\"
-            ><a
-              class=\\"u-url mention\\"
-              rel=\\"nofollow noopener noreferrer\\"
-              to=\\"/m.webtoo.ls/@elk\\"
-            ></a></span></mention-group
-        >content
+        <span class=\\"h-card\\"
+          ><a
+            class=\\"u-url mention\\"
+            rel=\\"nofollow noopener noreferrer\\"
+            to=\\"/m.webtoo.ls/@elk\\"
+          ></a
+        ></span>
+        <span class=\\"h-card\\"
+          ><a
+            class=\\"u-url mention\\"
+            rel=\\"nofollow noopener noreferrer\\"
+            to=\\"/m.webtoo.ls/@elk\\"
+          ></a
+        ></span>
+        content
         <span class=\\"h-card\\"
           ><a
             class=\\"u-url mention\\"
@@ -151,19 +151,53 @@ describe('content-rich', () => {
     `)
   })
 
-  it('shows some collapsed mentions', async () => {
+  it('shows some collapsed mentions inline', async () => {
     const { formatted } = await render('<p><span class="h-card"><a href="https://m.webtoo.ls/@elk" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>elk</span></a></span> <span class="h-card"><a href="https://m.webtoo.ls/@antfu" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>antfu</span></a></span> content</p>', {
       collapseMentionLink: true,
       inReplyToStatus: { account: { acct: 'elk@webtoo.ls' }, mentions: [] as mastodon.v1.StatusMention[] } as mastodon.v1.Status,
     })
     expect(formatted).toMatchInlineSnapshot(`
       "<p>
-        <mention-group>
-          <span class=\\"h-card\\"
+        <span class=\\"h-card\\"
+          ><a
+            class=\\"u-url mention\\"
+            rel=\\"nofollow noopener noreferrer\\"
+            to=\\"/m.webtoo.ls/@antfu\\"
+          ></a
+        ></span>
+        content
+      </p>
+      "
+    `)
+  })
+
+  it('shows some collapsed mentions grouped', async () => {
+    const { formatted } = await render('<p><span class="h-card"><a href="https://m.webtoo.ls/@elk" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>elk</span></a></span> <span class="h-card"><a href="https://m.webtoo.ls/@antfu" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>antfu</span></a></span> <span class="h-card"><a href="https://m.webtoo.ls/@patak" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>patak</span></a></span> <span class="h-card"><a href="https://m.webtoo.ls/@sxzz" class="u-url mention" rel="nofollow noopener noreferrer" target="_blank">@<span>sxzz</span></a></span>content</p>', {
+      collapseMentionLink: true,
+      inReplyToStatus: { account: { acct: 'elk@webtoo.ls' }, mentions: [] as mastodon.v1.StatusMention[] } as mastodon.v1.Status,
+    })
+    expect(formatted).toMatchInlineSnapshot(`
+      "<p>
+        <mention-group
+          ><span class=\\"h-card\\"
             ><a
               class=\\"u-url mention\\"
               rel=\\"nofollow noopener noreferrer\\"
               to=\\"/m.webtoo.ls/@antfu\\"
+            ></a
+          ></span>
+          <span class=\\"h-card\\"
+            ><a
+              class=\\"u-url mention\\"
+              rel=\\"nofollow noopener noreferrer\\"
+              to=\\"/m.webtoo.ls/@patak\\"
+            ></a
+          ></span>
+          <span class=\\"h-card\\"
+            ><a
+              class=\\"u-url mention\\"
+              rel=\\"nofollow noopener noreferrer\\"
+              to=\\"/m.webtoo.ls/@sxzz\\"
             ></a></span></mention-group
         >content
       </p>


### PR DESCRIPTION
### Description

After https://github.com/elk-zone/elk/pull/1293 (and https://github.com/elk-zone/elk/commit/5785047856e10861a1e10d614b18c1cb79591002), if you add a new mention in a conversation, a `mention-group` will be created only with it as the others are removed from the context. This could break the context, especially now that we edit with the grouped mentions so people may start using the initial handle as part of the text. But the main issue to me is that a `mention-group` that only has one or two handles ends up occupying more space extracted than inlined.

This PR lets mentions be inlined when only 1 or 2 remain to be shown and creates a `mention-group` when there are 3 or more.

Elk 0.5.0
![image](https://user-images.githubusercontent.com/583075/213318479-a716b8a2-ad63-4334-9311-4932052b183b.png)

Elk before this PR
![image](https://user-images.githubusercontent.com/583075/213318519-7984d0a5-4937-42f6-aba5-b5f456f1ee9d.png)

After this PR
<img width="606" alt="image" src="https://user-images.githubusercontent.com/583075/213318903-f8eabb1a-6c38-4e50-8cb0-de3e0a3f39dc.png">