### PR TITLE
feat: add metadata icon for Matrix

### DIFF
--- a/composables/masto/icons.ts
+++ b/composables/masto/icons.ts
@@ -21,6 +21,7 @@ export const accountFieldIcons: Record<string, string> = Object.fromEntries(Obje
   LinkedIn: 'i-ri:linkedin-box-line',
   Location: 'i-ri:map-pin-2-line',
   Mastodon: 'i-ri:mastodon-line',
+  Matrix: 'i-tabler:brand-matrix',
   Medium: 'i-ri:medium-line',
   OpenPGP: 'i-ri:key-2-line',
   Patreon: 'i-ri:patreon-line',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@iconify-json/mdi": "^1.1.44",
     "@iconify-json/ph": "^1.1.3",
     "@iconify-json/ri": "^1.1.4",
+    "@iconify-json/tabler": "^1.1.64",
     "@iconify-json/twemoji": "^1.1.10",
     "@iconify/utils": "^2.0.12",
     "@nuxt/devtools": "^0.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       '@iconify-json/mdi': ^1.1.44
       '@iconify-json/ph': ^1.1.3
       '@iconify-json/ri': ^1.1.4
+      '@iconify-json/tabler': ^1.1.64
       '@iconify-json/twemoji': ^1.1.10
       '@iconify/utils': ^2.0.12
       '@nuxt/devtools': ^0.1.4
@@ -136,6 +137,7 @@ importers:
       '@iconify-json/mdi': 1.1.44
       '@iconify-json/ph': 1.1.3
       '@iconify-json/ri': 1.1.4
+      '@iconify-json/tabler': 1.1.64
       '@iconify-json/twemoji': 1.1.10
       '@iconify/utils': 2.0.12
       '@nuxt/devtools': 0.1.4_nuxt@3.2.0
@@ -2043,6 +2045,12 @@ packages:
 
   /@iconify-json/ri/1.1.4:
     resolution: {integrity: sha512-gAk2gQBVghgbMLOmbUCc3l4COMMH5sR3HhBqpjaPUFBbC4WsNNRyOD4RZgjlanU7DTgFrj4NarY5K2EkXaVxuw==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: false
+
+  /@iconify-json/tabler/1.1.64:
+    resolution: {integrity: sha512-+QMcM/kNRVUt4AdhuXF18RBR+oEsMqIf+zqQX4SMkwfGUzlENtlh4JAFyoeyEaKMdZfszB2TjV7iswxwbPR5hA==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: false


### PR DESCRIPTION
Add metadata icon for [Matrix](https://matrix.org/).

I don't know what's the "popularity threshold" to add a metadata icon, but I already noticed a bunch of accounts (including myself!) adding their Matrix username to their profile.

Matrix is a decentralized, e2e encrypted, chat protocol. It's used by a variety of organizations, such as TC39, WHATWG, Mozilla or Germany's national healthcare system.
Mastodon : Twitter = Matrix : Discord 🙂 

<img width="275" alt="image" src="https://user-images.githubusercontent.com/7000710/222990090-fd0d9be0-232a-4f2c-ab37-589dac1c2b23.png">
