### PR TITLE
fix: viewport meta value for iOS PWA safe area

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -149,7 +149,7 @@ export default defineNuxtConfig({
   app: {
     keepalive: true,
     head: {
-      viewport: 'width=device-width,initial-scale=1',
+      viewport: 'width=device-width,initial-scale=1,viewport-fit=cover',
       bodyAttrs: {
         class: 'overflow-x-hidden',
       },


### PR DESCRIPTION
#1501 remove `viewport-fit=cover` caused this problem in iOS PWA
![IMG_ADF8FC52F99A-1](https://user-images.githubusercontent.com/14866249/215683568-9bf494d7-425f-46ed-ab9b-08a0ca92a898.jpeg)
