### PR TITLE
fix: character count should includes spoiler text

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -35,7 +35,7 @@ const {
   dropZoneRef,
 } = $(useUploadMediaAttachment($$(draft)))
 
-let { shouldExpanded, isExpanded, isSending, isPublishDisabled, publishDraft, failedMessages, preferredLanguage } = $(usePublish(
+let { shouldExpanded, isExpanded, isSending, isPublishDisabled, publishDraft, failedMessages, preferredLanguage, publishSpoilerText } = $(usePublish(
   {
     draftState,
     ...$$({ expanded, isUploading, initialDraft: initial }),
@@ -73,6 +73,8 @@ const characterCount = $computed(() => {
       return `@${handle}`
     }).join(' ').length + 1
   }
+
+  length += stringLength(publishSpoilerText)
 
   return length
 })
@@ -156,7 +158,7 @@ defineExpose({
 
         <div v-if="draft.params.sensitive">
           <input
-            v-model="draft.params.spoilerText"
+            v-model="publishSpoilerText"
             type="text"
             :placeholder="$t('placeholder.content_warning')"
             p2 border-rounded w-full bg-transparent

--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -21,6 +21,17 @@ export function usePublish(options: {
   const isExpanded = $ref(false)
   const failedMessages = $ref<string[]>([])
 
+  const publishSpoilerText = $computed({
+    get() {
+      return draft.params.sensitive ? draft.params.spoilerText : ''
+    },
+    set(val) {
+      if (!draft.params.sensitive)
+        return
+      draft.params.spoilerText = val
+    },
+  })
+
   const shouldExpanded = $computed(() => expanded || isExpanded || !isEmpty)
   const isPublishDisabled = $computed(() => {
     return isEmpty || isUploading || isSending || (draft.attachments.length === 0 && !draft.params.status) || failedMessages.length > 0
@@ -41,6 +52,7 @@ export function usePublish(options: {
 
     const payload = {
       ...draft.params,
+      spoilerText: publishSpoilerText,
       status: content,
       mediaIds: draft.attachments.map(a => a.id),
       language: draft.params.language || preferredLanguage,
@@ -91,6 +103,7 @@ export function usePublish(options: {
     isPublishDisabled,
     failedMessages,
     preferredLanguage,
+    publishSpoilerText,
     publishDraft,
   })
 }

--- a/composables/masto/statusDrafts.ts
+++ b/composables/masto/statusDrafts.ts
@@ -88,7 +88,6 @@ export const isEmptyDraft = (draft: Draft | null | undefined) => {
 
   return (text.length === 0)
     && attachments.length === 0
-    && (params.spoilerText || '').length === 0
 }
 
 export interface UseDraft {


### PR DESCRIPTION
resolves: #1512

In Mastodon, content warning (spoiler text) will be included in the character count

![mastodon](https://user-images.githubusercontent.com/39984251/215751972-440db877-9817-46c3-b2c0-6c426bc424fe.png)

But not currently
![main](https://user-images.githubusercontent.com/39984251/215752830-0a65efbe-f85c-440d-b599-ba17df0711f3.png)

After this PR, when the content warning (spoiler text) is activated, it will be included in the word count, and it will be ignored when it is closed.

https://user-images.githubusercontent.com/39984251/215755701-69f024c9-969f-403f-8fc6-90f535b40079.mp4


