### PR TITLE
chore: update ecosytem link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ These are known deployments using Elk as an alternative Web client for Mastodon 
 - [elk.universeodon.com](https://elk.universeodon.com) - Use Elk for the Universeodon Server
 - [elk.vmst.io](https://elk.vmst.io) - Use Elk for the `vmst.io` Server
 - [elk.hostux.social](https://elk.hostux.social) - Use Elk for the `hostux.social` Server
-- [elk.freelancers.online](https://elk.freelancers.online) - Use Elk for the `freelancers.online` Server
 - [elk.cupoftea.social](https://elk.cupoftea.social) - Use Elk for the `cupoftea.social` Server
 - [elk.aus.social](https://elk.aus.social) - Use Elk for the `aus.social` Server
 


### PR DESCRIPTION
Remove Freelancers.online from ecosystem. 
Project and server no longer going forward.