### PR TITLE
feat(ui): Adding Search History functionality

### DIFF
--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -18,7 +18,7 @@ router.afterEach(() => {
 </script>
 
 <template>
-  <div flex justify-between sticky top-0 bg-base z-1 py-4 native:py-7 data-tauri-drag-region>
+  <div flex justify-between sticky top-0 bg-base py-4 native:py-7 data-tauri-drag-region>
     <NuxtLink
       flex items-end gap-3
       py2 px-5

--- a/components/search/SearchHistory.vue
+++ b/components/search/SearchHistory.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import type { SavedSearchResult } from '@/composables/masto/search'
+
+const props = defineProps<{
+  searchHistory: SavedSearchResult[]
+}>()
+
+const emit = defineEmits<{
+  (event: 'clear-all'): void
+  (event: 'clear-history-item', id: string): void
+}>()
+
+const orderedHistoryItems = computed(() => {
+  return [...props.searchHistory].sort((a, b) => new Date(b.lastQueryTime).getTime() - new Date(a.lastQueryTime).getTime())
+})
+</script>
+
+<template>
+  <div left-0 top-12 w-full group-focus-within="pointer-events-auto visible" pointer-events-none>
+    <div class="grid grid-cols-[1fr_auto] place-items-center mx-2 mb-2">
+      <div justify-self-start text-xl font-500>
+        {{ $t('search.search_history_title') }}
+      </div>
+      <button
+        gap-1 items-center
+        border-1
+        rounded-full flex="~ gap2 center" font-400 px3 py1
+        bg-base border-primary text-primary
+        hover="text-inverted bg-primary border-primary"
+        @click="emit('clear-all')"
+      >
+        <span>{{ $t('search.search_clear_all') }}</span>
+      </button>
+    </div>
+    <div mx-2 class="grid grid-gap-1" overflow-x-hidden max-h-50>
+      <div v-for="searcHistoryItem in orderedHistoryItems" :key="searcHistoryItem.id" hover="bg-active" class="grid grid-cols-[auto_1fr_auto] place-items-center grid-gap-2">
+        <div v-if="searcHistoryItem.type === 'hashtag'" i-ri:hashtag />
+        <div v-else i-ri:user-search-line />
+        <NuxtLink :to="searcHistoryItem.to" justify-self-start w-full>
+          <div>
+            {{ searcHistoryItem.displayName }}
+          </div>
+        </NuxtLink>
+        <button btn-action-icon :aria-label="$t('tooltip.delete_search_history')" @click="emit('clear-history-item', searcHistoryItem.id)">
+          <div i-ri:delete-bin-line />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/components/search/SearchHistory.vue
+++ b/components/search/SearchHistory.vue
@@ -27,6 +27,7 @@ const orderedHistoryItems = computed(() => {
         rounded-full flex="~ gap2 center" font-400 px3 py1
         bg-base border-primary text-primary
         hover="text-inverted bg-primary border-primary"
+        :aria-label="$t('search.search_clear_all')"
         @click="emit('clear-all')"
       >
         <span>{{ $t('search.search_clear_all') }}</span>
@@ -41,9 +42,11 @@ const orderedHistoryItems = computed(() => {
             {{ searcHistoryItem.displayName }}
           </div>
         </NuxtLink>
-        <button btn-action-icon :aria-label="$t('tooltip.delete_search_history')" @click="emit('clear-history-item', searcHistoryItem.id)">
-          <div i-ri:delete-bin-line />
-        </button>
+        <CommonTooltip no-auto-focus :content="$t('tooltip.delete_search_history')">
+          <button btn-action-icon :aria-label="$t('tooltip.delete_search_history')" @click="emit('clear-history-item', searcHistoryItem.id)">
+            <div i-ri:delete-bin-line />
+          </button>
+        </CommonTooltip>
       </div>
     </div>
   </div>

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -6,7 +6,12 @@ defineProps<{
   active: boolean
 }>()
 
+const emit = defineEmits<{
+  (event: 'activate'): void
+}>()
+
 const onActivate = () => {
+  emit('activate');
   (document.activeElement as HTMLElement).blur()
 }
 </script>

--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import { useAsyncIDBKeyval } from '~/composables/idb'
+import { type AccountSearchResult, type HashTagSearchResult, type SavedSearchResult, type SearchResult } from '~/composables/masto/search'
+
+import {
+  STORAGE_KEY_SEARCH_HISTORY,
+} from '~/constants'
+
 const query = ref('')
 const { accounts, hashtags, loading, statuses } = useSearch(query)
 const index = ref(0)
@@ -13,6 +20,7 @@ defineExpose({
   input,
 })
 
+const searchHistory = await useAsyncIDBKeyval<SavedSearchResult[]>(STORAGE_KEY_SEARCH_HISTORY, [], { deep: true })
 const results = computed(() => {
   if (query.value.length === 0)
     return []
@@ -40,6 +48,22 @@ watch([results, focused], () => index.value = -1)
 
 const shift = (delta: number) => index.value = (index.value + delta % results.value.length + results.value.length) % results.value.length
 
+// Save to search history
+function addToSearchHistory(result: SearchResult) {
+  // check if searchHistory already contains result
+  const index = searchHistory.value.findIndex(item => item.id === result.id)
+  if (index !== -1)
+    searchHistory.value.splice(index, 1)
+
+  searchHistory.value.push({
+    id: result.id,
+    type: result.type,
+    displayName: result.type === 'hashtag' ? (result as HashTagSearchResult).data.name : (result as AccountSearchResult).data.displayName,
+    to: result.to,
+    lastQueryTime: new Date(),
+  })
+}
+
 const activate = () => {
   const currentIndex = index.value
 
@@ -56,6 +80,7 @@ const activate = () => {
   (document.activeElement as HTMLElement).blur()
   index.value = -1
 
+  addToSearchHistory(results.value[currentIndex])
   router.push(results.value[currentIndex].to)
 }
 </script>
@@ -84,10 +109,14 @@ const activate = () => {
     </div>
     <!-- Results -->
     <div left-0 top-11 absolute w-full z10 group-focus-within="pointer-events-auto visible" invisible pointer-events-none>
-      <div w-full bg-base border="~ base" rounded-3 max-h-100 overflow-auto py2>
-        <span v-if="query.trim().length === 0" block text-center text-sm text-secondary>
-          {{ t('search.search_desc') }}
-        </span>
+      <div w-full bg-base border="~ base" rounded-3 max-h-100 overflow-x-hidden py2>
+        <template v-if="query.trim().length === 0">
+          <SearchHistory
+            :search-history="searchHistory"
+            @clear-all="searchHistory = []"
+            @clear-history-item="searchHistory = searchHistory.filter(item => item.id !== $event)"
+          />
+        </template>
         <template v-else-if="!loading">
           <template v-if="results.length > 0">
             <SearchResult
@@ -95,6 +124,7 @@ const activate = () => {
               :active="index === parseInt(i.toString())"
               :result="result"
               :tabindex="focused ? 0 : -1"
+              @activate="addToSearchHistory(result)"
             />
           </template>
           <span v-else block text-center text-sm text-secondary>

--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -86,7 +86,7 @@ const activate = () => {
 </script>
 
 <template>
-  <div ref="el" relative group>
+  <div ref="el" relative group w-full>
     <div bg-base border="~ base" h10 px-4 rounded-3 flex="~ row" items-center relative focus-within:box-shadow-outline gap-3>
       <div i-ri:search-2-line pointer-events-none text-secondary mt="1px" class="rtl-flip" />
       <input

--- a/composables/masto/search.ts
+++ b/composables/masto/search.ts
@@ -19,6 +19,7 @@ export type HashTagSearchResult = BuildSearchResult<'hashtag', mastodon.v1.Tag>
 export type StatusSearchResult = BuildSearchResult<'status', mastodon.v1.Status>
 
 export type SearchResult = HashTagSearchResult | AccountSearchResult | StatusSearchResult
+export type SavedSearchResult = Omit<SearchResult, 'data'> & { displayName: string; lastQueryTime: Date }
 
 export function useSearch(query: MaybeComputedRef<string>, options: UseSearchOptions = {}) {
   const done = ref(false)

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -18,5 +18,6 @@ export const STORAGE_KEY_HIDE_EXPLORE_TAGS_TIPS = 'elk-hide-explore-tags-tips'
 export const STORAGE_KEY_NOTIFICATION = 'elk-notification'
 export const STORAGE_KEY_NOTIFICATION_POLICY = 'elk-notification-policy'
 export const STORAGE_KEY_PWA_HIDE_INSTALL = 'elk-pwa-hide-install'
+export const STORAGE_KEY_SEARCH_HISTORY = 'elk-search-history'
 
 export const HANDLED_MASTO_URLS = /^(https?:\/\/)?([\w\d-]+\.)+\w+\/(@[@\w\d-\.]+)(\/objects)?(\/\d+)?$/

--- a/locales/en.json
+++ b/locales/en.json
@@ -304,8 +304,10 @@
     }
   },
   "search": {
+    "search_clear_all": "Clear all",
     "search_desc": "Search for people & hashtags",
-    "search_empty": "Could not find anything for these search terms"
+    "search_empty": "Could not find anything for these search terms",
+    "search_history_title": "Recent"
   },
   "settings": {
     "about": {
@@ -553,6 +555,7 @@
     "add_publishable_content": "Add content to publish",
     "change_content_visibility": "Change content visibility",
     "change_language": "Change language",
+    "delete_search_history": "Delete this query from search history",
     "emoji": "Emoji",
     "explore_links_intro": "These news stories are being talked about by people on this and other servers of the decentralized network right now.",
     "explore_posts_intro": "These posts from this and other servers in the decentralized network are gaining traction on this server right now.",


### PR DESCRIPTION
This PR adds a search history functionality.

Each selected / executed search is added to the search history. Search history elements are presented in reversed execution order, ie. the most recent searches are appearing at top.

Individual search history can be deleted, or even the full search history can be deleted by "Clear all"

Search history is persisted to IndexedDB, to survive session termination or browser close.

Fixes #633 
![elk](https://user-images.githubusercontent.com/7863452/216835337-493e545a-0381-40c9-a2d0-3e4d5ec1c4da.gif)

