### PR TITLE
feat(editor): Respect default privacy setting of the account

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -27,7 +27,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const draftState = useDraft(draftKey, initial)
-const { draft } = $(draftState)
+const { draft, isEmpty } = $(draftState)
 
 const {
   isExceedingAttachmentLimit, isUploading, failedAttachments, isOverDropZone,
@@ -48,6 +48,8 @@ const { editor } = useTiptap({
     set: (newVal) => {
       draft.params.status = newVal
       draft.lastUpdated = Date.now()
+      if (isEmpty)
+        clearEmptyDrafts()
     },
   }),
   placeholder: computed(() => placeholder ?? draft.params.inReplyToId ? t('placeholder.replying') : t('placeholder.default_1')),

--- a/composables/masto/statusDrafts.ts
+++ b/composables/masto/statusDrafts.ts
@@ -30,7 +30,7 @@ export function getDefaultDraft(options: Partial<Mutable<mastodon.v1.CreateStatu
     params: {
       status: status || '',
       inReplyToId,
-      visibility: visibility || 'public',
+      visibility: currentUser.value?.account.source.privacy || visibility || 'public',
       sensitive: sensitive ?? false,
       spoilerText: spoilerText || '',
       language: language || '', // auto inferred from current language on posting
@@ -141,7 +141,7 @@ export function directMessageUser(account: mastodon.v1.Account) {
 
 export function clearEmptyDrafts() {
   for (const key in currentUserDrafts.value) {
-    if (builtinDraftKeys.includes(key))
+    if (builtinDraftKeys.includes(key) && !isEmptyDraft(currentUserDrafts.value[key]))
       continue
     if (!currentUserDrafts.value[key].params || isEmptyDraft(currentUserDrafts.value[key]))
       delete currentUserDrafts.value[key]


### PR DESCRIPTION
This PR changes default privacy setting of a post by considering the account's preferenced privacy setting when starting composing a post.

Also fixed an existing issue that empty drafts were not always cleared.

Fixes #1040 #1199