### PR TITLE
fix: make the user switcher's buttons fill container

### DIFF
--- a/components/user/UserSwitcher.vue
+++ b/components/user/UserSwitcher.vue
@@ -42,6 +42,7 @@ const clickUser = (user: UserLogin) => {
         is="button"
         :text="$t('user.add_existing')"
         icon="i-ri:user-add-line"
+        w-full
         @click="openSigninDialog"
       />
       <CommonDropdownItem
@@ -49,6 +50,7 @@ const clickUser = (user: UserLogin) => {
         v-if="isHydrated && currentUser"
         :text="$t('user.sign_out_account', [getFullHandle(currentUser.account)])"
         icon="i-ri:logout-box-line rtl-flip"
+        w-full
         @click="signout"
       />
     </div>


### PR DESCRIPTION
**Before**
<img width="324" alt="before" src="https://user-images.githubusercontent.com/39984251/214481657-db639a91-5303-42b8-be2d-373ad7985a00.png">

**After**
<img width="324" alt="after" src="https://user-images.githubusercontent.com/39984251/214481661-55724775-84a9-4633-b628-e81eb8101e36.png">
