### PR TITLE
docs: Add content for feature page

### DIFF
--- a/docs/content/1.guide/2.features.md
+++ b/docs/content/1.guide/2.features.md
@@ -6,9 +6,77 @@
 
 <!-- once the UI is more stable, we can add screenshots -->
 
+## Multiple accounts
+
+Elk supports logging into multiple Mastodon accounts.
+Select the three vertical dot menu button next to your profile picture on a desktop or your profile picture directly on mobile devices, then select **Add an existing account**.
+
+Switch between your accounts quickly:
+
+- On the desktop, select the profile picture for the account to use.
+- On mobile devices or smaller screens, tap your profile picture to see a list of signed-in accounts, then select the account to use.
+
+## Rich text
+
+Elk renders basic Markdown-like text markup in post texts as the expected HTML.
+
+- Use one asterisk (`*`) before and after a word or phrase to *italicize** the text.
+- Surround the text with two asterisks (`**word**`) to **bold** it.
+
+::alert{type="warning"}
+Many apps do not support Markdown in posts.
+Mastodon itself does not support Markdown in posts.
+
+Users who see your posts from other apps or the Mastodon web app see standard, unrendered Markdown text.
+::
+
+## Code blocks
+
+Elk supports adding code blocks to your posts.
+
+When writing the post, select the editor tools and then Code Block to add a block to your post.
+Paste or type in the contents.
+
+Once you've added the block, you can select the language to use for code highlighting.
+Hover over the right side of the code block to see the drop down box, then select the dropdown to see the full list of supported languages.
+
+Options include:
+
+* plain
+* c
+* cpp
+* csharp
+* css
+* dart
+* go
+* html
+* java
+* javascript
+* jsx
+* kotlin
+* python
+* rust
+* svelte
+* swift
+* tsx
+* typescript
+* vue
+
+## Connecting linked posts in the timeline
+
+Elk reorders timeline posts that are connected to each other to display them in a connected thread in the timelines.
+This helps keep the conversation context for a post and its replies.
+
+
+## Improved notifications
+
+Elk groups boosts and likes to the same post when they occur together in the notification history.
+Rather than displaying each like and boost with the post contents as in other apps, Elk displays the post one time with a list of the users who liked or boosted the post.
+This greatly simplifies your notification history.
+
+<!-- ## GitHub HTML cards -->
+
+
 <!-- - markdown support
-- code blocks
-- reordering and connecting posts in timelines
-- multi account
 - GitHub HTML cards
 - and so on... -->


### PR DESCRIPTION
Adds initial set of content to the features page of the docs.
Discusses 
- Multiple accounts
- Rich text
- Code blocks
- Connected linked posts
- Improved notifications
