### PR TITLE
fix(i18n): Update zh-TW translations

### DIFF
--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -21,7 +21,7 @@
     "followers_count": " {0} 位粉絲",
     "following": "正在追蹤",
     "following_count": "正在追蹤 {0} 人",
-    "follows_you": "已追蹤你",
+    "follows_you": "已追蹤您",
     "go_to_profile": "轉到個人資料",
     "joined": "已加入",
     "moved_title": "的新帳號是：",
@@ -103,12 +103,12 @@
     "block_account": {
       "cancel": "取消",
       "confirm": "封鎖",
-      "title": "你確定要封鎖 {0} 嗎？"
+      "title": "您確定要封鎖 {0} 嗎？"
     },
     "block_domain": {
       "cancel": "取消",
       "confirm": "封鎖",
-      "title": "你確定要封鎖 {0} 域名嗎？"
+      "title": "您確定要封鎖 {0} 域名嗎？"
     },
     "common": {
       "cancel": "否",
@@ -117,22 +117,22 @@
     "delete_posts": {
       "cancel": "取消",
       "confirm": "刪除",
-      "title": "你確定要刪除這則貼文嗎？"
+      "title": "您確定要刪除這則貼文嗎？"
     },
     "mute_account": {
       "cancel": "取消",
       "confirm": "靜音",
-      "title": "你確定要靜音 {0}嗎？"
+      "title": "您確定要靜音 {0}嗎？"
     },
     "show_reblogs": {
       "cancel": "取消",
       "confirm": "顯示",
-      "title": "你確定要顯示來自 {0} 的轉發嗎？"
+      "title": "您確定要顯示來自 {0} 的轉發嗎？"
     },
     "unfollow": {
       "cancel": "取消",
       "confirm": "取消追蹤",
-      "title": "你確定要取消追蹤嗎？"
+      "title": "您確定要取消追蹤嗎？"
     }
   },
   "conversation": {
@@ -148,10 +148,10 @@
   },
   "help": {
     "desc_highlight": "可能會在某些地方出現一些 bug 或缺少的功能。",
-    "desc_para1": "感謝你有興趣嘗試鹿鳴，一個我們正在積極開發的通用 Mastodon 用戶端。",
+    "desc_para1": "感謝您有興趣嘗試鹿鳴，一個我們正在積極開發的通用 Mastodon 用戶端。",
     "desc_para2": "我們正在努力開發中，並隨著時間的推移不斷完善。",
-    "desc_para3": "為了幫助促進開發，你可以通過以下連結贊助我們的團隊成員。希望你喜歡鹿鳴！",
-    "desc_para4": "鹿鳴是開源的，如果你願意幫助測試、提供回饋或作出貢獻，",
+    "desc_para3": "為了幫助促進開發，您可以通過以下連結贊助我們的團隊成員。希望您喜歡鹿鳴！",
+    "desc_para4": "鹿鳴是開源的，如果您願意幫助測試、提供回饋或作出貢獻，",
     "desc_para5": "在 GitHub 上聯繫我們",
     "desc_para6": "來參與其中。",
     "title": "預覽鹿鳴！"
@@ -214,17 +214,17 @@
     "zen_mode": "禪模式"
   },
   "notification": {
-    "favourited_post": "點讚了你的貼文",
-    "followed_you": "追蹤了你",
-    "followed_you_count": "{n} 人追蹤了你",
+    "favourited_post": "點讚了您的貼文",
+    "followed_you": "追蹤了您",
+    "followed_you_count": "{n} 人追蹤了您",
     "missing_type": "未知的通知類型：",
-    "reblogged_post": "轉發了你的貼文",
-    "request_to_follow": "請求追蹤你",
+    "reblogged_post": "轉發了您的貼文",
+    "request_to_follow": "請求追蹤您",
     "signed_up": "註冊了",
     "update_status": "更新了他們的狀態"
   },
   "placeholder": {
-    "content_warning": "寫下你的警告",
+    "content_warning": "寫下您的警告",
     "default_1": "在想些什麼？",
     "reply_to_account": "回覆 {0}",
     "replying": "回覆",
@@ -271,10 +271,10 @@
       "sponsors": "贊助",
       "sponsors_body_1": "鹿鳴的誕生得感謝以下的慷慨贊助與幫助：",
       "sponsors_body_2": "以及所有贊助鹿鳴成員的公司和個人，以及隊員們。",
-      "sponsors_body_3": "如果你喜歡鹿鳴，可以考慮贊助我們："
+      "sponsors_body_3": "如果您喜歡鹿鳴，可以考慮贊助我們："
     },
     "account_settings": {
-      "description": "在 Mastodon UI 中編輯你的帳號設定",
+      "description": "在 Mastodon UI 中編輯您的帳號設定",
       "label": "帳號設定"
     },
     "interface": {
@@ -302,10 +302,10 @@
           "follow": "新的粉絲",
           "mention": "提及",
           "poll": "投票",
-          "reblog": "轉發了你的貼文",
+          "reblog": "轉發了您的貼文",
           "title": "接收了什麼通知？"
         },
-        "description": "當你沒有在使用鹿鳴時也能接收通知。",
+        "description": "當您沒有在使用鹿鳴時也能接收通知。",
         "instructions": "不要忘記點擊 @:settings.notifications.push_notifications.save_settings 按鈕儲存變更！",
         "label": "推播通知設定",
         "policy": {
@@ -318,21 +318,21 @@
         "save_settings": "儲存設定變更",
         "subscription_error": {
           "clear_error": "清除錯誤",
-          "permission_denied": "權限不足：請在你的瀏覽器中打開通知權限。",
+          "permission_denied": "權限不足：請在您的瀏覽器中打開通知權限。",
           "request_error": "請求訂閱時發生了一個錯誤，請再次嘗試。如錯誤仍然存在，請到鹿鳴儲存庫中報告這一問題。",
           "title": "無法訂閱推播通知。",
-          "too_many_registrations": "由於瀏覽器限制，鹿鳴無法為不同伺服器上的多個帳號使用推播通知服務。 你應該取消訂閱其他帳號的推送通知，然後重試。"
+          "too_many_registrations": "由於瀏覽器限制，鹿鳴無法為不同伺服器上的多個帳號使用推播通知服務。 您應該取消訂閱其他帳號的推送通知，然後重試。"
         },
         "title": "推播通知設定",
         "undo_settings": "撤銷設定變更",
         "unsubscribe": "停用推播功能",
-        "unsupported": "你的瀏覽器不支援推播功能",
+        "unsupported": "您的瀏覽器不支援推播功能",
         "warning": {
           "enable_close": "關閉",
-          "enable_description": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。啟用後，你可以通過上面的 「前往通知設定」 按鈕來 精確控制哪種類型的互動可以產生桌面通知。",
-          "enable_description_desktop": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。啟用後，你可以在 「設定」 > 「通知」 > 「推播通知設定」 裡面選擇哪些互動你會接收到通知。",
-          "enable_description_mobile": "你也可以使用導覽列 「設定」 > 「通知」 > 「推播通知設定」 進入設定頁面。",
-          "enable_description_settings": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。 啟用後，你將能夠選擇哪些互動你會接收到通知。",
+          "enable_description": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。啟用後，您可以通過上面的 「前往通知設定」 按鈕來 精確控制哪種類型的互動可以產生桌面通知。",
+          "enable_description_desktop": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。啟用後，您可以在 「設定」 > 「通知」 > 「推播通知設定」 裡面選擇哪些互動您會接收到通知。",
+          "enable_description_mobile": "您也可以使用導覽列 「設定」 > 「通知」 > 「推播通知設定」 進入設定頁面。",
+          "enable_description_settings": "若想在鹿鳴未開啟時接收通知，請啟用推播通知功能。 啟用後，您將能夠選擇哪些互動您會接收到通知。",
           "enable_desktop": "啟用推播功能",
           "enable_title": "不錯過任何事",
           "re_auth": "您的伺服器似乎不支援推播通知。嘗試退出使用者並重新登入。如果此消息仍然出現，請聯繫您伺服器的管理員。"
@@ -362,7 +362,7 @@
         "title": "編輯個人資料"
       },
       "featured_tags": {
-        "description": "人們可以在這些標籤下瀏覽你的公開嘟文。",
+        "description": "人們可以在這些標籤下瀏覽您的公開嘟文。",
         "label": "精選的話題標籤"
       },
       "label": "個人資料"
@@ -375,8 +375,8 @@
     }
   },
   "share-target": {
-    "description": "如果你想分享其他應用程式上的內容到鹿鳴。請在你的行動裝置裝置或電腦上安裝鹿鳴並登入。",
-    "hint": "為了將內容分享到鹿鳴，你需要安裝鹿鳴並且登入。",
+    "description": "如果您想分享其他應用程式上的內容到鹿鳴。請在您的行動裝置裝置或電腦上安裝鹿鳴並登入。",
+    "hint": "為了將內容分享到鹿鳴，您需要安裝鹿鳴並且登入。",
     "title": "分享到鹿鳴"
   },
   "state": {


### PR DESCRIPTION
* prefer 您 over 你

In [zh-TW translation](https://crowdin.com/project/mastodon/zh-TW) of Mastodon Web UI, we prefer to use 您 to be more polite. This PR is to make Elk to be consistent with Mastodon Web UI.