### PR TITLE
fix: limit pinch scale to minimum 0.5

### DIFF
--- a/components/modal/ModalMediaPreviewCarousel.vue
+++ b/components/modal/ModalMediaPreviewCarousel.vue
@@ -64,7 +64,7 @@ const { isSwiping, lengthX, lengthY, direction } = useSwipe(target, {
 
 useGesture({
   onPinch({ offset: [distance, angle] }) {
-    set({ scale: 1 + distance / 200 })
+    set({ scale: Math.max(0.5, 1 + distance / 200) })
   },
   onMove({ movement: [x, y], dragging, pinching }) {
     if (dragging && !pinching)


### PR DESCRIPTION
I saw this zoom bug and it's also mentioned here: https://github.com/elk-zone/elk/pull/1620#issuecomment-1427096398

**Before**:
- On desktop, use pinch gesture on touchpad
- Zoom out of the image → Image scaled down
- Further pinching makes the `scale` to go negative thus flipping the image up-side-down

https://user-images.githubusercontent.com/2296/218365340-0683509c-b7c2-4fff-b663-2630aee4beca.mp4

**After**:
- Prevent the `scale` from becoming negative.
- I figured that might as well make the limit 0.5 instead of zero? I can't think of a reason for anyone to zoom out so much 😅

https://user-images.githubusercontent.com/2296/218365656-694c89a0-e6da-4208-93ce-9b9d2f02d87c.mp4

Tested on Chrome v109.0.5414.119 (Official Build) (arm64) and Edge v109.0.1518.78 (Official build) (arm64) on MacOS Ventura 13.2.