### PR TITLE
fix: avoid bar width division by zero

### DIFF
--- a/components/status/StatusPoll.vue
+++ b/components/status/StatusPoll.vue
@@ -57,7 +57,7 @@ const votersCount = $computed(() => poll.votersCount ?? poll.votesCount ?? 0)
       <div
         v-for="(option, index) of poll.options"
         :key="index" py-1 relative
-        :style="{ '--bar-width': toPercentage((option.votesCount || 0) / votersCount) }"
+        :style="{ '--bar-width': toPercentage((option.votesCount ?? 0) === 0 ? 0 : option.votesCount! / votersCount) }"
       >
         <div flex justify-between pb-2 w-full>
           <span inline-flex align-items>
@@ -67,7 +67,7 @@ const votersCount = $computed(() => poll.votersCount ?? poll.votesCount ?? 0)
           <span text-primary-active> {{ formatPercentage(votersCount > 0 ? (option.votesCount || 0) / votersCount : 0) }}</span>
         </div>
         <div class="bg-gray/40" rounded-l-sm rounded-r-lg h-5px w-full>
-          <div bg-primary-active h-full class="w-[var(--bar-width)]" />
+          <div bg-primary-active h-full min-w="1%" class="w-[var(--bar-width)]" />
         </div>
       </div>
     </template>

--- a/components/status/StatusPoll.vue
+++ b/components/status/StatusPoll.vue
@@ -57,7 +57,7 @@ const votersCount = $computed(() => poll.votersCount ?? poll.votesCount ?? 0)
       <div
         v-for="(option, index) of poll.options"
         :key="index" py-1 relative
-        :style="{ '--bar-width': toPercentage((option.votesCount ?? 0) === 0 ? 0 : option.votesCount! / votersCount) }"
+        :style="{ '--bar-width': toPercentage(votersCount === 0 ? 0 : (option.votesCount ?? 0) / votersCount) }"
       >
         <div flex justify-between pb-2 w-full>
           <span inline-flex align-items>


### PR DESCRIPTION
If `votersCount` is 0, then we possibly have a 0/0 resulting in a NaN `--bar-width`, which is displayed as a 100%.

This PR fixes this. Also, I added a minimum width of 1% which isn't quite related to this issue but Mastodon does it. If that's not preferred, then let me know and I'll remove it.

Original ([mastodon](https://mastodon.social/@probatio/109930593995266040)):
![image](https://user-images.githubusercontent.com/5954994/221406240-b2a68a68-c2a2-4684-b232-d11f54014718.png)

Elk canary ([link](https://main.elk.zone/universeodon.com/@probatio@mastodon.social/109930593983351304)):
![image](https://user-images.githubusercontent.com/5954994/221406092-f1e8c127-72c7-478c-8ea3-7540ae2759a4.png)

Patched ([link](https://deploy-preview-1826--elk-zone.netlify.app/universeodon.com/@probatio@mastodon.social/109930593983351304)):
![image](https://user-images.githubusercontent.com/5954994/221406254-f949b324-9e05-44e8-8b17-d4020efb3882.png)
