### PR TITLE
fix: Custom-emoji size on editor

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -39,6 +39,7 @@ body {
   vertical-align: text-bottom;
 }
 
+.content-editor .custom-emoji img,
 .custom-emoji img {
   max-height: 1.3em;
   max-width: 1.3em;


### PR DESCRIPTION
A visual representation of the issue:

![image](https://user-images.githubusercontent.com/1534150/215272775-d2fbb947-c026-4724-a82a-775055c45b73.png)

After this change:

![image](https://user-images.githubusercontent.com/1534150/215272829-82946d82-e83f-468c-bbbd-9e33c7c7273e.png)

To think about in the future: There's an incosistency here, because in the post the emoji is wrapped with a class custom-emoji whereas in the editor the custom-emoji class is directly in the img.