### PR TITLE
fix: Allow viewport zoom

### DIFF
--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -72,7 +72,7 @@ const handleFavouritedBoostedByClose = () => {
     </ModalDialog>
     <ModalDialog
       :model-value="isMediaPreviewOpen"
-      w-full max-w-full h-full max-h-full
+      w-full h-full
       bg-transparent border-0 shadow-none
       @update:model-value="closeMediaPreview"
     >

--- a/components/modal/ModalMediaPreview.vue
+++ b/components/modal/ModalMediaPreview.vue
@@ -37,7 +37,7 @@ onUnmounted(() => locked.value = false)
 </script>
 
 <template>
-  <div relative h-full w-full flex pt-12 w-100vh @click="onClick">
+  <div relative flex pt-12 w-100vh @click="onClick">
     <button
       v-if="hasNext" pointer-events-auto btn-action-icon bg="black/20" :aria-label="$t('action.previous')"
       hover:bg="black/40" dark:bg="white/30" dark-hover:bg="white/20" absolute top="1/2" right-1 z5
@@ -54,7 +54,7 @@ onUnmounted(() => locked.value = false)
     </button>
 
     <div flex flex-row items-center mxa>
-      <div flex="~ col center" max-h-full max-w-full>
+      <div flex="~ col center">
         <ModalMediaPreviewCarousel v-model="index" :media="mediaPreviewList" @close="emit('close')" />
 
         <div bg="black/30" dark:bg="white/10" ms-4 mb-6 mt-4 text-white rounded-full flex="~ center shrink-0" overflow-hidden>

--- a/components/modal/ModalMediaPreviewCarousel.vue
+++ b/components/modal/ModalMediaPreviewCarousel.vue
@@ -64,7 +64,7 @@ const distanceY = computed(() => {
   <div ref="target" flex flex-row max-h-full max-w-full overflow-hidden>
     <div flex :style="{ transform: `translateX(${distanceX}%) translateY(${distanceY}%)`, transition: isSwiping ? 'none' : canAnimate ? 'all 0.5s ease' : 'none' }">
       <div v-for="item in media" :key="item.id" p4 select-none w-full flex-shrink-0 flex flex-col place-items-center>
-        <img max-h-full max-w-full :draggable="false" select-none :src="item.url || item.previewUrl" :alt="item.description || ''">
+        <img :draggable="false" select-none :src="item.url || item.previewUrl" :alt="item.description || ''">
       </div>
     </div>
   </div>

--- a/components/modal/ModalMediaPreviewCarousel.vue
+++ b/components/modal/ModalMediaPreviewCarousel.vue
@@ -61,7 +61,7 @@ const distanceY = computed(() => {
 </script>
 
 <template>
-  <div ref="target" flex flex-row max-h-full max-w-full overflow-hidden>
+  <div ref="target" flex flex-row overflow-hidden>
     <div flex :style="{ transform: `translateX(${distanceX}%) translateY(${distanceY}%)`, transition: isSwiping ? 'none' : canAnimate ? 'all 0.5s ease' : 'none' }">
       <div v-for="item in media" :key="item.id" p4 select-none w-full flex-shrink-0 flex flex-col place-items-center>
         <img :draggable="false" select-none :src="item.url || item.previewUrl" :alt="item.description || ''">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -124,8 +124,10 @@ export default defineNuxtConfig({
   app: {
     keepalive: true,
     head: {
-      // Prevent arbitrary zooming on mobile devices
-      viewport: 'width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover',
+      // For information on viewport, see https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics
+      //  > `maximum-scale`: ...Any value less than 3 fails accessibility...
+      //  > `user-scalable`: ...Setting the value to 0, which is the same as no, is against Web Content Accessibility Guidelines (WCAG)...
+      viewport: 'width=device-width,initial-scale=1,user-scalable=1,viewport-fit=cover',
       bodyAttrs: {
         class: 'overflow-x-hidden',
       },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -127,7 +127,7 @@ export default defineNuxtConfig({
       // For information on viewport, see https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics
       //  > `maximum-scale`: ...Any value less than 3 fails accessibility...
       //  > `user-scalable`: ...Setting the value to 0, which is the same as no, is against Web Content Accessibility Guidelines (WCAG)...
-      viewport: 'width=device-width,initial-scale=1,maximum-scale=10,user-scalable=1,viewport-fit=cover',
+      viewport: 'width=device-width,initial-scale=1',
       bodyAttrs: {
         class: 'overflow-x-hidden',
       },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -127,7 +127,7 @@ export default defineNuxtConfig({
       // For information on viewport, see https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics
       //  > `maximum-scale`: ...Any value less than 3 fails accessibility...
       //  > `user-scalable`: ...Setting the value to 0, which is the same as no, is against Web Content Accessibility Guidelines (WCAG)...
-      viewport: 'width=device-width,initial-scale=1,user-scalable=1,viewport-fit=cover',
+      viewport: 'width=device-width,initial-scale=1,maximum-scale=10,user-scalable=1,viewport-fit=cover',
       bodyAttrs: {
         class: 'overflow-x-hidden',
       },

--- a/styles/global.css
+++ b/styles/global.css
@@ -186,8 +186,7 @@ html {
 }
 
 body {
-  /* Prevent arbitrary zooming on mobile devices */
-  touch-action: pan-x pan-y;
+  touch-action: pan-x pan-y pinch-zoom;
 }
 
 .sparkline--fill {


### PR DESCRIPTION
Currently, users can't scale (pinch zoom) on Elk mobile devices, this means that it's difficult/impossible to read/see some images posted. This PR allows zooming, which is also an accessibility requirement, according to [Mozilla Developer Network docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics):

> `maximum-scale`: ...Any value less than 3 fails accessibility...

> `user-scalable`: ...Setting the value to 0, which is the same as no, is against Web Content Accessibility Guidelines (WCAG)...

This PR changes the `viewport` meta element from:
```
<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover">
```

to
```
<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=1,viewport-fit=cover">
```

(noting that `maximum-scale` has a default and maximum of `10` so this will be the maximum unless it's re-added with a specific value)