### PR TITLE
fix: prevent videos from clipping when in fullscreen mode

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -104,6 +104,7 @@ const userSettings = useUserSettings()
         controls
         rounded-lg
         object-cover
+        fullscreen:object-contain
         :width="attachment.meta?.original?.width"
         :height="attachment.meta?.original?.height"
         :style="{

--- a/styles/global.css
+++ b/styles/global.css
@@ -240,9 +240,3 @@ allows controlling them individually
 [data-mode="grayscale"] video:hover {
   filter: grayscale(0);
 }
-
-@media all and (display-mode: fullscreen) {
-  video[object-cover] {
-    object-fit: contain;
-  }
-}

--- a/styles/global.css
+++ b/styles/global.css
@@ -240,3 +240,9 @@ allows controlling them individually
 [data-mode="grayscale"] video:hover {
   filter: grayscale(0);
 }
+
+@media all and (display-mode: fullscreen) {
+  video[object-cover] {
+    object-fit: contain;
+  }
+}

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -9,6 +9,8 @@ import {
   transformerVariantGroup,
 } from 'unocss'
 
+import { variantParentMatcher } from '@unocss/preset-mini/utils'
+
 export default defineConfig({
   shortcuts: [
     {
@@ -119,6 +121,7 @@ export default defineConfig({
         layer: 'native-mac',
       }
     },
+    variantParentMatcher('fullscreen', '@media (display-mode: fullscreen)'),
   ],
   rules: [
     // scrollbar-hide


### PR DESCRIPTION
Hi!

This prevents videos from clipping (display-mode: cover) when in fullscreen.

~~I'm looking for better unocss ways to accomplish this, but I havenoideawhatI'mdoing.jpg so any advice would be appreciated. :) Thank you!~~ Now resolved, thanks @kreha1!

Edit: Worth noting this doesn't affect iOS - it's only a problem on desktop (tested on macOS, should also affect Windows) with chrome/ff/safari.

This is mainly a problem when you try to fullscreen a portrait video on a landscape (aka, regular laptop) screen.