### PR TITLE
fix(i18n): use American spelling

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -6,6 +6,9 @@
     "favourite": "Favourite",
     "favourited": "Favourited"
   },
+  "menu": {
+    "show_favourited_and_boosted_by": "Show who favourited and boosted"
+  },
   "nav": {
     "favourites": "Favourites"
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -214,7 +214,7 @@
     "open_in_original_site": "Open in original site",
     "pin_on_profile": "Pin on profile",
     "share_post": "Share this post",
-    "show_favourited_and_boosted_by": "Show who favourited and boosted",
+    "show_favourited_and_boosted_by": "Show who favorited and boosted",
     "show_reblogs": "Show boosts from {0}",
     "show_untranslated": "Show untranslated",
     "toggle_theme": {


### PR DESCRIPTION
For consistency with the other occurrences of _favo(u)rite_

<img width="359" alt="Menu item “Show who favourited and boosted” in the Elk user interface" src="https://user-images.githubusercontent.com/5496284/218882838-c7e6a492-93b7-4fa9-bc56-05055afadf0a.png">