### PR TITLE
feat(ui): Adding Mute/Block user/domain to the post dropdown menu as well

### DIFF
--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import { toggleBlockAccount, toggleBlockDomain, toggleMuteAccount } from '~~/composables/masto/relationship'
 
 const { account } = defineProps<{
   account: mastodon.v1.Account
@@ -11,46 +12,6 @@ const isSelf = $(useSelfAccount(() => account))
 
 const { t } = useI18n()
 const { client } = $(useMasto())
-
-const toggleMute = async () => {
-  if (!relationship!.muting && await openConfirmDialog({
-    title: t('confirm.mute_account.title', [account.acct]),
-    confirm: t('confirm.mute_account.confirm'),
-    cancel: t('confirm.mute_account.cancel'),
-  }) !== 'confirm')
-    return
-
-  relationship!.muting = !relationship!.muting
-  relationship = relationship!.muting
-    ? await client.v1.accounts.mute(account.id, {
-      // TODO support more options
-    })
-    : await client.v1.accounts.unmute(account.id)
-}
-
-const toggleBlockUser = async () => {
-  if (!relationship!.blocking && await openConfirmDialog({
-    title: t('confirm.block_account.title', [account.acct]),
-    confirm: t('confirm.block_account.confirm'),
-    cancel: t('confirm.block_account.cancel'),
-  }) !== 'confirm')
-    return
-
-  relationship!.blocking = !relationship!.blocking
-  relationship = await client.v1.accounts[relationship!.blocking ? 'block' : 'unblock'](account.id)
-}
-
-const toggleBlockDomain = async () => {
-  if (!relationship!.domainBlocking && await openConfirmDialog({
-    title: t('confirm.block_domain.title', [getServerName(account)]),
-    confirm: t('confirm.block_domain.confirm'),
-    cancel: t('confirm.block_domain.cancel'),
-  }) !== 'confirm')
-    return
-
-  relationship!.domainBlocking = !relationship!.domainBlocking
-  await client.v1.domainBlocks[relationship!.domainBlocking ? 'block' : 'unblock'](getServerName(account))
-}
 
 const toggleReblogs = async () => {
   if (!relationship!.showingReblogs && await openConfirmDialog({
@@ -115,16 +76,16 @@ const toggleReblogs = async () => {
           <CommonDropdownItem
             v-if="!relationship?.muting"
             :text="$t('menu.mute_account', [`@${account.acct}`])"
-            icon="i-ri:volume-up-fill"
+            icon="i-ri:volume-mute-line"
             :command="command"
-            @click="toggleMute()"
+            @click="toggleMuteAccount (relationship!, account)"
           />
           <CommonDropdownItem
             v-else
             :text="$t('menu.unmute_account', [`@${account.acct}`])"
-            icon="i-ri:volume-mute-line"
+            icon="i-ri:volume-up-fill"
             :command="command"
-            @click="toggleMute()"
+            @click="toggleMuteAccount (relationship!, account)"
           />
 
           <CommonDropdownItem
@@ -132,14 +93,14 @@ const toggleReblogs = async () => {
             :text="$t('menu.block_account', [`@${account.acct}`])"
             icon="i-ri:forbid-2-line"
             :command="command"
-            @click="toggleBlockUser()"
+            @click="toggleBlockAccount (relationship!, account)"
           />
           <CommonDropdownItem
             v-else
             :text="$t('menu.unblock_account', [`@${account.acct}`])"
             icon="i-ri:checkbox-circle-line"
             :command="command"
-            @click="toggleBlockUser()"
+            @click="toggleBlockAccount (relationship!, account)"
           />
 
           <template v-if="getServerName(account) !== currentServer">
@@ -148,14 +109,14 @@ const toggleReblogs = async () => {
               :text="$t('menu.block_domain', [getServerName(account)])"
               icon="i-ri:shut-down-line"
               :command="command"
-              @click="toggleBlockDomain()"
+              @click="toggleBlockDomain(relationship!, account)"
             />
             <CommonDropdownItem
               v-else
               :text="$t('menu.unblock_domain', [getServerName(account)])"
               icon="i-ri:restart-line"
               :command="command"
-              @click="toggleBlockDomain()"
+              @click="toggleBlockDomain(relationship!, account)"
             />
           </template>
         </template>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import { toggleBlockAccount, toggleBlockDomain, toggleMuteAccount, useRelationship } from '~~/composables/masto/relationship'
 
 const props = defineProps<{
   status: mastodon.v1.Status
@@ -245,6 +246,51 @@ const showFavoritedAndBoostedBy = () => {
               icon="i-ri:at-line"
               :command="command"
               @click="mentionUser(status.account)"
+            />
+
+            <CommonDropdownItem
+              v-if="!useRelationship(status.account).value?.muting"
+              :text="$t('menu.mute_account', [`@${status.account.acct}`])"
+              icon="i-ri:volume-mute-line"
+              :command="command"
+              @click="toggleMuteAccount(useRelationship(status.account).value!, status.account)"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.unmute_account', [`@${status.account.acct}`])"
+              icon="i-ri:volume-up-fill"
+              :command="command"
+              @click="toggleMuteAccount(useRelationship(status.account).value!, status.account)"
+            />
+
+            <CommonDropdownItem
+              v-if="!useRelationship(status.account).value?.blocking"
+              :text="$t('menu.block_account', [`@${status.account.acct}`])"
+              icon="i-ri:forbid-2-line"
+              :command="command"
+              @click="toggleBlockAccount(useRelationship(status.account).value!, status.account)"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.unblock_account', [`@${status.account.acct}`])"
+              icon="i-ri:checkbox-circle-line"
+              :command="command"
+              @click="toggleBlockAccount(useRelationship(status.account).value!, status.account)"
+            />
+
+            <CommonDropdownItem
+              v-if="!useRelationship(status.account).value?.domainBlocking"
+              :text="$t('menu.block_domain', [getServerName(status.account)])"
+              icon="i-ri:shut-down-line"
+              :command="command"
+              @click="toggleBlockDomain(useRelationship(status.account).value!, status.account)"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.unblock_domain', [getServerName(status.account)])"
+              icon="i-ri:restart-line"
+              :command="command"
+              @click="toggleBlockDomain(useRelationship(status.account).value!, status.account)"
             />
           </template>
         </template>

--- a/composables/masto/relationship.ts
+++ b/composables/masto/relationship.ts
@@ -31,3 +31,52 @@ async function fetchRelationships() {
   for (let i = 0; i < requested.length; i++)
     requested[i][1].value = relationships[i]
 }
+
+export async function toggleMuteAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.muting && await openConfirmDialog({
+    title: i18n.t('confirm.mute_account.title', [account.acct]),
+    confirm: i18n.t('confirm.mute_account.confirm'),
+    cancel: i18n.t('confirm.mute_account.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.muting = !relationship!.muting
+  relationship = relationship!.muting
+    ? await client.v1.accounts.mute(account.id, {
+      // TODO support more options
+    })
+    : await client.v1.accounts.unmute(account.id)
+}
+
+export async function toggleBlockAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.blocking && await openConfirmDialog({
+    title: i18n.t('confirm.block_account.title', [account.acct]),
+    confirm: i18n.t('confirm.block_account.confirm'),
+    cancel: i18n.t('confirm.block_account.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.blocking = !relationship!.blocking
+  relationship = await client.v1.accounts[relationship!.blocking ? 'block' : 'unblock'](account.id)
+}
+
+export async function toggleBlockDomain(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.domainBlocking && await openConfirmDialog({
+    title: i18n.t('confirm.block_domain.title', [getServerName(account)]),
+    confirm: i18n.t('confirm.block_domain.confirm'),
+    cancel: i18n.t('confirm.block_domain.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.domainBlocking = !relationship!.domainBlocking
+  await client.v1.domainBlocks[relationship!.domainBlocking ? 'block' : 'unblock'](getServerName(account))
+}


### PR DESCRIPTION
This PR adds parity functions, enabling Mute/ Block user/Block domain directly from the post dropdown menu, without the need to open the user's profile.

Fixes #1518