### PR TITLE
fix: reply language defaults to status language

### DIFF
--- a/composables/masto/statusDrafts.ts
+++ b/composables/masto/statusDrafts.ts
@@ -74,6 +74,7 @@ export function getReplyDraft(status: mastodon.v1.Status) {
         inReplyToId: status!.id,
         visibility: status.visibility,
         mentions: accountsToMention,
+        language: status.language,
       })
     },
   }


### PR DESCRIPTION
closes #1609 

This PR sets the default language on replys to the language of the original status