### PR TITLE
fix: properly parse bolded italics

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -445,7 +445,7 @@ function replaceCustomEmoji(customEmojis: Record<string, mastodon.v1.CustomEmoji
 }
 
 const _markdownReplacements: [RegExp, (c: (string | Node)[]) => Node][] = [
-  [/\*\*\*(.*?)\*\*\*/g, c => h('b', null, [h('em', null, c)])],
+  [/\*\*\*(.*?)\*\*\*/g, ([c]) => h('b', null, [h('em', null, c)])],
   [/\*\*(.*?)\*\*/g, c => h('b', null, c)],
   [/\*(.*?)\*/g, c => h('em', null, c)],
   [/~~(.*?)~~/g, c => h('del', null, c)],


### PR DESCRIPTION
It would appear that the current markdown replacer function for bolded italics (line 448) that converts a match into an ultrahtml `h()` object doesn't expect an array in `c`'s place.
https://github.com/elk-zone/elk/blob/29b37e67c7675d65a554aac05f742922771484bf/composables/content-parse.ts#L447-L455

When supplied with c = `['foo']`, it simply puts `['foo']` in the elements children, which isn't properly parsed by Vue. If instead, it is in the form `'foo'`, it's parsed properly.

I'm not too familiar with ultrahtml but this seems to work for me and seems to be the root cause as far as I can tell.

Before: (Screenshot taken from mocked dev, but I'd guess viewing [this](https://universeodon.com/@yenche123/109895545528086301) would yield similar results)
![image](https://user-images.githubusercontent.com/5954994/220776027-89d5cde0-45e0-424a-acef-2f04fae4c8c2.png)

After:
![image](https://user-images.githubusercontent.com/5954994/220775825-60e348a5-a2d0-4acb-9393-e70de53c0b6a.png)


Fixes #1804.