### PR TITLE
fix: Spanish translation for request to follow is incorrect

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -35,7 +35,7 @@
     "posts_count": "{0} Publicaciones|{0} Publicación|{0} Publicaciones",
     "profile_description": "Encabezado del perfil de {0}",
     "profile_unavailable": "Perfil no disponible",
-    "request_follow": "Solicitud para seguirte",
+    "request_follow": "Solicitar seguirle",
     "unblock": "Desbloquear",
     "unfollow": "Dejar de seguir",
     "unmute": "Dejar de silenciar",


### PR DESCRIPTION
The current translation implies a request to follow you has been made (instead of requesting to follow someone). The phrase was also not stated as a verb, as the other actions.