### PR TITLE
fix: disable side nav item tooltip on small screen

### DIFF
--- a/components/nav/NavSideItem.vue
+++ b/components/nav/NavSideItem.vue
@@ -53,7 +53,7 @@ const noUserVisual = computed(() => isHydrated.value && props.userOnly && !curre
     :tabindex="noUserDisable ? -1 : null"
     @click="$scrollToTop"
   >
-    <CommonTooltip :disabled="!isMediumScreen" :content="text" placement="right">
+    <CommonTooltip :disabled="!isMediumOrLargeScreen" :content="text" placement="right">
       <div
         flex items-center gap4
         w-fit rounded-3

--- a/composables/screen.ts
+++ b/composables/screen.ts
@@ -4,3 +4,4 @@ export const breakpoints = useBreakpoints(breakpointsTailwind)
 
 export const isSmallScreen = breakpoints.smallerOrEqual('md')
 export const isMediumScreen = breakpoints.smallerOrEqual('lg')
+export const isMediumOrLargeScreen = breakpoints.between('sm', 'xl')


### PR DESCRIPTION
### Description
This PR aims to keep tooltip vs shown text functionality on SideNavItem consistent. If the text is hidden, show the tooltip (and vice versa).

- Fix #1320 and disable side nav item tooltips on mobile (see the issue for video of the bug in action)
- Enable the tooltip when on a `lg` screen, matching the show/hide functionality on the item's text content

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Translations update
- [ ] Other
