### PR TITLE
fix: account setting button hover style

### DIFF
--- a/components/common/dropdown/DropdownItem.vue
+++ b/components/common/dropdown/DropdownItem.vue
@@ -46,6 +46,7 @@ useCommand({
     v-bind="$attrs"
     :is="is"
     ref="el"
+    w-full
     flex gap-3 items-center cursor-pointer px4 py3
     select-none
     hover-bg-active


### PR DESCRIPTION
## detail
The hover style of the account setting button is strange. Give it a 'width: 100%' maybe look better.

## before
![SWrUoPWWcI](https://user-images.githubusercontent.com/46164858/215472168-68f14f48-ebef-4b3a-a4c6-603c75a2de42.png)


## after
![f21uIOGXxO](https://user-images.githubusercontent.com/46164858/215472185-a6029683-9b49-4bc6-9552-4c44038a5f90.png)
