### PR TITLE
fix(pwa): use 303 redirect in web share target api

### DIFF
--- a/service-worker/share-target.ts
+++ b/service-worker/share-target.ts
@@ -21,7 +21,7 @@ export const onShareTarget = (event: FetchEvent) => {
 }
 
 async function handleSharedTarget(event: FetchEvent) {
-  event.respondWith(Response.redirect('/home?share-target=true'))
+  event.respondWith(Response.redirect('/home?share-target=true', 303))
   await waitForClientToGetReady(event.resultingClientId)
 
   const [client, formData] = await getClientAndFormData(event)


### PR DESCRIPTION
Use [303 response code redirection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303): https://developer.chrome.com/articles/web-share-target/#processing-post-shares suggest using 303