### PR TITLE
fix: wrap non-sensitive spoilers in spoiler status

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -20,7 +20,7 @@ const isFiltered = $computed(() => status.account.id !== currentUser.value?.acco
 
 // check spoiler text or media attachment
 // needed to handle accounts that mark all their posts as sensitive
-const hasSensitiveSpoilerOrMedia = $computed(() => status.sensitive && (!!status.spoilerText || !!status.mediaAttachments.length))
+const hasSpoilerOrSensitiveMedia = $computed(() => !!status.spoilerText || (status.sensitive && !!status.mediaAttachments.length))
 </script>
 
 <template>
@@ -32,7 +32,7 @@ const hasSensitiveSpoilerOrMedia = $computed(() => status.sensitive && (!!status
     }"
   >
     <StatusBody v-if="!isFiltered && status.sensitive && !status.spoilerText" :status="status" :newer="newer" :with-action="!isDetails" :class="isDetails ? 'text-xl' : ''" />
-    <StatusSpoiler :enabled="hasSensitiveSpoilerOrMedia || isFiltered" :filter="isFiltered" :is-d-m="isDM">
+    <StatusSpoiler :enabled="hasSpoilerOrSensitiveMedia || isFiltered" :filter="isFiltered" :is-d-m="isDM">
       <template v-if="status.spoilerText" #spoiler>
         <p>{{ status.spoilerText }}</p>
       </template>


### PR DESCRIPTION
This fixes a regression introduced in #1633 that causes spoilers to be disabled if media is non-sensitive, when the expected behavior would be to: "enable spoilers as long as there's **[spoiler text or sensitive media]** or [if its filtered]".

I'm fairly sure that this should be as simple of a fix as that, but I think @ayoayco would be able to verify if anything else needs to be addressed.

(again, not evident in these screenshots but this post has `sensitive: false`)
Original instance ([link](https://infosec.exchange/@catsalad/109890930166069976)):
![image](https://user-images.githubusercontent.com/5954994/223505237-ec0f9710-62c9-4b12-b1a2-df2ff84c425c.png)

Elk ([canary link](https://main.elk.zone/infosec.exchange/@catsalad/109890930166069976)):
![image](https://user-images.githubusercontent.com/5954994/223506071-f12debcb-a4cf-422a-98f8-026bec0c7a04.png)

With this fix ([preview link](https://deploy-preview-1864--elk-zone.netlify.app/infosec.exchange/@catsalad/109890930166069976)):
![image](https://user-images.githubusercontent.com/5954994/223506231-714b521a-0d7c-432e-abf5-9ec52df89d00.png)


Fixes #1846.