### PR TITLE
fix(i18n): update portuguese from Portugal translation

### DIFF
--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -428,6 +428,8 @@
         "label": "Aspeto",
         "profile_metadata": "Metadados de perfil",
         "profile_metadata_desc": "Pode ter até {0} itens expostos, em forma de tabela, no seu perfil",
+        "profile_metadata_label": "Rótulo",
+        "profile_metadata_value": "Conteúdo",
         "title": "Editar perfil"
       },
       "featured_tags": {


### PR DESCRIPTION
Add and translate 2 new keys:
- profile_metadata_label
- profile_metadata_value
