### PR TITLE
fix: only use username part of mention

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -71,12 +71,18 @@ const characterCount = $computed(() => {
   // taken from https://github.com/mastodon/mastodon/blob/07f8b4d1b19f734d04e69daeb4c3421ef9767aac/app/lib/text_formatter.rb
   const linkRegex = /(https?:\/\/(www\.)?|xmpp:)\S+/g
 
+  // taken from https://github.com/mastodon/mastodon/blob/af578e/app/javascript/mastodon/features/compose/util/counter.js
+  const countableMentionRegex = /(^|[^/\w])@(([a-z0-9_]+)@[a-z0-9.-]+[a-z0-9]+)/ig
+
   // maximum of 23 chars per link
   // https://github.com/elk-zone/elk/issues/1651
   const maxLength = 23
 
   for (const [fullMatch] of text.matchAll(linkRegex))
     length -= fullMatch.length - Math.min(maxLength, fullMatch.length)
+
+  for (const [fullMatch, before, handle, username] of text.matchAll(countableMentionRegex))
+    length -= fullMatch.length - (before + username).length - 1 // - 1 for the @
 
   if (draft.mentions) {
     // + 1 is needed as mentions always need a space seperator at the end


### PR DESCRIPTION
As mentioned from the [docs link](https://docs.joinmastodon.org/user/posting/#mentions) in the [referenced issue](https://github.com/elk-zone/elk/issues/1803)
> You can mention users by typing out their full address, e.g. @[alice@example.com](mailto:alice@example.com). Note that any usage of@word will be interpreted as mentioning the local user with the username word, if that user exists. Only the username part will count against your character limit – the domain is not counted.

I've taken a look at how mastodon themselves deal with this and used their regex (with attribution in a comment) since I assume theirs would handle any weird edge cases.

Mastodon:
![image](https://user-images.githubusercontent.com/5954994/222538201-a6c19be3-446c-4949-9fd3-9bb4b32ff47f.png)

Elk canary (incorrect, 6 characters expected):
![image](https://user-images.githubusercontent.com/5954994/222538316-f7fdc684-c986-42a7-98de-1da867321cc7.png)


This patch:
![image](https://user-images.githubusercontent.com/5954994/222538092-b9af04f4-aa29-4f5f-b3b0-057aa28bddb6.png)

This should be fine. I tested it with a bunch of random text and it matches up with lengths reported by mastodon.

Fixes #1803.