### PR TITLE
chore(i18n): `en` as source language

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,8 @@
   ],
   "i18n-ally.preferredDelimiter": "_",
   "i18n-ally.sortKeys": true,
-  "i18n-ally.sourceLanguage": "en-US",
+  "i18n-ally.sourceLanguage": "en",
+  "i18n-ally.languageTagSystem": "bcp47",
   "prettier.enable": false,
   "volar.completion.preferredTagNameCase": "pascal",
   "volar.completion.preferredAttrNameCase": "kebab"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,6 @@
   "i18n-ally.preferredDelimiter": "_",
   "i18n-ally.sortKeys": true,
   "i18n-ally.sourceLanguage": "en",
-  "i18n-ally.languageTagSystem": "bcp47",
   "prettier.enable": false,
   "volar.completion.preferredTagNameCase": "pascal",
   "volar.completion.preferredAttrNameCase": "kebab"


### PR DESCRIPTION
As we have now variants enable, en-US is no more the source of language as it's a variant itself.

So, I suggest to switch too EN ~~and force the [BCP47](https://en.wikipedia.org/wiki/IETF_language_tag) language system~~