### PR TITLE
feat(i18n): allow "Version" string on about page to localize

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -280,7 +280,8 @@
       "sponsors": "Sponsors",
       "sponsors_body_1": "Elk is made possible thanks the generous sponsoring and help of:",
       "sponsors_body_2": "And all the companies and individuals sponsoring Elk Team and the members.",
-      "sponsors_body_3": "If you're enjoying the app, consider sponsoring us:"
+      "sponsors_body_3": "If you're enjoying the app, consider sponsoring us:",
+      "version": "Version"
     },
     "account_settings": {
       "description": "Edit your account settings in Mastodon UI",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -244,7 +244,8 @@
       "sponsors": "スポンサー",
       "sponsors_body_1": "Elkは以下の寛大なスポンサー",
       "sponsors_body_2": "そして、Elkのチームとメンバーを支援してくれているすべての企業と個人のおかげで実現しました。",
-      "sponsors_body_3": "もしアプリを楽しんでくれているなら、サポートすることを考えてみてください。"
+      "sponsors_body_3": "もしアプリを楽しんでくれているなら、サポートすることを考えてみてください。",
+      "version": "バージョン"
     },
     "account_settings": {
       "description": "Mastodon UIでアカウントの設定を編集します",

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -33,7 +33,7 @@ const handleShowCommit = () => {
 
     <template v-if="isHydrated">
       <SettingsItem
-        text="Version"
+        :text="$t('settings.about.version')"
         :to="showCommit ? `https://github.com/elk-zone/elk/commit/${buildInfo.commit}` : undefined"
         external target="_blank"
         @click="handleShowCommit"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR makes the string "Version" on the About page to be localizable.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
At least in Japanese, translating the word "Version" is quite natural so I'd like to translate it too.

<img width="320" alt="Screenshot 2023-01-19 at 20 19 01" src="https://user-images.githubusercontent.com/1425259/213431156-186c788a-6576-41e1-bf6e-f6c952abfe89.png">


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related snapshots or videos.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
