### PR TITLE
perf: tree-shake dependencies from server

### DIFF
--- a/components/common/CommonInputImage.vue
+++ b/components/common/CommonInputImage.vue
@@ -35,6 +35,8 @@ const previewImage = ref('')
 const imageSrc = computed<string>(() => previewImage.value || defaultImage.value)
 
 const pickImage = async () => {
+  if (process.server)
+    return
   const image = await fileOpen({
     description: 'Image',
     mimeTypes: props.allowedFileTypes,

--- a/components/modal/ModalMediaPreviewCarousel.vue
+++ b/components/modal/ModalMediaPreviewCarousel.vue
@@ -21,7 +21,7 @@ const { modelValue } = defineModel<{
 const target = ref()
 
 const animateTimeout = useTimeout(10)
-const reduceMotion = useReducedMotion()
+const reduceMotion = process.server ? ref(false) : useReducedMotion()
 
 const canAnimate = computed(() => !reduceMotion.value && animateTimeout.value)
 

--- a/components/tiptap/TiptapEmojiList.vue
+++ b/components/tiptap/TiptapEmojiList.vue
@@ -12,6 +12,9 @@ const { items, command } = defineProps<{
 }>()
 
 const emojis = computed(() => {
+  if (process.server)
+    return []
+
   return items.map((item: CustomEmoji | Emoji) => {
     if (isCustomEmoji(item)) {
       return {

--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -150,6 +150,8 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
   }
 
   async function pickAttachments() {
+    if (process.server)
+      return
     const mimeTypes = currentInstance.value!.configuration?.mediaAttachments.supportedMimeTypes
     const files = await fileOpen({
       description: 'Attachments',

--- a/composables/tiptap.ts
+++ b/composables/tiptap.ts
@@ -1,3 +1,4 @@
+import type { Editor } from '@tiptap/vue-3'
 import { Extension, useEditor } from '@tiptap/vue-3'
 import Placeholder from '@tiptap/extension-placeholder'
 import Document from '@tiptap/extension-document'
@@ -27,6 +28,9 @@ export interface UseTiptapOptions {
 }
 
 export function useTiptap(options: UseTiptapOptions) {
+  if (process.server)
+    return { editor: ref<Editor | undefined>() }
+
   const {
     autofocus,
     content,

--- a/composables/tiptap/suggestion.ts
+++ b/composables/tiptap/suggestion.ts
@@ -16,18 +16,20 @@ export { Emoji }
 export type CustomEmoji = (mastodon.v1.CustomEmoji & { custom: true })
 export const isCustomEmoji = (emoji: CustomEmoji | Emoji): emoji is CustomEmoji => !!(emoji as CustomEmoji).custom
 
-export const TiptapMentionSuggestion: Partial<SuggestionOptions> = {
-  pluginKey: new PluginKey('mention'),
-  char: '@',
-  async items({ query }) {
-    if (query.length === 0)
-      return []
+export const TiptapMentionSuggestion: Partial<SuggestionOptions> = process.server
+  ? {}
+  : {
+      pluginKey: new PluginKey('mention'),
+      char: '@',
+      async items({ query }) {
+        if (query.length === 0)
+          return []
 
-    const results = await useMastoClient().v2.search({ q: query, type: 'accounts', limit: 25, resolve: true })
-    return results.accounts
-  },
-  render: createSuggestionRenderer(TiptapMentionList),
-}
+        const results = await useMastoClient().v2.search({ q: query, type: 'accounts', limit: 25, resolve: true })
+        return results.accounts
+      },
+      render: createSuggestionRenderer(TiptapMentionList),
+    }
 
 export const TiptapHashtagSuggestion: Partial<SuggestionOptions> = {
   pluginKey: new PluginKey('hashtag'),
@@ -52,7 +54,7 @@ export const TiptapEmojiSuggestion: Partial<SuggestionOptions> = {
   pluginKey: new PluginKey('emoji'),
   char: ':',
   async items({ query }): Promise<(CustomEmoji | Emoji)[]> {
-    if (query.length === 0)
+    if (process.server || query.length === 0)
       return []
 
     if (currentCustomEmojis.value.emojis.length === 0)

--- a/composables/users.ts
+++ b/composables/users.ts
@@ -19,7 +19,7 @@ import { useAsyncIDBKeyval } from '~/composables/idb'
 
 const mock = process.mock
 
-const initializeUsers = async (): Promise<Ref<UserLogin[]> | RemovableRef<UserLogin[]>> => {
+const initializeUsers = (): Promise<Ref<UserLogin[]> | RemovableRef<UserLogin[]>> | Ref<UserLogin[]> | RemovableRef<UserLogin[]> => {
   let defaultUsers = mock ? [mock.user] : []
 
   // Backward compatibility with localStorage
@@ -34,7 +34,7 @@ const initializeUsers = async (): Promise<Ref<UserLogin[]> | RemovableRef<UserLo
 
   const users = process.server
     ? ref<UserLogin[]>(defaultUsers)
-    : await useAsyncIDBKeyval<UserLogin[]>(STORAGE_KEY_USERS, defaultUsers, { deep: true })
+    : useAsyncIDBKeyval<UserLogin[]>(STORAGE_KEY_USERS, defaultUsers, { deep: true })
 
   if (removeUsersOnLocalStorage)
     globalThis.localStorage.removeItem(STORAGE_KEY_USERS)
@@ -42,7 +42,7 @@ const initializeUsers = async (): Promise<Ref<UserLogin[]> | RemovableRef<UserLo
   return users
 }
 
-const users = await initializeUsers()
+const users = process.server ? initializeUsers() : await initializeUsers()
 const nodes = useLocalStorage<Record<string, any>>(STORAGE_KEY_NODES, {}, { deep: true })
 const currentUserHandle = useLocalStorage<string>(STORAGE_KEY_CURRENT_USER_HANDLE, mock ? mock.user.account.id : '')
 export const instanceStorage = useLocalStorage<Record<string, mastodon.v1.Instance>>(STORAGE_KEY_SERVERS, mock ? mock.server : {}, { deep: true })

--- a/composables/users.ts
+++ b/composables/users.ts
@@ -42,7 +42,7 @@ const initializeUsers = (): Promise<Ref<UserLogin[]> | RemovableRef<UserLogin[]>
   return users
 }
 
-const users = process.server ? initializeUsers() : await initializeUsers()
+const users = process.server ? initializeUsers() as Ref<UserLogin[]> | RemovableRef<UserLogin[]> : await initializeUsers()
 const nodes = useLocalStorage<Record<string, any>>(STORAGE_KEY_NODES, {}, { deep: true })
 const currentUserHandle = useLocalStorage<string>(STORAGE_KEY_CURRENT_USER_HANDLE, mock ? mock.user.account.id : '')
 export const instanceStorage = useLocalStorage<Record<string, mastodon.v1.Instance>>(STORAGE_KEY_SERVERS, mock ? mock.server : {}, { deep: true })

--- a/mocks/class.ts
+++ b/mocks/class.ts
@@ -1,0 +1,3 @@
+export default class SomeClass {
+
+}

--- a/mocks/eventemitter.ts
+++ b/mocks/eventemitter.ts
@@ -1,0 +1,3 @@
+export default class EventEmitter {
+
+}

--- a/mocks/eventemitter.ts
+++ b/mocks/eventemitter.ts
@@ -1,3 +1,0 @@
-export default class EventEmitter {
-
-}

--- a/mocks/prosemirror.ts
+++ b/mocks/prosemirror.ts
@@ -1,0 +1,8 @@
+import proxy from 'unenv/runtime/mock/proxy'
+
+export const Plugin = proxy
+export const PluginKey = proxy
+export const Decoration = proxy
+export const DecorationSet = proxy
+
+export { proxy as default }

--- a/mocks/tiptap.ts
+++ b/mocks/tiptap.ts
@@ -1,0 +1,17 @@
+import proxy from 'unenv/runtime/mock/proxy'
+
+export const Extension = proxy
+export const useEditor = proxy
+export const EditorContent = proxy
+export const NodeViewContent = proxy
+export const NodeViewWrapper = proxy
+export const nodeViewProps = proxy
+export const Node = proxy
+export const mergeAttributes = proxy
+export const nodeInputRule = proxy
+export const nodePasteRule = proxy
+export const VueNodeViewRenderer = proxy
+export const findChildren = proxy
+export const VueRenderer = proxy
+
+export { proxy as default }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -128,10 +128,10 @@ export default defineNuxtConfig({
       },
     },
   },
-  build: {
-    transpile: ['masto'],
-  },
   nitro: {
+    alias: {
+      'isomorphic-ws': 'unenv/runtime/mock/proxy',
+    },
     esbuild: {
       options: {
         target: 'esnext',
@@ -148,6 +148,15 @@ export default defineNuxtConfig({
       const nuxt = useNuxt()
       config.virtual = config.virtual || {}
       config.virtual['#storage-config'] = `export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}`
+    },
+    'vite:extendConfig': function (config, { isServer }) {
+      if (isServer) {
+        const alias = config.resolve!.alias as Record<string, string>
+        alias.eventemitter = resolve('./mocks/eventemitter')
+        alias['shiki-es'] = 'unenv/runtime/mock/proxy'
+
+        config.ssr!.noExternal!.push('masto', '@fnando/sparkline')
+      }
     },
   },
   app: {

--- a/pages/settings/users/index.vue
+++ b/pages/settings/users/index.vue
@@ -12,6 +12,9 @@ useHeadFixed({
 const loggedInUsers = useUsers()
 
 async function exportTokens() {
+  if (process.server)
+    return
+
   if (!confirm('Please aware that the tokens represent the **full access** to your accounts, and should be treated as sensitive information. Are you sure you want to export the tokens?'))
     return
 
@@ -28,6 +31,8 @@ async function exportTokens() {
 }
 
 async function importTokens() {
+  if (process.server)
+    return
   const file = await fileOpen({
     description: 'Token File',
     mimeTypes: ['application/json'],


### PR DESCRIPTION
This takes the node server build output (including dependencies) from 23M -> 9.8M.

It also improves compatibility with cloudflare target, though I'm not sure we're fully there.