### PR TITLE
perf!: allow tree-shaking unstorage drivers

### DIFF
--- a/modules/tauri/index.ts
+++ b/modules/tauri/index.ts
@@ -22,6 +22,7 @@ export default defineNuxtModule({
       ...nuxt.options.alias,
       'unstorage/drivers/fs': 'unenv/runtime/mock/proxy',
       'unstorage/drivers/cloudflare-kv-http': 'unenv/runtime/mock/proxy',
+      '#storage-config': resolve('./runtime/storage-config'),
       'node:events': 'unenv/runtime/node/events/index',
       '#build-info': resolve('./runtime/build-info'),
     }

--- a/modules/tauri/runtime/storage-config.ts
+++ b/modules/tauri/runtime/storage-config.ts
@@ -1,0 +1,2 @@
+export const driver = undefined
+export const fsBase = ''

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -134,10 +134,7 @@ export default defineNuxtConfig({
     'nitro:config': function (config) {
       const nuxt = useNuxt()
       config.virtual = config.virtual || {}
-      config.virtual['#storage-config'] = `
-        export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}
-        export const fsBase = ${JSON.stringify(nuxt.options.appConfig.storage.fsBase)}
-      `
+      config.virtual['#storage-config'] = `export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}`
     },
   },
   app: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,4 @@
-import { createResolver } from '@nuxt/kit'
+import { createResolver, useNuxt } from '@nuxt/kit'
 import Inspect from 'vite-plugin-inspect'
 import { isCI, isDevelopment, isWindows } from 'std-env'
 import { isPreview } from './config/env'
@@ -86,6 +86,12 @@ export default defineNuxtConfig({
       'postcss-nested': {},
     },
   },
+  appConfig: {
+    storage: {
+      driver: process.env.NUXT_STORAGE_DRIVER ?? (isCI ? 'cloudflare' : 'fs'),
+      fsBase: process.env.NUXT_STORAGE_FS_BASE ?? 'node_modules/.cache/app',
+    },
+  },
   runtimeConfig: {
     adminKey: '',
     cloudflare: {
@@ -100,10 +106,6 @@ export default defineNuxtConfig({
       translateApi: '',
       // Use the instance where Elk has its Mastodon account as the default
       defaultServer: 'm.webtoo.ls',
-    },
-    storage: {
-      driver: isCI ? 'cloudflare' : 'fs',
-      fsBase: 'node_modules/.cache/servers',
     },
   },
   routeRules: {
@@ -124,6 +126,16 @@ export default defineNuxtConfig({
       crawlLinks: true,
       routes: ['/'],
       ignore: ['/settings'],
+    },
+  },
+  hooks: {
+    'nitro:config': function (config) {
+      const nuxt = useNuxt()
+      config.virtual = config.virtual || {}
+      config.virtual['#storage-config'] = `
+        export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}
+        export const fsBase = ${JSON.stringify(nuxt.options.appConfig.storage.fsBase)}
+      `
     },
   },
   app: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -89,7 +89,6 @@ export default defineNuxtConfig({
   appConfig: {
     storage: {
       driver: process.env.NUXT_STORAGE_DRIVER ?? (isCI ? 'cloudflare' : 'fs'),
-      fsBase: process.env.NUXT_STORAGE_FS_BASE ?? 'node_modules/.cache/app',
     },
   },
   runtimeConfig: {
@@ -106,6 +105,9 @@ export default defineNuxtConfig({
       translateApi: '',
       // Use the instance where Elk has its Mastodon account as the default
       defaultServer: 'm.webtoo.ls',
+    },
+    storage: {
+      fsBase: 'node_modules/.cache/app',
     },
   },
   routeRules: {

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -15,7 +15,7 @@ import cached from './cache-driver'
 // @ts-expect-error virtual import
 import { env } from '#build-info'
 // @ts-expect-error virtual import
-import { driver, fsBase } from '#storage-config'
+import { driver } from '#storage-config'
 
 import type { AppInfo } from '~/types'
 import { APP_NAME } from '~/constants'
@@ -27,7 +27,8 @@ const memory = _memory as typeof import('unstorage/dist/drivers/memory')['defaul
 const storage = useStorage() as Storage
 
 if (driver === 'fs') {
-  storage.mount('servers', fs({ base: fsBase }))
+  const config = useRuntimeConfig()
+  storage.mount('servers', fs({ base: config.storage.fsBase }))
 }
 else if (driver === 'cloudflare') {
   const config = useRuntimeConfig()

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -14,11 +14,11 @@ import cached from './cache-driver'
 
 // @ts-expect-error virtual import
 import { env } from '#build-info'
+// @ts-expect-error virtual import
+import { driver, fsBase } from '#storage-config'
 
 import type { AppInfo } from '~/types'
 import { APP_NAME } from '~/constants'
-
-const config = useRuntimeConfig()
 
 const fs = _fs as typeof import('unstorage/dist/drivers/fs')['default']
 const kv = _kv as typeof import('unstorage/dist/drivers/cloudflare-kv-http')['default']
@@ -26,17 +26,18 @@ const memory = _memory as typeof import('unstorage/dist/drivers/memory')['defaul
 
 const storage = useStorage() as Storage
 
-if (config.storage.driver === 'fs') {
-  storage.mount('servers', fs({ base: config.storage.fsBase }))
+if (driver === 'fs') {
+  storage.mount('servers', fs({ base: fsBase }))
 }
-else if (config.storage.driver === 'cloudflare') {
+else if (driver === 'cloudflare') {
+  const config = useRuntimeConfig()
   storage.mount('servers', cached(kv({
     accountId: config.cloudflare.accountId,
     namespaceId: config.cloudflare.namespaceId,
     apiToken: config.cloudflare.apiToken,
   })))
 }
-else if (config.storage.driver === 'memory') {
+else if (driver === 'memory') {
   storage.mount('servers', memory())
 }
 


### PR DESCRIPTION
follow-up on https://github.com/elk-zone/elk/pull/1508

This makes the choice of unstorage driver fixed at build-time, to avoid including more dependencies than needed. I think it's unlikely users will swap between cloudflare/memory/fs at runtime.