### PR TITLE
fix: show correct account on hover

### DIFF
--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -7,7 +7,9 @@ const props = defineProps<{
   disabled?: boolean
 }>()
 
-const account = props.account || (props.handle ? useAccountByHandle(props.handle!) : undefined)
+const account = computedAsync(async () => (
+  props.account || (props.handle ? await fetchAccountByHandle(props.handle!) : null)
+), null)
 const userSettings = useUserSettings()
 
 defineOptions({


### PR DESCRIPTION
Fix #1363
Fix #1453

I know this issue has not been triaged but I ran into the same problem so decided to just try fixing it.