### PR TITLE
feat(native): add pwa to Tauri

### DIFF
--- a/composables/setups.ts
+++ b/composables/setups.ts
@@ -11,6 +11,8 @@ export function setupPageHeader() {
     return acc
   }, {} as Record<string, Directions>)
 
+  const publicRuntimeConfig = useRuntimeConfig().public
+
   useHeadFixed({
     htmlAttrs: {
       lang: () => locale.value,
@@ -23,12 +25,17 @@ export function setupPageHeader() {
         titleTemplate += ` (${buildInfo.env})`
       return titleTemplate
     },
-    link: process.client && useRuntimeConfig().public.pwaEnabled
+    link: process.client && publicRuntimeConfig.pwaEnabled && !publicRuntimeConfig.tauriPlatform
       ? () => [{
           key: 'webmanifest',
           rel: 'manifest',
           href: `/manifest-${locale.value}${colorMode.value === 'dark' ? '-dark' : ''}.webmanifest`,
         }]
-      : [],
+      : process.client && publicRuntimeConfig.pwaEnabled && publicRuntimeConfig.tauriPlatform
+        ? () => [{
+            rel: 'manifest',
+            href: '/manifest.webmanifest',
+          }]
+        : [],
   })
 }

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -37,6 +37,34 @@ export const createI18n = async (): Promise<LocalizedWebManifest> => {
 
   const defaultManifest: Required<WebManifestEntry> = pwa.webmanifest[env]
 
+  if (process.env.TAURI_PLATFORM) {
+    return {
+      'en-US': {
+        ...defaultManifest,
+        lang: 'en-US',
+        dir: 'ltr',
+        scope: '/',
+        id: '/',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#ffffff',
+        icons: [
+          {
+            src: 'pwa-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: 'pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+        ],
+      },
+    }
+  }
+
   const locales: RequiredWebManifestEntry[] = await Promise.all(
     pwaLocales
       .filter(l => l.code !== 'en-US')

--- a/modules/pwa/index.ts
+++ b/modules/pwa/index.ts
@@ -112,11 +112,11 @@ export default defineNuxtModule<VitePWANuxtOptions>({
         next()
       }
       nuxt.hook('vite:serverCreated', (viteServer, { isServer }) => {
-        if (isServer || !tauriPlatform)
+        if (isServer)
           return
 
         viteServer.middlewares.stack.push({ route: webManifest, handle: emptyHandle })
-        if (webmanifests) {
+        if (webmanifests && !tauriPlatform) {
           Object.keys(webmanifests).forEach((wm) => {
             viteServer.middlewares.stack.push({
               route: `${nuxt.options.app.baseURL}manifest-${wm}.webmanifest`,
@@ -141,6 +141,7 @@ export default defineNuxtModule<VitePWANuxtOptions>({
     }
     else {
       nuxt.hook('nitro:config', async (nitroConfig) => {
+        // /manifest.webmanifest added on nuxt config file
         if (!tauriPlatform)
           return
 

--- a/modules/tauri/index.ts
+++ b/modules/tauri/index.ts
@@ -15,7 +15,6 @@ export default defineNuxtModule({
     if (nuxt.options.dev)
       nuxt.options.ssr = false
 
-    nuxt.options.pwa.disable = true
     nuxt.options.sourcemap.client = false
 
     nuxt.options.alias = {
@@ -44,12 +43,6 @@ export default defineNuxtModule({
     // cleanup files copied from the public folder that we don't need
     nuxt.hook('close', async () => {
       await rm('.output/public/_redirects')
-      await rm('.output/public/apple-touch-icon.png')
-      await rm('.output/public/elk-og.png')
-      await rm('.output/public/favicon.ico')
-      await rm('.output/public/pwa-192x192.png')
-      await rm('.output/public/pwa-512x512.png')
-      await rm('.output/public/robots.txt')
     })
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,6 +92,7 @@ export default defineNuxtConfig({
     public: {
       env: '', // set in build-env module
       buildInfo: {} as BuildInfo, // set in build-env module
+      tauriPlatform: !!process.env.TAURI_PLATFORM,
       pwaEnabled: !isDevelopment || process.env.VITE_DEV_PWA === 'true',
       // We use LibreTranslate(https://github.com/LibreTranslate/LibreTranslate) as our default translation server #76
       translateApi: '',

--- a/plugins/pwa.client.ts
+++ b/plugins/pwa.client.ts
@@ -37,6 +37,9 @@ export default defineNuxtPlugin(() => {
       registrationError.value = true
     },
     onRegisteredSW(swUrl, r) {
+      if (useRuntimeConfig().public.tauriPlatform)
+        return
+
       // should add support in pwa plugin
       if (r?.active?.state === 'activated') {
         swActivated.value = true

--- a/service-worker/tauri-sw.ts
+++ b/service-worker/tauri-sw.ts
@@ -1,0 +1,97 @@
+/// <reference lib="WebWorker" />
+/// <reference types="vite/client" />
+import { clientsClaim } from 'workbox-core'
+import { registerRoute } from 'workbox-routing'
+import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { onNotificationClick, onPush } from './web-push-notifications'
+
+declare let self: ServiceWorkerGlobalScope
+
+self.skipWaiting()
+clientsClaim()
+
+if (import.meta.env.DEV) {
+  // Avoid caching on dev: force always go to the server
+  registerRoute(
+    () => true,
+    new NetworkFirst({
+      cacheName: 'elk-dev',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [-1] }),
+      ],
+    }),
+  )
+}
+
+if (import.meta.env.PROD) {
+  const denyList: RegExp[] = [/^\/api\//, /^\/login\//, /^\/oauth\//, /^\/signin\//, /^\/web-share-target\//]
+  const matchDenyList = (url: URL) => {
+    const pathnameAndSearch = url.pathname + url.search
+    for (const regExp of denyList) {
+      if (regExp.test(pathnameAndSearch))
+        return false
+    }
+
+    return true
+  }
+  // Cache page navigations (html) with a Network First strategy
+  registerRoute(
+    ({ sameOrigin, request, url }) => {
+      return sameOrigin && request.mode === 'navigate' && matchDenyList(url)
+    },
+    new NetworkFirst({
+      cacheName: 'elk-pages',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+      ],
+    }),
+  )
+
+  // Cache CSS, JS, and Web Worker requests with a Stale While Revalidate strategy
+  registerRoute(
+    ({ sameOrigin, request }) =>
+      sameOrigin && (request.destination === 'style'
+            || request.destination === 'manifest'
+            || request.destination === 'script'
+            || request.destination === 'worker'),
+    new StaleWhileRevalidate({
+      cacheName: 'elk-assets',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+      ],
+    }),
+  )
+
+  // include shiki cache
+  registerRoute(
+    ({ sameOrigin, url }) =>
+      sameOrigin && url.pathname.startsWith('/shiki/'),
+    new StaleWhileRevalidate({
+      cacheName: 'elk-shiki',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+        // 365 days max
+        new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 365 }),
+      ],
+    }),
+  )
+
+  // Cache images with a Cache First strategy
+  registerRoute(
+    ({ sameOrigin, request }) =>
+      sameOrigin && request.destination === 'image',
+    new CacheFirst({
+      cacheName: 'elk-images',
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
+        // 150 max, 30 days max: purge on quota error
+        new ExpirationPlugin({ purgeOnQuotaError: true, maxEntries: 150, maxAgeSeconds: 60 * 60 * 24 * 30 }),
+      ],
+    }),
+  )
+}
+
+self.addEventListener('push', onPush)
+self.addEventListener('notificationclick', onNotificationClick)


### PR DESCRIPTION
Since Tauri is using custom protocol scheme (`tauri://`), native WebView will handle it as non secured, and so, we cannot register the service worker (at least `macOS`): check discord thread https://discord.com/channels/1044887051155292200/1065996405493202944/1066040488005746739