### PR TITLE
docs: add mastodon link to header

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -6,6 +6,11 @@ export default defineAppConfig({
     socials: {
       twitter: 'elk_zone',
       github: 'elk-zone/elk',
+      mastodon: {
+        label: 'Mastodon',
+        icon: 'IconMastodon',
+        href: 'https://elk.zone/@elk@webtoo.ls',
+      },
     },
     aside: {
       level: 0,


### PR DESCRIPTION
It was bothering me that the docs had a link to twitter and not mastodon, while Docus doesn't have native mastodon support it does allow for arbitrary social networks.