### PR TITLE
fix(ui): unintentionally hardcoded word order of status.replying_to

### DIFF
--- a/components/status/StatusReplyingTo.vue
+++ b/components/status/StatusReplyingTo.vue
@@ -27,15 +27,16 @@ const account = isSelf ? computed(() => status.account) : useAccountById(status.
     </template>
     <template v-else>
       <div i-ri-chat-1-line text-blue />
-      <div ws-nowrap>
-        <i18n-t keypath="status.replying_to" />
+      <div ws-nowrap flex>
+        <i18n-t keypath="status.replying_to">
+          <template v-if="account">
+            <AccountInlineInfo :account="account" :link="false" m-inline-1 />
+          </template>
+          <template v-else>
+            {{ $t('status.someone') }}
+          </template>
+        </i18n-t>
       </div>
-      <template v-if="account">
-        <AccountInlineInfo :account="account" :link="false" />
-      </template>
-      <template v-else>
-        {{ $t('status.someone') }}
-      </template>
     </template>
   </NuxtLink>
 </template>


### PR DESCRIPTION
- Fix #1663 that breaks the word order of translation
- To keep it one-line, make it a flexbox and wrap `<AccountInlinInfo>` with a little margin to compensate loss of word spacing; don't know if it's a good idea but looks best among what I tried

https://github.com/elk-zone/elk/blob/635d55befbb71e0f36a91b63d251099d6015c3bb/locales/tr-TR.json#L375

Before | After
:-: | :-:
![cevap veriliyor (account name) 👎 ](https://user-images.githubusercontent.com/84892012/218459001-aa2acd58-29bb-43a7-a22e-e759dad0badc.png) | ![(account name) cevap veriliyor 👍 ](https://user-images.githubusercontent.com/84892012/218459020-e29f0ae8-e38f-4e2d-8e52-8830ec7cdbea.png)