### PR TITLE
fix: only count 23 characters per link when composing

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -75,7 +75,8 @@ const characterCount = $computed(() => {
   // https://github.com/elk-zone/elk/issues/1651
   const maxLength = 23
 
-  length += [...text.matchAll(linkRegex)].reduce((sum, match) => sum - match[0].length + Math.min(maxLength, match[0].length), 0)
+  for (const [fullMatch] of text.matchAll(linkRegex))
+    length -= fullMatch.length - Math.min(maxLength, fullMatch.length)
 
   if (draft.mentions) {
     // + 1 is needed as mentions always need a space seperator at the end

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -64,7 +64,18 @@ const { editor } = useTiptap({
 })
 
 const characterCount = $computed(() => {
-  let length = stringLength(htmlToText(editor.value?.getHTML() || ''))
+  const text = htmlToText(editor.value?.getHTML() || '')
+
+  let length = stringLength(text)
+
+  // taken from https://github.com/mastodon/mastodon/blob/07f8b4d1b19f734d04e69daeb4c3421ef9767aac/app/lib/text_formatter.rb
+  const linkRegex = /(https?:\/\/(www\.)?|xmpp:)\S+/g
+
+  // maximum of 23 chars per link
+  // https://github.com/elk-zone/elk/issues/1651
+  const maxLength = 23
+
+  length += [...text.matchAll(linkRegex)].reduce((sum, match) => sum - match[0].length + Math.min(maxLength, match[0].length), 0)
 
   if (draft.mentions) {
     // + 1 is needed as mentions always need a space seperator at the end


### PR DESCRIPTION
Fix #1651 
limit length of links counting towards character limit to 23

Signed-off-by: Chris-Robin Ennen <chris-robin@ennen.dev>