### PR TITLE
feat: copy content warning when replying

### DIFF
--- a/composables/masto/statusDrafts.ts
+++ b/composables/masto/statusDrafts.ts
@@ -72,6 +72,8 @@ export function getReplyDraft(status: mastodon.v1.Status) {
       return getDefaultDraft({
         initialText: '',
         inReplyToId: status!.id,
+        sensitive: status.sensitive,
+        spoilerText: status.spoilerText,
         visibility: status.visibility,
         mentions: accountsToMention,
         language: status.language,


### PR DESCRIPTION
Automatically inserts content warnings when applicable.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/57513430/217455716-463fb04f-b423-43bb-9c19-e3f288c1bcae.png">
