### PR TITLE
docs(i18n): include translation status in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ You can check current [translation status](https://docs.elk.zone/docs/guide/cont
 
 If you are updating a translation in your local environment, you can run the following commands to check the status:
 - from root folder: `nr prepare-translation-status`
-- change to `docs` folder and run docs dev server `cd docs && nr dev`
+- change to `docs` folder and run docs dev server `nr dev`
 - open `http://localhost:3000/docs/guide/contributing#translation-status` in your browser
 
 ### Adding a new language

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,13 @@ We've added some `UnoCSS` utilities styles to help you with that:
 
 We are using [vue-i18n](https://vue-i18n.intlify.dev/) via [nuxt-i18n](https://i18n.nuxtjs.org/) to handle internationalization.
 
+You can check current [translation status](https://elk-docs.netlify.app/docs/guide/contributing#translation-status): more instructions on table caption.
+
+If you are updating a translation in your local environment, you can run the following commands to check the status:
+- from root folder: `nr prepare-translation-status`
+- change to `docs` folder and run docs dev server `cd docs && nr dev`
+- open `http://localhost:3000/docs/guide/contributing#translation-status` in your browser
+
 ### Adding a new language
 
 1. Add a new file in [locales](./locales) folder with the language code as the filename.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ We've added some `UnoCSS` utilities styles to help you with that:
 
 We are using [vue-i18n](https://vue-i18n.intlify.dev/) via [nuxt-i18n](https://v8.i18n.nuxtjs.org/) to handle internationalization.
 
-You can check current [translation status](https://elk-docs.netlify.app/docs/guide/contributing#translation-status): more instructions on table caption.
+You can check current [translation status](https://docs.elk.zone/docs/guide/contributing#translation-status): more instructions on table caption.
 
 If you are updating a translation in your local environment, you can run the following commands to check the status:
 - from root folder: `nr prepare-translation-status`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ We've added some `UnoCSS` utilities styles to help you with that:
 
 ## Internationalization
 
-We are using [vue-i18n](https://vue-i18n.intlify.dev/) via [nuxt-i18n](https://i18n.nuxtjs.org/) to handle internationalization.
+We are using [vue-i18n](https://vue-i18n.intlify.dev/) via [nuxt-i18n](https://v8.i18n.nuxtjs.org/) to handle internationalization.
 
 You can check current [translation status](https://elk-docs.netlify.app/docs/guide/contributing#translation-status): more instructions on table caption.
 

--- a/docs/components/global/TranslationState.vue
+++ b/docs/components/global/TranslationState.vue
@@ -78,11 +78,15 @@ const copyToClipboard = async () => {
         <div>
           If you want to send a PR, click on <strong>Edit</strong> link on the corresponding translation file, it will open <strong>Codeflow</strong>:
           <NuxtLink
+            class="inline"
             target="_blank"
             href="https://developer.stackblitz.com/codeflow/working-in-codeflow-ide#making-a-pr-with-codeflow-ide"
             title="How to make a PR with Codeflow IDE (opens in new window)"
           >
             read the following guide
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+              <path fill="currentColor" d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h14v-7h2v7q0 .825-.587 1.413Q19.825 21 19 21Zm4.7-5.3l-1.4-1.4L17.6 5H14V3h7v7h-2V6.4Z" />
+            </svg>
           </NuxtLink>
         </div>
       </caption>
@@ -239,6 +243,7 @@ tr.expandable, tr.expandable td {
 }
 
 a.codeflow,
+a.inline,
 td.expandable div {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This PR also updates nuxt-i18n link: old one pointing to Nuxt 2 docs