### PR TITLE
fix(a11y): increase status action size on small and medium screens

### DIFF
--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -60,7 +60,7 @@ useCommand({
   >
     <CommonTooltip placement="bottom" :content="content">
       <div
-        rounded-full p4 sm:p-2
+        rounded-full p4 md:p-2
         v-bind="disabled ? {} : {
           'group-hover': groupHover,
           'group-focus-visible': groupHover,

--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -60,7 +60,7 @@ useCommand({
   >
     <CommonTooltip placement="bottom" :content="content">
       <div
-        rounded-full p2
+        rounded-full p4 sm:p-2
         v-bind="disabled ? {} : {
           'group-hover': groupHover,
           'group-focus-visible': groupHover,


### PR DESCRIPTION
Maybe we can change it to `md:p-2`: changed, see title

closes #1709