### PR TITLE
fix(i18n): better login description for single instance server

### DIFF
--- a/components/user/UserSignInEntry.vue
+++ b/components/user/UserSignInEntry.vue
@@ -10,7 +10,7 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
       </i18n-t>
     </p>
     <p text-sm text-secondary>
-      {{ $t('user.sign_in_desc') }}
+      {{ $t(singleInstanceServer ? 'user.single_instance_sign_in_desc' : 'user.sign_in_desc') }}
     </p>
     <button
       v-if="singleInstanceServer"

--- a/locales/en.json
+++ b/locales/en.json
@@ -570,6 +570,7 @@
     "sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts, or interact from your account on a different server.",
     "sign_in_notice_title": "Viewing {0} public data",
     "sign_out_account": "Sign out {0}",
+    "single_instance_sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts.",
     "tip_no_account": "If you don't have a Mastodon account yet, {0}.",
     "tip_register_account": "pick your server and register one"
   },

--- a/locales/es.json
+++ b/locales/es.json
@@ -570,6 +570,7 @@
     "sign_in_desc": "Inicia sesión para seguir perfiles o etiquetas, marcar cómo favorita, compartir y responder a publicaciones, o interactuar con un servidor diferente con tu usuario.",
     "sign_in_notice_title": "Viendo información pública de {0}",
     "sign_out_account": "Cerrar sesión {0}",
+    "single_instance_sign_in_desc": "Inicia sesión para seguir perfiles o etiquetas, marcar cómo favorita, compartir y responder a publicaciones.",
     "tip_no_account": "Si aún no tienes una cuenta Mastodon, {0}.",
     "tip_register_account": "selecciona tu servidor y registrate"
   },


### PR DESCRIPTION
The message in `UserSignInEntry` includes `, or interact from your account on a different server.`, on single instance server there is only 1 server, the default.