### PR TITLE
fix: render replies to fill the screen height

### DIFF
--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -42,6 +42,12 @@ async function scrollTo() {
   statusElement.scrollIntoView(true)
 }
 
+const clientHeight = ref(0)
+
+onMounted(() => {
+  clientHeight.value = document.documentElement.clientHeight
+})
+
 const publishWidget = ref()
 const focusEditor = () => publishWidget.value?.focusEditor?.()
 
@@ -96,6 +102,7 @@ onReactivated(() => {
               v-slot="{ item, index, active }"
               :items="context?.descendants || []"
               :min-item-size="200"
+              :buffer="clientHeight"
               key-field="id"
               page-mode
             >


### PR DESCRIPTION
When viewing a post, by default not all replies are rendered ([Mark Ruffalo post](https://main.elk.zone/mastodon.social/@MarkRuffalo/109638532333776039)):
![image](https://user-images.githubusercontent.com/5954994/222984669-a532aa05-088f-495a-92c6-e344e798e6cc.png)

This PR fixes this and makes it such that replies would always fill up the document's `clientHeight`
![image](https://user-images.githubusercontent.com/5954994/222984804-a8adb91d-20fc-48e5-8ebf-e3619491d2bd.png)

For more information regarding the details of this, take a look at the linked issue below.

FYI, Since the original PR that introduced the `<DynamicScroller>` was for performance reasons, I should note that this PR does not affect performance as the Mark Ruffallo post rendered perfectly fine with this fix.

Fixes #1849.