### PR TITLE
feat: normal text color for nav logo

### DIFF
--- a/components/nav/NavLogo.vue
+++ b/components/nav/NavLogo.vue
@@ -29,9 +29,9 @@
 
 <style scoped>
 svg path.wood {
-    fill: var(--c-dark-primary-light);
+    fill: var(--c-text-secondary);
 }
 svg path.body {
-    fill: var(--c-primary);
+    fill: var(--c-text-base);
 }
 </style>

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -8,7 +8,6 @@ onMounted(() => {
 router.afterEach(() => {
   back.value = router.options.history.state.back
 })
-const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 </script>
 
 <template>

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -8,6 +8,7 @@ onMounted(() => {
 router.afterEach(() => {
   back.value = router.options.history.state.back
 })
+const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 </script>
 
 <template>
@@ -24,7 +25,7 @@ router.afterEach(() => {
     >
       <NavLogo shrink-0 aspect="1/1" sm:h-8 xl:h-10 class="rtl-flip" />
       <div hidden xl:block>
-        {{ $t('app_name') }} <sup text-sm italic text-secondary mt-1>{{ env === 'release' ? 'alpha' : env }}</sup>
+        {{ env === 'release' ? $t('app_name') : capitalized(env) }}
       </div>
     </NuxtLink>
     <div

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -25,7 +25,7 @@ const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
     >
       <NavLogo shrink-0 aspect="1/1" sm:h-8 xl:h-10 class="rtl-flip" />
       <div hidden xl:block>
-        {{ env === 'release' ? $t('app_name') : capitalized(env) }}
+        {{ $t('app_name') }} <sup text-sm italic text-secondary mt-1>{{ env === 'release' ? 'alpha' : env }}</sup>
       </div>
     </NuxtLink>
     <div


### PR DESCRIPTION
### Description

See @antfu's comment here https://github.com/elk-zone/elk/pull/1316#issuecomment-1397079724, it is now a bit confusing to know in what env we are.

This PR tests the idea of using normal color for the nav logo (same as many other apps, like GitHub, Twitter, etc). The brand isn't content for the user, and a big primary color blob in the corner is a bit distracting in my opinion.

The PR also switches to directly change `Elk` by `Dev` or `Main` instead of the superinduce so the layout doesn't change much.

![image](https://user-images.githubusercontent.com/583075/213480593-39c21403-3b74-4d18-b4c9-6a7618511ae6.png)

![image](https://user-images.githubusercontent.com/583075/213480626-82b1d624-dc28-4c68-a1ed-b1b9d061b5e4.png)

Dev:

![image](https://user-images.githubusercontent.com/583075/213480659-cac9afc1-9ead-42f7-850a-9a8c312a3ffe.png)

