### PR TITLE
feat: improve set font size user experience

### DIFF
--- a/components/settings/SettingsFontSize.vue
+++ b/components/settings/SettingsFontSize.vue
@@ -1,14 +1,19 @@
 <script lang="ts" setup>
+import { isNumber } from '@vueuse/core'
 import { DEFAULT_FONT_SIZE } from '~/constants'
 import type { FontSize } from '~/composables/settings'
 
 const userSettings = useUserSettings()
 
 const sizes = (new Array(11)).fill(0).map((x, i) => `${10 + i}px`) as FontSize[]
+const selectedIndex = $computed(() => sizes.indexOf(userSettings.value.fontSize))
 
-const setFontSize = (e: Event) => {
-  if (e.target && 'valueAsNumber' in e.target)
-    userSettings.value.fontSize = sizes[e.target.valueAsNumber as number]
+const setFontSize = (eventOrNumber: Event | number) => {
+  if (isNumber(eventOrNumber))
+    userSettings.value.fontSize = sizes[eventOrNumber]
+
+  else if (eventOrNumber.target && 'valueAsNumber' in eventOrNumber.target)
+    userSettings.value.fontSize = sizes[eventOrNumber.target.valueAsNumber as number]
 }
 </script>
 
@@ -29,18 +34,29 @@ const setFontSize = (e: Event) => {
         @change="setFontSize"
       >
       <div flex items-center justify-between absolute w-full pointer-events-none>
-        <div
-          v-for="i in sizes.length" :key="i"
-          h-3 w-3
-          rounded-full bg-secondary-light
+        <CommonTooltip
+          v-for="(size, index) in sizes" :key="size"
           relative
+          cursor-pointer
+          pointer-events-auto
+          :content="`${size}${size === DEFAULT_FONT_SIZE ? `${$t('settings.interface.default')}` : ''}`"
+          :distance="selectedIndex === index ? 10 : 6"
         >
           <div
-            v-if="(sizes.indexOf(userSettings.fontSize)) === i - 1"
-            absolute rounded-full class="-top-1 -left-1"
-            bg-primary h-5 w-5
-          />
-        </div>
+            block
+            relative
+            h-3 w-3
+            rounded-full bg-secondary-light
+            role="button"
+            @click="setFontSize(index)"
+          >
+            <div
+              v-if="selectedIndex === index"
+              absolute rounded-full class="-top-1 -left-1"
+              bg-primary h-5 w-5
+            />
+          </div>
+        </CommonTooltip>
       </div>
     </div>
     <span text-xl text-secondary>Aa</span>

--- a/components/settings/SettingsFontSize.vue
+++ b/components/settings/SettingsFontSize.vue
@@ -25,7 +25,7 @@ const setFontSize = (e: Event) => {
         type="range"
         focus:outline-none
         appearance-none bg-transparent
-        w-full cursor-pointer
+        w-full h-3 cursor-pointer
         @change="setFontSize"
       >
       <div flex items-center justify-between absolute w-full pointer-events-none>


### PR DESCRIPTION
This PR has adjusted two parts:

1. Make set font size clickable block bigger (94b836ecc37a7bb090e0ed7316fea607a9df9b07)
  ![small](https://user-images.githubusercontent.com/39984251/214201719-77451071-0891-400f-8746-4d70192839bf.png)
  ![bigger](https://user-images.githubusercontent.com/39984251/214201982-e3f93967-fd00-42c1-bae5-87215a070e10.png)

2. Add tooltip for every set font size point (839b5b02422c0329c311a9afba78f0dd39d1bdfb)
  ![tooltip](https://user-images.githubusercontent.com/39984251/214241739-74608047-62ef-4055-b003-82e9908fdb5f.png)
