### PR TITLE
feat: add 'copy original link to this post' menu item

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -42,6 +42,12 @@ const copyLink = async (status: mastodon.v1.Status) => {
     await clipboard.copy(url)
 }
 
+const copyOriginalLink = async (status: mastodon.v1.Status) => {
+  const url = status.url
+  if (url)
+    await clipboard.copy(url)
+}
+
 const { share, isSupported: isShareSupported } = useShare()
 const shareLink = async (status: mastodon.v1.Status) => {
   const url = getPermalinkUrl(status)
@@ -167,6 +173,13 @@ const showFavoritedAndBoostedBy = () => {
           icon="i-ri:link"
           :command="command"
           @click="copyLink(status)"
+        />
+
+        <CommonDropdownItem
+          :text="$t('menu.copy_original_link_to_post')"
+          icon="i-ri:links-fill"
+          :command="command"
+          @click="copyOriginalLink(status)"
         />
 
         <CommonDropdownItem

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -117,6 +117,7 @@
     "block_account": "Block {0}",
     "block_domain": "Block domain {0}",
     "copy_link_to_post": "Copy link to this post",
+    "copy_original_link_to_post": "Copy original link to this post",
     "delete": "Delete",
     "delete_and_redraft": "Delete & re-draft",
     "direct_message_account": "Direct message {0}",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -172,6 +172,7 @@
     "block_account": "Block {0}",
     "block_domain": "Block domain {0}",
     "copy_link_to_post": "Copy link to this post",
+    "copy_original_link_to_post": "Copy original link to this post",
     "delete": "Delete",
     "delete_and_redraft": "Delete & re-draft",
     "direct_message_account": "Direct message {0}",


### PR DESCRIPTION
### Description

This PR adds a new context menu item 'Copy original link to post'. Selecting this menu will copy the original URL to the clipboard, aka without the elk.zone prefix

Fixes #1064

### Additional context
See #1064 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/elk-zone/elk/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide related snapshots or videos.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
