### PR TITLE
fix: unswap uid/gid in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ARG GID=911
 
 # Create a dedicated user and group
 RUN set -eux; \
-    addgroup -g $UID elk; \
-    adduser -u $GID -D -G elk elk;
+    addgroup -g $GID elk; \
+    adduser -u $UID -D -G elk elk;
 
 USER elk
 


### PR DESCRIPTION
UID and GID arguments where swapped