### PR TITLE
fix: fullscreen video scaling issues

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -103,7 +103,7 @@ const userSettings = useUserSettings()
         playsinline
         controls
         rounded-lg
-        object-cover
+        object-contain
         :width="attachment.meta?.original?.width"
         :height="attachment.meta?.original?.height"
         :style="{


### PR DESCRIPTION
While using my ultrawide monitor, I encountered a scaling issue with full-screen videos  (firefox, linux). They were stretched and displayed incorrect proportions. I quickly opened dev tools and poked around, and discovered that the "object-fit" property was set to "cover," causing the issue.

After checking it on my 13-inch laptop (firefox, macos) and mobile (firefox and chromium-based, android) I haven't found any negative consequences.

The surprising bit is that scaling issues existed and were degrading video quality on regular displays, even though it went unnoticed until now.

Before:
21:9
![image](https://user-images.githubusercontent.com/3883601/216732897-f159c122-7318-411a-802d-052075f60b19.png)

16:10
![image](https://user-images.githubusercontent.com/3883601/216732974-13e7fddf-16c2-4056-abc0-9323bb2847c5.png)

After:
21:9
![image](https://user-images.githubusercontent.com/3883601/216733003-bcac7b5c-b711-4065-af56-f641db37e2a1.png)

16:10
![image](https://user-images.githubusercontent.com/3883601/216733015-f10f79c2-6165-4b66-afd1-cbe14ad26dc9.png)

mobile horizontal
![image](https://user-images.githubusercontent.com/3883601/216733164-162c27f5-e25b-4b18-adb9-b83a37a2f403.png)

mobile vertical
![image](https://user-images.githubusercontent.com/3883601/216733208-b56f0ed3-4b2e-45a2-b253-1480f8b37857.png)

