### PR TITLE
fix(a11y): do not prevent arbitrary zooming on mobile devices

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -130,8 +130,7 @@ export default defineNuxtConfig({
   app: {
     keepalive: true,
     head: {
-      // Prevent arbitrary zooming on mobile devices
-      viewport: 'width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover',
+      viewport: 'width=device-width,initial-scale=1',
       bodyAttrs: {
         class: 'overflow-x-hidden',
       },


### PR DESCRIPTION
Noticed cannot zoom on mobile devices at all because it's completely disabled on meta viewport. I don't understand the reasoning behind this. I know there is a font-size scale setting but it's not sufficient for many users with the problems on eye-sight. As Elk works as PWA, zooming should always be enabled.

## Why it Matters

The `maximum-scale` parameter limits the amount the user can zoom. This is problematic for people with low vision who rely on screen magnifiers to properly see the contents of a web page.

Users with partial vision and low vision often choose to enlarge the fonts or other elements on their browser to make text and images on the web easier to read and recognize. The browser's viewport focus is everything visible in the browser window at a given moment. Maximizing the browser to full size on a high-resolution monitor creates a large the viewport focus area and may include the entire web page.

If the browser window is small, the viewport focus area only includes a small part of the web page. The browser's viewport focus does not affect the programmatic focus. Users can scroll up and down the web page, but the programmatic focus does not follow the viewport. The Web Content Accessibility Guidelines calls for developers to design pages so that they support resize up to 200%.

Please always ensure that the `user-scalable="no"` parameter is not present in the `<meta name="viewport">` element and the `maximum-scale` parameter is not less than 2 or not defined at all to allow scaling as user pleases.

The overflow-x: hidden is present so let's at least give user a choice to zoom. Thank you.

closes #1507