### PR TITLE
fix: list should be user-only

### DIFF
--- a/components/list/ListEntry.vue
+++ b/components/list/ListEntry.vue
@@ -64,7 +64,7 @@ async function removeList() {
   await nextTick()
 
   const confirmDelete = await openConfirmDialog({
-    title: t('confirm.delete_list.title'),
+    title: t('confirm.delete_list.title', [list.title]),
     confirm: t('confirm.delete_list.confirm'),
     cancel: t('confirm.delete_list.cancel'),
   })

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -32,7 +32,7 @@ const { notifications } = useNotifications()
     <NavSideItem :text="$t('nav.explore')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:hashtag" :command="command" />
     <NavSideItem :text="$t('nav.local')" :to="isHydrated ? `/${currentServer}/public/local` : '/public/local'" icon="i-ri:group-2-line " :command="command" />
     <NavSideItem :text="$t('nav.federated')" :to="isHydrated ? `/${currentServer}/public` : '/public'" icon="i-ri:earth-line" :command="command" />
-    <NavSideItem :text="$t('nav.lists')" :to="`/${currentServer}/lists`" icon="i-ri:list-check" :command="command" />
+    <NavSideItem :text="$t('nav.lists')" :to="`/${currentServer}/lists`" icon="i-ri:list-check" user-only :command="command" />
 
     <div shrink hidden sm:block mt-4 />
     <NavSideItem :text="$t('nav.settings')" to="/settings" icon="i-ri:settings-3-line" :command="command" />

--- a/locales/en.json
+++ b/locales/en.json
@@ -119,7 +119,7 @@
     "delete_list": {
       "cancel": "Cancel",
       "confirm": "Delete",
-      "title": "Are you sure you want to delete this list?"
+      "title": "Are you sure you want to delete \"{0}\" list?"
     },
     "delete_posts": {
       "cancel": "Cancel",

--- a/locales/es.json
+++ b/locales/es.json
@@ -116,6 +116,11 @@
       "cancel": "No",
       "confirm": "Si"
     },
+    "delete_list": {
+      "cancel": "Cancelar",
+      "confirm": "Eliminar",
+      "title": "¿Está seguro de querer eliminar la lista \"{0}\"?"
+    },
     "delete_posts": {
       "cancel": "Cancelar",
       "confirm": "Eliminar",
@@ -177,8 +182,14 @@
   },
   "list": {
     "add_account": "Agregar cuenta a la lista",
+    "cancel_edit": "Cancelar edición",
+    "create": "Crear",
+    "delete": "Eliminar esta lista",
+    "edit": "Ediar esta lista",
+    "list_title_placeholder": "Título de la lista",
     "modify_account": "Modificar listas con cuenta",
-    "remove_account": "Eliminar cuenta de la lista"
+    "remove_account": "Eliminar cuenta de la lista",
+    "save": "Guardar"
   },
   "menu": {
     "block_account": "Bloquear a {0}",

--- a/pages/[[server]]/list/[list]/index.vue
+++ b/pages/[[server]]/list/[list]/index.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import type { CommonRouteTabOption } from '~/components/common/CommonRouteTabs.vue'
 
+definePageMeta({
+  middleware: 'auth',
+})
+
 const list = $computed(() => useRoute().params.list as string)
 const server = $computed(() => useRoute().params.server as string)
 

--- a/pages/[[server]]/lists.vue
+++ b/pages/[[server]]/lists.vue
@@ -1,6 +1,10 @@
 <script lang="ts" setup>
 import type { mastodon } from 'masto'
 
+definePageMeta({
+  middleware: 'auth',
+})
+
 const { t } = useI18n()
 
 const client = useMastoClient()


### PR DESCRIPTION
This PR includes 
- `user-only` on navigation 
- `auth` middleware in lists and list pages
- spanish translation for new entries