### PR TITLE
fix: resize large images attachments on upload

### DIFF
--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -122,7 +122,7 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
 
   const maxPixels
     = currentInstance.value!.configuration?.mediaAttachments?.imageMatrixLimit
-      ?? 4096**2
+      ?? 4096 ** 2
 
   const loadImage = (inputFile: Blob) => new Promise<HTMLImageElement>((resolve, reject) => {
     const url = URL.createObjectURL(inputFile)

--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -122,7 +122,7 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
 
   const maxPixels
     = currentInstance.value!.configuration?.mediaAttachments?.imageMatrixLimit
-      ?? 16777216 // 4096x4096
+      ?? 4096**2
 
   const loadImage = (inputFile: Blob) => new Promise<HTMLImageElement>((resolve, reject) => {
     const url = URL.createObjectURL(inputFile)

--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -120,6 +120,55 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
   let failedAttachments = $ref<MediaAttachmentUploadError[]>([])
   const dropZoneRef = ref<HTMLDivElement>()
 
+  const maxPixels
+    = currentInstance.value!.configuration?.mediaAttachments?.imageMatrixLimit
+      ?? 16777216 // 4096x4096
+
+  const loadImage = (inputFile: Blob) => new Promise<HTMLImageElement>((resolve, reject) => {
+    const url = URL.createObjectURL(inputFile)
+    const img = new Image()
+
+    img.onerror = err => reject(err)
+    img.onload = () => resolve(img)
+
+    img.src = url
+  })
+
+  function resizeImage(img: CanvasImageSource, type = 'image/png'): Promise<Blob | null> {
+    const { width, height } = img
+
+    const aspectRatio = (width as number) / (height as number)
+
+    const canvas = document.createElement('canvas')
+
+    const resizedWidth = canvas.width = Math.round(Math.sqrt(maxPixels * aspectRatio))
+    const resizedHeight = canvas.height = Math.round(Math.sqrt(maxPixels / aspectRatio))
+
+    const context = canvas.getContext('2d')
+
+    context?.drawImage(img, 0, 0, resizedWidth, resizedHeight)
+
+    return new Promise((resolve) => {
+      canvas.toBlob(resolve, type)
+    })
+  }
+
+  async function processImageFile(file: File) {
+    const image = await loadImage(file) as HTMLImageElement
+
+    if (image.width * image.height > maxPixels)
+      file = await resizeImage(image, file.type) as File
+
+    return file
+  }
+
+  async function processFile(file: File) {
+    if (file.type.startsWith('image/'))
+      return await processImageFile(file)
+
+    return file
+  }
+
   async function uploadAttachments(files: File[]) {
     isUploading = true
     failedAttachments = []
@@ -131,7 +180,7 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
         isExceedingAttachmentLimit = false
         try {
           const attachment = await client.v1.mediaAttachments.create({
-            file,
+            file: await processFile(file),
           })
           draft.attachments.push(attachment)
         }

--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -154,12 +154,19 @@ export function useUploadMediaAttachment(draftRef: Ref<Draft>) {
   }
 
   async function processImageFile(file: File) {
-    const image = await loadImage(file) as HTMLImageElement
+    try {
+      const image = await loadImage(file) as HTMLImageElement
 
-    if (image.width * image.height > maxPixels)
-      file = await resizeImage(image, file.type) as File
+      if (image.width * image.height > maxPixels)
+        file = await resizeImage(image, file.type) as File
 
-    return file
+      return file
+    }
+    catch (e) {
+      // Resize failed, just use the original file
+      console.error(e)
+      return file
+    }
   }
 
   async function processFile(file: File) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -206,7 +206,7 @@ export default defineNuxtConfig({
           'font-src': ['\'self\''],
           'form-action': ['\'none\''],
           'frame-ancestors': ['\'none\''],
-          'img-src': ['\'self\'', 'https:', 'http:', 'data:'],
+          'img-src': ['\'self\'', 'https:', 'http:', 'data:', 'blob:'],
           'media-src': ['\'self\'', 'https:', 'http:'],
           'object-src': ['\'none\''],
           'script-src': ['\'self\'', '\'unsafe-inline\'', '\'wasm-unsafe-eval\''],


### PR DESCRIPTION
Mastodon's API has a [4096x4096px file size](https://github.com/mastodon/mastodon/blob/730bb3e211a84a2f30e3e2bbeae3f77149824a68/app/models/concerns/attachmentable.rb#L8) limit on image attachments, its web client however simply resizes larger images on the client-side to an acceptable size for the API request.

This PR brings this functionality to elk. The approach is [based on theirs](https://github.com/mastodon/mastodon/blob/730bb3e211a84a2f30e3e2bbeae3f77149824a68/app/javascript/mastodon/utils/resize_image.js), though re-written by myself in a much more stripped down way.

To test, try uploading a large attachment [like this one](https://unsplash.com/photos/7f4WaNrR4uo/download?force=true).

Fixes #1702