### PR TITLE
feat: improve github status preview ui

### DIFF
--- a/components/status/StatusPreviewGitHub.vue
+++ b/components/status/StatusPreviewGitHub.vue
@@ -114,9 +114,9 @@ const meta = $computed(() => {
             <span text-secondary leading-tight>{{ meta.details }}</span>
           </NuxtLink>
         </div>
-        <div>
+        <div shrink-0 w-18 sm:w-30>
           <NuxtLink :href="meta.titleUrl" target="_blank" external>
-            <img w-30 aspect-square width="20" height="20" rounded-2 :src="meta.avatar">
+            <img w-full aspect-square width="112" height="112" rounded-2 :src="meta.avatar">
           </NuxtLink>
         </div>
       </div>


### PR DESCRIPTION
Currently(v0.6.1), the avatar will scale with the content on the left.

![other](https://user-images.githubusercontent.com/39984251/214120031-b6cfb452-d2cc-4456-8c38-00a5766ebe5d.png)

![before](https://user-images.githubusercontent.com/39984251/214118134-e2f93c6d-f20c-4bdb-a719-7acda870ec36.png)

This PR sets the avatar size to a fixed value of `7.5rem`, and `4.5rem` for small sizes.

![after](https://user-images.githubusercontent.com/39984251/214118131-c1d01153-964d-4e72-9211-d4f90184c219.png)

---

Image taken from https://elk.zone/@mas.to/@nuxt@webtoo.ls/109738793310974724