### PR TITLE
feat: improve follows you grouping

### DIFF
--- a/components/notification/NotificationPaginator.vue
+++ b/components/notification/NotificationPaginator.vue
@@ -27,6 +27,10 @@ const groupId = (item: mastodon.v1.Notification): string => {
   return JSON.stringify(id)
 }
 
+function hasHeader(account: mastodon.v1.Account) {
+  return !account.header.endsWith('/original/missing.png')
+}
+
 function groupItems(items: mastodon.v1.Notification[]): NotificationSlot[] {
   const results: NotificationSlot[] = []
 
@@ -44,31 +48,31 @@ function groupItems(items: mastodon.v1.Notification[]): NotificationSlot[] {
     // This normally happens when you transfer an account, if not, show
     // a big profile card for each follow
     if (group[0].type === 'follow') {
-      let groups: mastodon.v1.Notification[] = []
+      // Order group by followers count
+      const processedGroup = [...group]
+      processedGroup.sort((a, b) => {
+        const aHasHeader = hasHeader(a.account)
+        const bHasHeader = hasHeader(b.account)
+        if (bHasHeader && !aHasHeader)
+          return 1
+        if (aHasHeader && !bHasHeader)
+          return -1
+        return b.account.followersCount - a.account.followersCount
+      })
 
-      function newGroup() {
-        if (groups.length > 0) {
-          results.push({
-            id: `grouped-${id++}`,
-            type: 'grouped-follow',
-            items: groups,
-          })
-          groups = []
-        }
+      if (processedGroup.length > 0 && hasHeader(processedGroup[0].account))
+        results.push(processedGroup.shift()!)
+
+      if (processedGroup.length === 1 && hasHeader(processedGroup[0].account))
+        results.push(processedGroup.shift()!)
+
+      if (processedGroup.length > 0) {
+        results.push({
+          id: `grouped-${id++}`,
+          type: 'grouped-follow',
+          items: processedGroup,
+        })
       }
-
-      for (const item of group) {
-        const hasHeader = !item.account.header.endsWith('/original/missing.png')
-        if (hasHeader && (item.account.followersCount > 250 || (group.length === 1 && item.account.followersCount > 25))) {
-          newGroup()
-          results.push(item)
-        }
-        else {
-          groups.push(item)
-        }
-      }
-
-      newGroup()
       return
     }
 


### PR DESCRIPTION
See https://elk.zone/fediverse.zachleat.com/@zachleat/109739539249687601 for context.

We got feedback that using a hard limit using the followers count was a bit awkward. We had already discussed something along these lines before and proposed using percentages relative to the user followers count. I think this wouldn't be ok either.

This PR changes the grouping algorithm to test in it in the wild in the next release.

It now orders the group according to who has a header first (giving priority to folks that did setup their account), and who has more followers second. Then it shows the first one of the group (if it has a header) as a big card, no matter how many followers it has. If only one remains and it has a header, it is also expanded as a big card. If not, the remaining are shown as a group of avatars in a single line.