### PR TITLE
fix(ui): Prevent word-wrap on "Replying To"

### DIFF
--- a/components/status/StatusReplyingTo.vue
+++ b/components/status/StatusReplyingTo.vue
@@ -27,14 +27,15 @@ const account = isSelf ? computed(() => status.account) : useAccountById(status.
     </template>
     <template v-else>
       <div i-ri-chat-1-line text-blue />
-      <i18n-t keypath="status.replying_to">
-        <template v-if="account">
-          <AccountInlineInfo :account="account" :link="false" />
-        </template>
-        <template v-else>
-          {{ $t('status.someone') }}
-        </template>
-      </i18n-t>
+      <div ws-nowrap>
+        <i18n-t keypath="status.replying_to" />
+      </div>
+      <template v-if="account">
+        <AccountInlineInfo :account="account" :link="false" />
+      </template>
+      <template v-else>
+        {{ $t('status.someone') }}
+      </template>
     </template>
   </NuxtLink>
 </template>


### PR DESCRIPTION
"Replying to" was breaking on small screens / mobile devices.

Before:
![image](https://user-images.githubusercontent.com/7863452/217181112-9447d7ff-0b6f-4aae-b49a-94f1dfec9030.png)

After:
![image](https://user-images.githubusercontent.com/7863452/217181177-9cabb9d5-22f4-412b-b602-f19ab066065d.png)
