### PR TITLE
fix: Custom-emoji size on editor revisited

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -39,7 +39,7 @@ body {
   vertical-align: text-bottom;
 }
 
-.content-editor .custom-emoji img,
+.content-editor img.custom-emoji,
 .custom-emoji img {
   max-height: 1.3em;
   max-width: 1.3em;


### PR DESCRIPTION
Referencing issue: #1551 
Referencing PR: #1503 

Thought I already fixed this, was kinda waiting it to be effective. Not thoroughly tested by me it seems, for this I apologize. There is an inconsistency, since everywhere else it's `.custom-emoji img` where as inside editor it is `img.custom-emoji`.

This time I tested it thoroughly and confirmed working:

![Screenshot from 2023-02-19 13-29-18](https://user-images.githubusercontent.com/1534150/219945250-822a753f-3554-42d7-b189-adbb1204519d.png)