### PR TITLE
fix: remove alone vertical bar on start

### DIFF
--- a/composables/setups.ts
+++ b/composables/setups.ts
@@ -46,7 +46,7 @@ export function setupPageHeader() {
       if (titleTemplate.length)
         titleTemplate += ' | '
 
-      titleTemplate += `${t('app_name')}`
+      titleTemplate += t('app_name')
       if (buildInfo.env !== 'release')
         titleTemplate += ` (${buildInfo.env})`
 

--- a/composables/setups.ts
+++ b/composables/setups.ts
@@ -43,7 +43,10 @@ export function setupPageHeader() {
         titleTemplate = `${titleTemplate.slice(0, 60)}...${titleTemplate.endsWith('"') ? '"' : ''}`
       }
 
-      titleTemplate += ` | ${t('app_name')}`
+      if (titleTemplate.length)
+        titleTemplate += ' | '
+
+      titleTemplate += `${t('app_name')}`
       if (buildInfo.env !== 'release')
         titleTemplate += ` (${buildInfo.env})`
 


### PR DESCRIPTION
Just see on opening Elk, we can see empty vertical bar:

## ACTUAL
![title-actual](https://user-images.githubusercontent.com/2922851/217897626-b9477199-32d9-4bd1-917f-bfa202c06d28.gif)


## FIXED
![title-fixed](https://user-images.githubusercontent.com/2922851/217897647-b8f7edd6-a065-4a2d-9c2a-060c7e79a442.gif)

