### PR TITLE
fix: missed language code fallback

### DIFF
--- a/plugins/setup-i18n.client.ts
+++ b/plugins/setup-i18n.client.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin(async (nuxt) => {
 
   const supportLanguages = (locales as LocaleObject[]).map(locale => locale.code)
   if (!supportLanguages.includes(lang))
-    userSettings.value.language = getDefaultLanguage(locales as string[])
+    userSettings.value.language = getDefaultLanguage(supportLanguages)
 
   watch([$$(lang), isHydrated], () => {
     if (isHydrated.value && lang !== i18n.locale)


### PR DESCRIPTION
This PR fixes missed language code fallback.

How to test:
- go to local storage and update language code to smth like `foo-FOO`
- reload the page
- it would error out before the fix