### PR TITLE
fix: return redirect for whatsapp user agent

### DIFF
--- a/plugins/social.server.ts
+++ b/plugins/social.server.ts
@@ -1,6 +1,6 @@
 import { sendRedirect } from 'h3'
 
-const BOT_RE = /bot\b|index|spider|facebookexternalhit|crawl|wget|slurp|mediapartners-google/i
+const BOT_RE = /bot\b|index|spider|facebookexternalhit|crawl|wget|slurp|mediapartners-google|whatsapp/i
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const route = useRoute()


### PR DESCRIPTION
Add the WhatsApp user-agent to the bot regex.

I don't use WhatsApp myself, but I tested this with Signal, which sends a `WhatsApp/2' user-agent for link previews.