### PR TITLE
feat: prioritize user languages in language picker

### DIFF
--- a/components/publish/PublishLanguagePicker.vue
+++ b/components/publish/PublishLanguagePicker.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import Fuse from 'fuse.js'
-import { ComputedRef } from 'vue'
 
 let { modelValue } = $defineModel<{
   modelValue: string

--- a/components/publish/PublishLanguagePicker.vue
+++ b/components/publish/PublishLanguagePicker.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import Fuse from 'fuse.js'
+import { ComputedRef } from 'vue'
 
 let { modelValue } = $defineModel<{
   modelValue: string
 }>()
 
 const { t } = useI18n()
+const userSettings = useUserSettings()
 
 const languageKeyword = $ref('')
 
@@ -17,9 +19,22 @@ const fuse = new Fuse(languagesNameList, {
 const languages = $computed(() =>
   languageKeyword.trim()
     ? fuse.search(languageKeyword).map(r => r.item)
-    : [...languagesNameList].sort(({ code: a }, { code: b }) => {
-        return a === modelValue ? -1 : b === modelValue ? 1 : a.localeCompare(b)
-      }),
+    : [...languagesNameList].filter(entry => !userSettings.value.disabledTranslationLanguages.includes(entry.code))
+        .sort(({ code: a }, { code: b }) => {
+          return a === modelValue ? -1 : b === modelValue ? 1 : a.localeCompare(b)
+        }),
+)
+
+const preferredLanguages = computed(() => {
+  const result = []
+  for (const langCode of userSettings.value.disabledTranslationLanguages) {
+    const completeLang = languagesNameList.find(listEntry => listEntry.code === langCode)
+    if (completeLang)
+      result.push(completeLang)
+  }
+  return result
+},
+
 )
 
 function chooseLanguage(language: string) {
@@ -38,6 +53,18 @@ function chooseLanguage(language: string) {
       >
     </div>
     <div max-h-40vh overflow-auto>
+      <template v-if="!languageKeyword.trim()">
+        <CommonDropdownItem
+          v-for="{ code, nativeName, name } in preferredLanguages"
+          :key="code"
+          :text="nativeName"
+          :description="name"
+          :checked="code === modelValue"
+          @click="chooseLanguage(code)"
+        />
+        <hr class="border-base ">
+      </template>
+
       <CommonDropdownItem
         v-for="{ code, nativeName, name } in languages"
         :key="code"


### PR DESCRIPTION
closes #1548 

if the user has configured one or more language not to translate (aka known languages), these languages get prioritized in the language picker because these are most likely the languages the user is searching for.

<img width="391" alt="Bildschirmfoto 2023-02-03 um 23 45 58" src="https://user-images.githubusercontent.com/16021919/216725554-49b3fd67-7686-48e2-a8bf-2d3733517bbe.png">
