### PR TITLE
fix: display correct percentages for multiple choice polls

### DIFF
--- a/components/status/StatusPoll.vue
+++ b/components/status/StatusPoll.vue
@@ -57,7 +57,7 @@ const votersCount = $computed(() => poll.votersCount ?? poll.votesCount ?? 0)
       <div
         v-for="(option, index) of poll.options"
         :key="index" py-1 relative
-        :style="{ '--bar-width': toPercentage((option.votesCount || 0) / poll.votesCount) }"
+        :style="{ '--bar-width': toPercentage((option.votesCount || 0) / votersCount) }"
       >
         <div flex justify-between pb-2 w-full>
           <span inline-flex align-items>


### PR DESCRIPTION
Percentages currently use `votesCount`, regardless of whether the poll is a regular poll or a multiple choice one. It should instead read the computed `votersCount`, which is already used to display the (correct) percentages.

Example poll ([link](https://mastodon.social/@emilydoesastro@mstdn.social/109880570959162892)):
![image](https://user-images.githubusercontent.com/5954994/221266687-c56b3e88-872e-4a7a-9e00-ecb7ac04758b.png)

Before ([elk link](https://elk.zone/mastodon.social/@emilydoesastro@mstdn.social/109880570959162892)):
![image](https://user-images.githubusercontent.com/5954994/221270292-8e2c6b77-5e50-41b0-87bd-a480116f2b76.png)

After ([deploy preview link](https://deploy-preview-1821--elk-zone.netlify.app/universeodon.com/@emilydoesastro@mstdn.social/109880570340375814)):
![image](https://user-images.githubusercontent.com/5954994/221270373-805a106f-a2c9-4d70-96a2-430aa19c162f.png)


Fixes #1780.