### PR TITLE
fix: correct federated timeline title icon

### DIFF
--- a/pages/[[server]]/public/index.vue
+++ b/pages/[[server]]/public/index.vue
@@ -12,7 +12,7 @@ useHeadFixed({
   <MainContent>
     <template #title>
       <NuxtLink to="/public" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:group-2-line />
+        <div i-ri:earth-line />
         <span>{{ t('title.federated_timeline') }}</span>
       </NuxtLink>
     </template>


### PR DESCRIPTION
Fix the wrong icon used in Federated Timeline title bar. It should be the same `earth` icon as in side bar, not the `group` icon used by Local Timeline.

<img src=https://user-images.githubusercontent.com/1430856/213636546-bafb5d8b-a7c9-4350-8d4e-446140041b7c.png width=250>
