### PR TITLE
fix(default): update layout to use dynamic vh

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,7 +18,7 @@ const isGrayscale = usePreferences('grayscaleMode')
   <div h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''" data-tauri-drag-region>
     <main flex w-full mxa lg:max-w-80rem class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_minmax(600px,2fr)_1fr]">
       <aside class="native:w-auto w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 zen-hide" hidden sm:flex justify-end xl:me-4 native:me-0 relative>
-        <div sticky top-0 w-20 xl:w-100 h-screen flex="~ col" lt-xl-items-center>
+        <div sticky top-0 w-20 xl:w-100 h-100dvh flex="~ col" lt-xl-items-center>
           <slot name="left">
             <div flex="~ col" overflow-y-auto justify-between h-full max-w-full overflow-x-hidden>
               <NavTitle />
@@ -60,7 +60,7 @@ const isGrayscale = usePreferences('grayscaleMode')
         </div>
       </div>
       <aside v-if="isHydrated && !wideLayout" class="hidden lg:w-1/5 xl:w-1/4 sm:none xl:block native:w-full zen-hide">
-        <div sticky top-0 h-screen flex="~ col" gap-2 py3 ms-2>
+        <div sticky top-0 h-100dvh flex="~ col" gap-2 py3 ms-2>
           <slot name="right">
             <div flex-auto />
 

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -130,6 +130,11 @@ export default defineConfig({
       res += `\n${res.replace('{scrollbar-width:none;}', '::-webkit-scrollbar{display: none;}')}`
       return res
     }],
+    [/^h-100dvh$/, (_, { constructCSS }) => {
+      let res = constructCSS({ height: '100vh' })
+      res += `\n${res.replace('{height:100vh;}', '{height:100vh;height:100dvh;}')}`
+      return res
+    }],
     ['box-shadow-outline', { 'box-shadow': '0 0 0 1px var(--c-primary)' }],
   ],
 })


### PR DESCRIPTION
This PR fixes issue #1279 which overflows the user avatar section and footer. The issue is documented [here](https://web.dev/viewport-units/), where 100vh will take 100% of viewport height regardless of UI chrome. This is solved using the `dvh` unit which changes based on the UI.

This issue only affects tablets at >1280px width (eg: 11/13in iPad Pro).

I'm not very knowledgable in unocss syntax, but copied the `scrollbar-hide` implementation since it applies a non-standard CSS rule-set. Reason being is if they are applied directly to tag (eg: `<div h-screen h-100dvh>`, it can not apply correctly if `h-screen` is after `h-100dvh` in the stylesheet.

The CSS rule I created merges the two to read like so:

```
.h-100dvh {
  height: 100vh;
  height: 100dvh;
}
```

Where it will apply 100dvh where it is [supported](https://caniuse.com/mdn-css_types_length_viewport_percentage_units_dynamic), and 100vh elsewhere.