### PR TITLE
chore(i18n): update i18n module and `en-US` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ We are using [vue-i18n](https://vue-i18n.intlify.dev/) via [nuxt-i18n](https://i
       - Add all country variants in [country variants object](./config/i18n.ts#L12)
       - Add all country variants files with empty `messages` object: `{}`
       - Translate the strings in the generic language file
-      - Later, when anyone wants to add the corresponding translations for the country variant, you can override all entries in the corresponding file: check `en` (english variants), and override the entries in all country files, if you omit them, `i18n` module will use the language entry. You will need also copy from base file to the rest of country variants those messages not being shared (the Elk team is working on resolving this, assuming it can be resolved).
+      - Later, when anyone wants to add the corresponding translations for the country variant, just override any entry in the corresponding file: you can see an example with `en` variants.
    - If the generic language already exists:
       - If the translation doesn't differ from the generic language, then add the corresponding translations in the corresponding file
       - If the translation differs from the generic language, then add the corresponding translations in the corresponding file and remove it from the country variants entry

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,18 +1,1 @@
-{
-  "account": {
-    "favourites": "Favorites"
-  },
-  "action": {
-    "favourite": "Favorite",
-    "favourited": "Favorited"
-  },
-  "nav": {
-    "favourites": "Favorites"
-  },
-  "notification": {
-    "favourited_post": "favorited your post"
-  },
-  "user": {
-    "sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts, or interact from your account on a different server."
-  }
-}
+{}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@iconify-json/ri": "^1.1.4",
     "@iconify-json/twemoji": "^1.1.10",
     "@nuxtjs/color-mode": "^3.2.0",
-    "@nuxtjs/i18n": "8.0.0-beta.8",
+    "@nuxtjs/i18n": "8.0.0-beta.9",
     "@pinia/nuxt": "^0.4.6",
     "@types/chroma-js": "^2.1.4",
     "@types/file-saver": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
       '@iconify-json/twemoji': ^1.1.10
       '@iconify/utils': ^2.0.12
       '@nuxtjs/color-mode': ^3.2.0
-      '@nuxtjs/i18n': 8.0.0-beta.8
+      '@nuxtjs/i18n': 8.0.0-beta.9
       '@pinia/nuxt': ^0.4.6
       '@tiptap/extension-character-count': 2.0.0-beta.204
       '@tiptap/extension-code-block': 2.0.0-beta.204
@@ -175,7 +175,7 @@ importers:
       '@iconify-json/ri': 1.1.4
       '@iconify-json/twemoji': 1.1.10
       '@nuxtjs/color-mode': 3.2.0
-      '@nuxtjs/i18n': 8.0.0-beta.8
+      '@nuxtjs/i18n': 8.0.0-beta.9
       '@pinia/nuxt': 0.4.6_typescript@4.9.4
       '@types/chroma-js': 2.1.4
       '@types/file-saver': 2.0.5
@@ -211,7 +211,7 @@ importers:
       unplugin-auto-import: 0.12.1_@vueuse+core@9.11.1
       unplugin-vue-inspector: 0.0.2
       vite-plugin-inspect: 0.7.14
-      vite-plugin-pwa: 0.14.1_tz3vz2xt4jvid2diblkpydcyn4
+      vite-plugin-pwa: 0.14.1
       vitest: 0.28.1_jsdom@21.1.0
       vitest-environment-nuxt: 0.4.0_vitest@0.28.1
       vue-tsc: 1.0.24_typescript@4.9.4
@@ -2883,14 +2883,14 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxtjs/i18n/8.0.0-beta.8:
-    resolution: {integrity: sha512-XXOGdAnlbjHPVtY0exI+V+K9Lz0xo3oOtR0mZDV1hvO5H5EOQGvHtHvG6aufFsR10rgw4tI66pCvo/MLKeoH4g==}
+  /@nuxtjs/i18n/8.0.0-beta.9:
+    resolution: {integrity: sha512-Vz90kpmr1WJIPqAhlLWD3Yov8/DWCUQiT/5Xu8Kuqw+iZ47ZI7HI2W6BzwusHSRHn+fINxg/lKgs0uWw38PfKw==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
       '@intlify/bundle-utils': 3.4.0_vue-i18n@9.3.0-beta.16
       '@intlify/shared': 9.3.0-beta.11
       '@intlify/unplugin-vue-i18n': 0.8.1_vue-i18n@9.3.0-beta.16
-      '@nuxt/kit': 3.0.0
+      '@nuxt/kit': 3.1.0
       '@vue/compiler-sfc': 3.2.45
       cookie-es: 0.5.0
       debug: 4.3.4
@@ -12877,12 +12877,10 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.14.1_tz3vz2xt4jvid2diblkpydcyn4:
+  /vite-plugin-pwa/0.14.1:
     resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
-      workbox-build: ^6.5.4
-      workbox-window: ^6.5.4
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.10.1
       debug: 4.3.4
@@ -12892,6 +12890,7 @@ packages:
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:
+      - '@types/babel__core'
       - supports-color
     dev: true
 


### PR DESCRIPTION
This is the final update for country variants: 
- nuxt i18n module fix merging files and `en-US` is now correct
- update contributing guide to remove the workaround