### PR TITLE
fix: default main content dir to ltr

### DIFF
--- a/composables/setups.ts
+++ b/composables/setups.ts
@@ -8,14 +8,14 @@ export function setupPageHeader() {
   const enablePinchToZoom = usePreferences('enablePinchToZoom')
 
   const localeMap = (locales.value as LocaleObject[]).reduce((acc, l) => {
-    acc[l.code!] = l.dir ?? 'auto'
+    acc[l.code!] = l.dir ?? 'ltr'
     return acc
   }, {} as Record<string, Directions>)
 
   useHeadFixed({
     htmlAttrs: {
       lang: () => locale.value,
-      dir: () => localeMap[locale.value] ?? 'auto',
+      dir: () => localeMap[locale.value] ?? 'ltr',
       class: () => enablePinchToZoom.value ? ['enable-pinch-to-zoom'] : [],
     },
     meta: [{


### PR DESCRIPTION
The list of locales from the `i18n` module contains explicit `dir` property for RTL languages. The rest of the LTR languages have `dir` `undefined`.

I believe it's sufficient to default the `html` tag `dir` to LTR, as the majority of the content on the page should be user language specific and not derived from the currently present post language _(and language direction)_.

`dir="auto"` infers the language direction from parsing the characters inside the element _(`html` in this case)_, until it finds **a character with a strong directionality**, according to [MDN `dir` docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir)

Fixes: #1569