### PR TITLE
fix: allow parsing codeblocks with multiple text nodes in children

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -162,6 +162,13 @@ export function htmlToText(html: string) {
   }
 }
 
+export function recursiveTreeToText(input: Node): string {
+  if (input && input.children && input.children.length > 0)
+    return input.children.map((n: Node) => recursiveTreeToText(n)).join('')
+  else
+    return treeToText(input)
+}
+
 export function treeToText(input: Node): string {
   let pre = ''
   let body = ''

--- a/composables/content-render.ts
+++ b/composables/content-render.ts
@@ -107,7 +107,7 @@ function handleCodeBlock(el: Node) {
     const codeEl = el.children[0] as Node
     const classes = codeEl.attributes.class as string
     const lang = classes?.split(/\s/g).find(i => i.startsWith('language-'))?.replace('language-', '')
-    const code = recursiveTreeToText(codeEl)
+    const code = codeEl.children && codeEl.children.length > 0 ? recursiveTreeToText(codeEl) : ''
     return h(ContentCode, { lang, code: encodeURIComponent(code) })
   }
 }

--- a/composables/content-render.ts
+++ b/composables/content-render.ts
@@ -107,7 +107,7 @@ function handleCodeBlock(el: Node) {
     const codeEl = el.children[0] as Node
     const classes = codeEl.attributes.class as string
     const lang = classes?.split(/\s/g).find(i => i.startsWith('language-'))?.replace('language-', '')
-    const code = codeEl.children[0] ? treeToText(codeEl.children[0]) : ''
+    const code = recursiveTreeToText(codeEl)
     return h(ContentCode, { lang, code: encodeURIComponent(code) })
   }
 }


### PR DESCRIPTION
Currently, if we have a `<pre>` with a nested `<code>`, we assume that there's only one child within that code block. But in some cases, we might find some `<br>`s in there causing there to be more than just one child. So we don't want to only consume the first child and throw the rest away, rather we want to properly consume each child.

This could be done iteratively or recursively. I chose to go with the recursive solution since since we might possibly run into a few odd situations in which code blocks (for whatever reason) might have children that then have other nested children (not something to normally expect, but then again, who expects `<br>`s in `<code>`s like what happened just now?).

Before screenshot ([canary link](https://main.elk.zone/social.treehouse.systems/@alyssa/109933427007257424)):
![image](https://user-images.githubusercontent.com/5954994/222424772-8aa6b855-72b6-43a6-8d12-3a9cd88b464f.png)

Patched screenshot:
(Don't have a deploy link for this one cause it would redirect to a different URL for some reason, but you could pull this and test it out locally using [this link](http://localhost:5314/social.treehouse.systems/@alyssa/109933427007257424))
(Regarding the redirect; this is important, if on `.../social.treehouse.systems/@alyssa/...` the content parsed is the buggy content which this pr fixes, if it instead is the `.../mastodon.social/@alyssa@treehouse.systems/...`, then it's fed different content that's parsed without the pre tag which this pr does not affect since the bug does not take action there)
![image](https://user-images.githubusercontent.com/5954994/222425086-661fddd0-00ab-437c-a9e7-cdcd99ebe5ff.png)


Fixes #1840.