### PR TITLE
fix: use "⌘" as modifier key name on macOS

### DIFF
--- a/components/command/CommandPanel.vue
+++ b/components/command/CommandPanel.vue
@@ -64,6 +64,8 @@ const result = $computed<QueryResult>(() => commandMode
   : searchResult,
 )
 
+const modifierKeyName = $computed(() => navigator.userAgentData?.platform === 'macOS' ? 'Command' : 'Ctrl')
+
 let active = $ref(0)
 watch($$(result), (n, o) => {
   if (n.length !== o.length || !n.items.every((i, idx) => i === o.items[idx]))
@@ -233,8 +235,8 @@ const onKeyDown = (e: KeyboardEvent) => {
     <!-- Footer -->
     <div class="flex items-center px-3 py-1 text-xs">
       <div i-ri:lightbulb-flash-line /> Tip: Use
-      <CommandKey name="Ctrl+K" /> to search,
-      <CommandKey name="Ctrl+/" /> to activate command mode.
+      <CommandKey :name="`${modifierKeyName}+K`" /> to search,
+      <CommandKey :name="`${modifierKeyName}+/`" /> to activate command mode.
     </div>
   </div>
 </template>

--- a/components/command/CommandPanel.vue
+++ b/components/command/CommandPanel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useIsMac } from '~/composables/misc'
 import type { SearchResult as SearchResultType } from '~/composables/masto/search'
 import type { CommandScope, QueryResult, QueryResultItem } from '~/composables/command'
 
@@ -65,7 +64,8 @@ const result = $computed<QueryResult>(() => commandMode
   : searchResult,
 )
 
-const modifierKeyName = $computed(() => useIsMac() ? 'Command' : 'Ctrl')
+const isMac = useIsMac()
+const modifierKeyName = $computed(() => isMac.value ? 'Command' : 'Ctrl')
 
 let active = $ref(0)
 watch($$(result), (n, o) => {

--- a/components/command/CommandPanel.vue
+++ b/components/command/CommandPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useIsMac } from '~/composables/misc'
 import type { SearchResult as SearchResultType } from '~/composables/masto/search'
 import type { CommandScope, QueryResult, QueryResultItem } from '~/composables/command'
 
@@ -64,7 +65,7 @@ const result = $computed<QueryResult>(() => commandMode
   : searchResult,
 )
 
-const modifierKeyName = $computed(() => navigator.userAgentData?.platform === 'macOS' ? 'Command' : 'Ctrl')
+const modifierKeyName = $computed(() => useIsMac() ? 'Command' : 'Ctrl')
 
 let active = $ref(0)
 watch($$(result), (n, o) => {

--- a/components/command/CommandPanel.vue
+++ b/components/command/CommandPanel.vue
@@ -65,7 +65,7 @@ const result = $computed<QueryResult>(() => commandMode
 )
 
 const isMac = useIsMac()
-const modifierKeyName = $computed(() => isMac.value ? 'Command' : 'Ctrl')
+const modifierKeyName = $computed(() => isMac.value ? '⌘' : 'Ctrl')
 
 let active = $ref(0)
 watch($$(result), (n, o) => {


### PR DESCRIPTION
This replaces the wrong "Ctrl" with "Command" as a modifier key name in the command pallet on macOS.

**Before**
<img width="710" alt="Screenshot 2023-01-29 at 2 55 46" src="https://user-images.githubusercontent.com/1425259/215283146-5da3c47d-0384-4cfb-b549-a6f339b73fab.png">

**After**
<img width="711" alt="Screenshot 2023-01-29 at 2 55 55" src="https://user-images.githubusercontent.com/1425259/215283145-b5603fb2-55aa-4050-b5fb-16bf400f927a.png">


I used `navigator.userAgentData.platform` to detect the platform name. However, this is implemented only in Chromium-based browsers at this moment.

ref. ["userAgentData" | Can I use... Support tables for HTML5, CSS3, etc](https://caniuse.com/?search=userAgentData)

If we want to work this on any browser, we need to use another way until all major browsers implement `userAgentData`. Then, does anyone know the best way to reliably detect the macOS in the Vue ecosystem?