### PR TITLE
feat: allow select a language by keyboard in the setting by prepending English language names

### DIFF
--- a/components/settings/SettingsLanguage.vue
+++ b/components/settings/SettingsLanguage.vue
@@ -1,16 +1,22 @@
 <script lang="ts" setup>
 import type { ComputedRef } from 'vue'
+import ISO6391 from 'iso-639-1'
 import type { LocaleObject } from '#i18n'
 
 const userSettings = useUserSettings()
 
 const { locales } = useI18n() as { locales: ComputedRef<LocaleObject[]> }
+
+// Find English name from language code (e.g. 'ja-JP' -> 'Japanese')
+function getEnglishName(langCode: string): string {
+  return ISO6391.getName(langCode.split('-')[0])
+}
 </script>
 
 <template>
   <select v-model="userSettings.language">
     <option v-for="item in locales" :key="item.code" :value="item.code" :selected="userSettings.language === item.code">
-      {{ item.name }}
+      {{ getEnglishName(item.code) }} - {{ item.name }}
     </option>
   </select>
 </template>


### PR DESCRIPTION
## Problem
Currently, the language selector in the setting doesn't allow us to select a specific item by typing the language name if the name has no alphabet characters. So we have to click the item by mouse or use the arrow keys several times.

## Solution
This PR adds the English name for each language item in the selector so that users can select the specific language by just typing a few first characters of its English word. For example, "Japanese" can be selected by typing only one character `j`. Previously, it required 8 times `↓` keystrokes (open menu + 7 times down).

<img width="681" alt="Screenshot 2023-01-24 at 23 45 11" src="https://user-images.githubusercontent.com/1425259/214328387-f6793ca8-cb40-4878-8f8d-610b1730d013.png">
<img width="321" alt="Screenshot 2023-01-24 at 23 42 42" src="https://user-images.githubusercontent.com/1425259/214328399-1073bce0-4908-49a6-be62-91871390d450.png">
