### PR TITLE
feat(native): Improved layout in elk-native

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -5,6 +5,9 @@ defineProps<{
   /** Show the back button on both small and big screens */
   back?: boolean
 }>()
+
+const route = useRoute()
+const wideLayout = computed(() => route.meta.wideLayout ?? false)
 </script>
 
 <template>
@@ -15,7 +18,7 @@ defineProps<{
       border="b base" bg="[rgba(var(--rbg-bg-base),0.7)]"
     >
       <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region>
-        <div flex gap-3 items-center overflow-hidden py2>
+        <div flex gap-3 items-center overflow-hidden py2 class="native-mac:pl-14 native-mac:sm:pl-0">
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
             :aria-label="$t('nav.back')"
@@ -38,6 +41,8 @@ defineProps<{
       <slot name="header" />
     </div>
     <div :class="{ 'xl:block': $route.name !== 'tag' }" hidden h-6 />
-    <slot />
+    <div :class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'" m-auto>
+      <slot />
+    </div>
   </div>
 </template>

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -16,7 +16,7 @@ const wideLayout = computed(() => route.meta.wideLayout ?? false)
       sticky top-0 z10 backdrop-blur
       pt="[env(safe-area-inset-top,0)]"
       border="b base" bg="[rgba(var(--rbg-bg-base),0.7)]"
-      class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(100%+(100vw-1200px)/2))]"
+      class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(135%+(100vw-1200px)/2)]"
     >
       <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region native:xl:flex>
         <div flex gap-3 items-center overflow-hidden py2 class="native-mac:pl-14 native-mac:sm:pl-0">

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -16,8 +16,9 @@ const wideLayout = computed(() => route.meta.wideLayout ?? false)
       sticky top-0 z10 backdrop-blur
       pt="[env(safe-area-inset-top,0)]"
       border="b base" bg="[rgba(var(--rbg-bg-base),0.7)]"
+      class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(100%+(100vw-1200px)/2))]"
     >
-      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region>
+      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region native:xl:flex>
         <div flex gap-3 items-center overflow-hidden py2 class="native-mac:pl-14 native-mac:sm:pl-0">
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -18,7 +18,7 @@ const wideLayout = computed(() => route.meta.wideLayout ?? false)
       border="b base" bg="[rgba(var(--rbg-bg-base),0.7)]"
       class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(135%+(100vw-1200px)/2)]"
     >
-      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region native:xl:flex>
+      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" data-tauri-drag-region class="native:xl:flex">
         <div flex gap-3 items-center overflow-hidden py2 class="native-mac:pl-14 native-mac:sm:pl-0">
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,11 +16,11 @@ const isGrayscale = usePreferences('grayscaleMode')
 
 <template>
   <div h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''">
-    <main flex w-full mxa lg:max-w-80rem class="native:grid native:grid-cols-[auto_1fr]">
+    <main flex w-full mxa lg:max-w-80rem class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_2fr_1fr]">
       <aside class="hidden native:w-auto sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
         <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>
           <slot name="left">
-            <div flex="~ col" overflow-y-auto justify-between h-full max-w-full mt-5>
+            <div flex="~ col" overflow-y-auto justify-between h-full max-w-full pt-5 native:pt-7>
               <NavTitle />
               <NavSide command />
               <div flex-auto />
@@ -50,7 +50,7 @@ const isGrayscale = usePreferences('grayscaleMode')
           </slot>
         </div>
       </aside>
-      <div w-full min-h-screen :class="isHydrated && wideLayout ? 'xl:w-full sm:w-600px' : 'sm:w-600px md:shrink-0'" border-base>
+      <div w-full min-h-screen border-base>
         <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
           <slot />
         </div>
@@ -59,7 +59,7 @@ const isGrayscale = usePreferences('grayscaleMode')
           <NavBottom v-if="isHydrated" sm:hidden />
         </div>
       </div>
-      <aside v-if="isHydrated && !wideLayout" class="hidden sm:none lg:block w-1/4 zen-hide">
+      <aside v-if="isHydrated && !wideLayout" class="hidden sm:none lg:block w-1/4 zen-hide native:lg:w-full">
         <div sticky top-0 h-screen flex="~ col" gap-2 py3 ms-2>
           <slot name="right">
             <div flex-auto />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,7 +16,7 @@ const isGrayscale = usePreferences('grayscaleMode')
 
 <template>
   <div h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''">
-    <main flex w-full mxa lg:max-w-80rem class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_2fr_1fr]">
+    <main flex w-full mxa lg:max-w-80rem class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_minmax(600px,2fr)_1fr]">
       <aside class="hidden native:w-auto sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
         <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>
           <slot name="left">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,8 +16,8 @@ const isGrayscale = usePreferences('grayscaleMode')
 
 <template>
   <div h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''">
-    <main flex w-full mxa lg:max-w-80rem>
-      <aside class="hidden sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
+    <main flex w-full mxa lg:max-w-80rem class="native:grid native:grid-cols-[auto_1fr]">
+      <aside class="hidden native:w-auto sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
         <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>
           <slot name="left">
             <div flex="~ col" overflow-y-auto justify-between h-full max-w-full mt-5>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -20,7 +20,7 @@ const isGrayscale = usePreferences('grayscaleMode')
       <aside class="hidden native:w-auto sm:flex w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 justify-end xl:me-4 zen-hide" relative>
         <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>
           <slot name="left">
-            <div flex="~ col" overflow-y-auto justify-between h-full max-w-full pt-5 native:pt-7>
+            <div flex="~ col" overflow-y-auto justify-between h-full max-w-full pt-5 native:pt-7 overflow-x-hidden>
               <NavTitle />
               <NavSide command />
               <div flex-auto />

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,9 +47,10 @@ export default defineNuxtConfig({
     'floating-vue/dist/style.css',
     '~/styles/default-theme.css',
     '~/styles/vars.css',
+    '~/styles/global.css',
     ...process.env.TAURI_PLATFORM === 'macos'
-      ? ['~/styles/global.css']
-      : ['~/styles/global.css', '~/styles/scrollbars.css'],
+      ? []
+      : ['~/styles/scrollbars.css'],
     '~/styles/tiptap.css',
     '~/styles/dropdown.css',
   ],

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,7 +47,9 @@ export default defineNuxtConfig({
     'floating-vue/dist/style.css',
     '~/styles/default-theme.css',
     '~/styles/vars.css',
-    '~/styles/global.css',
+    ...process.env.TAURI_PLATFORM === 'macos'
+      ? ['~/styles/global.css']
+      : ['~/styles/global.css', '~/styles/scrollbars.css'],
     '~/styles/tiptap.css',
     '~/styles/dropdown.css',
   ],

--- a/styles/global.css
+++ b/styles/global.css
@@ -12,32 +12,6 @@ html {
   src: url(/fonts/homemade-apple-v18.ttf) format('truetype');
 }
 
-* {
-  scrollbar-color: #8885 var(--c-border);
-}
-
-::-webkit-scrollbar {
-  width: 10px;
-}
-
-::-webkit-scrollbar:horizontal {
-  height: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--c-border);
-  border-radius: 1px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #8885;
-  border-radius: 1px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #8886;
-}
-
 ::-moz-selection {
   background: var(--c-bg-selection);
 }

--- a/styles/scrollbars.css
+++ b/styles/scrollbars.css
@@ -1,0 +1,25 @@
+* {
+  scrollbar-color: #8885 var(--c-border);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar:horizontal {
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--c-border);
+  border-radius: 1px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #8885;
+  border-radius: 1px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #8886;
+}

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -100,6 +100,18 @@ export default defineConfig({
       },
     },
   },
+  ...process.env.TAURI_PLATFORM && {
+    variants: [
+      (matcher) => {
+        if (!matcher.startsWith('native:'))
+          return matcher
+        return {
+          matcher: matcher.slice(7),
+          layer: 'native',
+        }
+      },
+    ],
+  },
   rules: [
     // scrollbar-hide
     [/^scrollbar-hide$/, (_, { constructCSS }) => {

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -100,18 +100,24 @@ export default defineConfig({
       },
     },
   },
-  ...process.env.TAURI_PLATFORM && {
-    variants: [
-      (matcher) => {
-        if (!matcher.startsWith('native:'))
-          return matcher
-        return {
-          matcher: matcher.slice(7),
-          layer: 'native',
-        }
-      },
-    ],
-  },
+  variants: [
+    (matcher) => {
+      if (!process.env.TAURI_PLATFORM || !matcher.startsWith('native:'))
+        return matcher
+      return {
+        matcher: matcher.slice(7),
+        layer: 'native',
+      }
+    },
+    (matcher) => {
+      if (process.env.TAURI_PLATFORM !== 'macos' || !matcher.startsWith('native-mac:'))
+        return matcher
+      return {
+        matcher: matcher.slice(11),
+        layer: 'native-mac',
+      }
+    },
+  ],
   rules: [
     // scrollbar-hide
     [/^scrollbar-hide$/, (_, { constructCSS }) => {


### PR DESCRIPTION
- Two new variants have been added to UnoCSS: `native:` and `native-mac:`. Styles for these variants will only be generated if the `TAURI_PLATFORM` variable is properly set during the build process.
- The application now respects the user's system preferences for the style and behavior of the style bar on the Mac
- The title bar is always visible in the app, which should fix a problem when the window was not draggable on larger screens. elk-zone/elk-native#43
- This is not the final iteration, in the future, I plan to move the navigation in narrow windows to the left side.

Here are before and after screenshots:
--
650px:
![before-650](https://user-images.githubusercontent.com/244174/213860841-798c6e48-ada7-4029-85cc-2585428b70f3.png)
![after-650](https://user-images.githubusercontent.com/244174/213860843-b403a694-f931-4f75-b224-551db7940b7e.png)
1000px:
![before-1000](https://user-images.githubusercontent.com/244174/213860851-c9a1901d-27b4-4928-93dd-2b63f4a42b88.jpeg)
![after-1000](https://user-images.githubusercontent.com/244174/213860890-af9d6768-0173-443e-b92e-b390bb97307d.png)
1200px:
![before-1200](https://user-images.githubusercontent.com/244174/213860900-f95999fe-0656-4491-b18f-95f560be8c79.png)
![after-1200](https://user-images.githubusercontent.com/244174/213860903-e0fdebc4-c63f-4b7e-b51b-e8835d01cb2b.jpeg)
1400px:
![before-1400](https://user-images.githubusercontent.com/244174/213860911-9c068f76-e532-4284-9fd3-5f0fefe3ea27.png)
![after-1400](https://user-images.githubusercontent.com/244174/213860912-a87a63e6-cbf4-4c0c-aafe-8a085ba9975b.jpeg)

closes elk-zone/elk-native#44