### PR TITLE
fix: disallow media description exceeding limits

### DIFF
--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -15,6 +15,9 @@ const emit = defineEmits<{
   (evt: 'setDescription', description: string): void
 }>()
 
+// from https://github.com/mastodon/mastodon/blob/dfa984/app/models/media_attachment.rb#L40
+const maxDescriptionLength = 1500
+
 const isEditDialogOpen = ref(false)
 const description = ref(props.attachment.description ?? '')
 const toggleApply = () => {
@@ -55,7 +58,10 @@ const toggleApply = () => {
           </h1>
           <div flex flex-col gap-2>
             <textarea v-model="description" p-3 h-50 bg-base rounded-2 border-strong border-1 md:w-100 />
-            <button btn-outline @click="toggleApply">
+            <div flex flex-row-reverse>
+              <PublishCharacterCounter :length="description.length" :max="maxDescriptionLength" />
+            </div>
+            <button btn-outline :disabled="description.length > maxDescriptionLength" @click="toggleApply">
               {{ $t('action.apply') }}
             </button>
           </div>

--- a/components/publish/PublishCharacterCounter.vue
+++ b/components/publish/PublishCharacterCounter.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const props = defineProps<{
+  max: number
+  length: number
+}>()
+</script>
+
+<template>
+  <div dir="ltr" pointer-events-none pe-1 pt-2 text-sm tabular-nums text-secondary flex gap="0.5" :class="{ 'text-rose-500': length > max }">
+    {{ length ?? 0 }}<span text-secondary-light>/</span><span text-secondary-light>{{ max }}</span>
+  </div>
+</template>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -97,6 +97,10 @@ const characterCount = $computed(() => {
   return length
 })
 
+const isExceedingCharacterLimit = $computed(() => {
+  return characterCount > characterLimit.value
+})
+
 const postLanguageDisplay = $computed(() => languagesNameList.find(i => i.code === (draft.params.language || preferredLanguage))?.nativeName)
 
 async function handlePaste(evt: ClipboardEvent) {
@@ -292,9 +296,7 @@ defineExpose({
 
         <div flex-auto />
 
-        <div dir="ltr" pointer-events-none pe-1 pt-2 text-sm tabular-nums text-secondary flex gap="0.5" :class="{ 'text-rose-500': characterCount > characterLimit }">
-          {{ characterCount ?? 0 }}<span text-secondary-light>/</span><span text-secondary-light>{{ characterLimit }}</span>
-        </div>
+        <PublishCharacterCounter :max="characterLimit" :length="characterCount" />
 
         <CommonTooltip placement="top" :content="$t('tooltip.change_language')">
           <CommonDropdown placement="bottom" auto-boundary-max-size>
@@ -337,12 +339,12 @@ defineExpose({
           </button>
         </CommonTooltip>
 
-        <CommonTooltip v-else id="publish-tooltip" placement="top" :content="$t('tooltip.add_publishable_content')" :disabled="!isPublishDisabled">
+        <CommonTooltip v-else id="publish-tooltip" placement="top" :content="$t('tooltip.add_publishable_content')" :disabled="!(isPublishDisabled || isExceedingCharacterLimit)">
           <button
             btn-solid rounded-3 text-sm w-full flex="~ gap1" items-center
             md:w-fit
             class="publish-button"
-            :aria-disabled="isPublishDisabled"
+            :aria-disabled="isPublishDisabled || isExceedingCharacterLimit"
             aria-describedby="publish-tooltip"
             @click="publish"
           >


### PR DESCRIPTION
Mastodon enforces a 1500 character limit on media attachment descriptions. This is visible in their interface too:
![image](https://user-images.githubusercontent.com/5954994/222964794-9b86e5ab-01ef-4b09-8b46-1d32d60c5743.png)

Elk on the other hand has no such indicator:
![image](https://user-images.githubusercontent.com/5954994/222964817-f652a8e5-fe91-4986-bf49-b62fec8e1f5a.png)

As such, it enforces no limits on the attachment length, and so if you post something exceeding 1500 characters, you get this in your console:
![image](https://user-images.githubusercontent.com/5954994/222964871-e788ef57-0df4-4b5f-8031-dcc4c0a6194c.png)

This error is not visible to the user (due to it not being captured in `failedMessages` since the error occurs in `setDescription` (`publish.ts`) which has no access to that array)

In any case, the potential solutions to this issue would be as follows:
- Let the user enter a large description, but display the error once they apply the description
- Indicate to the user how many characters have been entered and how many are left, and prevent setting descriptions that exceed that value

I chose to go with the latter solution, since the first one was a bit difficult to implement given the current architecture of the code.

So with this PR, one would see this after entering too many characters:
![image](https://user-images.githubusercontent.com/5954994/222965102-54eb3b4b-8fd9-4531-a61a-02963bf63962.png)

**Additionally**, since this PR prevents setting long descriptions (i.e. disables the button), I figured I'd also include that inside the status submission ("Publish") button, since that effectively prevents the user from calling an unnecessary API request that will always fail, and will always throw an error message to the user. So long statuses won't be publishable:
![image](https://user-images.githubusercontent.com/5954994/222965542-eb4815b7-96ee-4b1d-b81d-13cdd2db8bd5.png)

(Perhaps not the most elegant solution -- disabled button does not look the greatest, and I had to make a simple character component just to avoid code duplication -- but it works)

Fixes #1018.