### PR TITLE
fix: repeated content on reblog without comment

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -26,7 +26,7 @@ const props = withDefaults(
 const userSettings = useUserSettings()
 
 const status = $computed(() => {
-  if (props.status.reblog && !props.status.content)
+  if (props.status.reblog && (!props.status.content || props.status.content === props.status.reblog.content))
     return props.status.reblog
   return props.status
 })


### PR DESCRIPTION
Resolve #1541

When a user reblog a post without comment, some non-mastodon servers like Akkoma and GoToSocial copy the content of the original status to the content of the new reblogging status, instead of leaving it empty.

Currently, Elk treats this as **reblogging with comment**, and displays both `status.content` and `status.reblog.content`. As a result, the content is displayed twice.

After this fix, `StatusCard.vue` will consider both **reblog with empty `status.content`** and **reblog with repeated `status.content`** as **reblog without comment**, and display it with corresponding format.