### PR TITLE
fix: tag link

### DIFF
--- a/components/tag/TagCard.vue
+++ b/components/tag/TagCard.vue
@@ -7,7 +7,10 @@ const {
   tag: mastodon.v1.Tag
 }>()
 
-const to = $computed(() => new URL(tag.url).pathname)
+const to = $computed(() => {
+  const { hostname, pathname } = new URL(tag.url)
+  return `/${hostname}${pathname}`
+})
 </script>
 
 <template>


### PR DESCRIPTION
When navigating over the hashtags links to the hashtags details page, the instance was not included in the URL
this results in that the follow/unfollow button was not displayed