### PR TITLE
fix: add margin on top of search width to make the border visible

### DIFF
--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -6,7 +6,7 @@ const { notifications } = useNotifications()
 </script>
 
 <template>
-  <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full>
+  <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full mt-1>
     <SearchWidget lg:ms-1 lg:me-5 hidden xl:block />
     <NavSideItem :text="$t('nav.search')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:search-line" hidden sm:block xl:hidden :command="command" />
 


### PR DESCRIPTION
By redoing a bit the sidenav logo padding (and removing the margin from sidenav content), the top border is cropped when we focus it (on canary):

## ACTUAL (https://main.elk.zone)
<img width="589" alt="Capture d’écran 2023-02-10 à 10 43 19" src="https://user-images.githubusercontent.com/2922851/218059164-194f47e8-fa57-47c2-bc9c-f706f81dbb97.png">

## FIXED
<img width="739" alt="Capture d’écran 2023-02-10 à 10 48 45" src="https://user-images.githubusercontent.com/2922851/218059826-df7e34e8-1f6a-4968-8eae-199217dae0ec.png">

