### PR TITLE
fix: copy and paste custom-emoji

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -218,8 +218,10 @@ export function treeToText(input: Node): string {
     body = (input.children as Node[]).map(n => treeToText(n)).join('')
 
   if (input.name === 'img' || input.name === 'picture') {
-    if (input.attributes.class?.includes('custom-emoji'))
-      return `:${input.attributes['data-emoji-id'] ?? input.attributes.title ?? input.attributes.alt?.slice(1, -1)}:`
+    if (input.attributes.class?.includes('custom-emoji')) {
+      const id = input.attributes['data-emoji-id'] ?? input.attributes.title ?? input.attributes.alt ?? 'unknown'
+      return id[0] !== ':' ? `:${id}:` : id
+    }
     if (input.attributes.class?.includes('iconify-emoji'))
       return input.attributes.alt
   }

--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -219,7 +219,7 @@ export function treeToText(input: Node): string {
 
   if (input.name === 'img' || input.name === 'picture') {
     if (input.attributes.class?.includes('custom-emoji'))
-      return `:${input.attributes['data-emoji-id'] || input.attributes.title}:`
+      return `:${input.attributes['data-emoji-id'] ?? input.attributes.title ?? input.attributes.alt?.slice(1, -1)}:`
     if (input.attributes.class?.includes('iconify-emoji'))
       return input.attributes.alt
   }


### PR DESCRIPTION
Reference:
- #1871

@cyberalien it looks like when we copy and paste, there is no `title` in the attributes and we are instead adding a `alt` that has the full `:name:`

This PR fixes copy and paste, but I don't know if this is correct long term. We also are creating [here](https://github.com/elk-zone/elk/blob/fa3cfd6059f2bdd42bc5d349ac225c29c6f666de/composables/content-parse.ts#L429) a custom emoji without a title but this one has a `emoji-data-id`

Looks like the `emoji-data-id` is lost on copy and paste.
We could still merge this one as a patch.