### PR TITLE
feat: allow user to view follow list in "Hide following/follower count" mode

### DIFF
--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -19,6 +19,6 @@ const relationship = $(useRelationship(account))
     <div v-if="account.note" max-h-100 overflow-y-auto>
       <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
     </div>
-    <AccountPostsFollowers text-sm :account="account" />
+    <AccountPostsFollowers text-sm :account="account" :is-hover-card="true" />
   </div>
 </template>

--- a/components/account/AccountPostsFollowers.vue
+++ b/components/account/AccountPostsFollowers.vue
@@ -26,7 +26,6 @@ const userSettings = useUserSettings()
       </template>
     </NuxtLink>
     <NuxtLink
-      v-if="!getPreferences(userSettings, 'hideFollowerCount')"
       :to="getAccountFollowingRoute(account)"
       replace
       text-secondary exact-active-class="text-primary"
@@ -35,13 +34,13 @@ const userSettings = useUserSettings()
         <CommonLocalizedNumber
           keypath="account.following_count"
           :count="account.followingCount"
+          :hide-number="getPreferences(userSettings, 'hideFollowerCount')"
           font-bold
           :class="isExactActive ? 'text-primary' : 'text-base'"
         />
       </template>
     </NuxtLink>
     <NuxtLink
-      v-if="!getPreferences(userSettings, 'hideFollowerCount')"
       :to="getAccountFollowersRoute(account)"
       replace text-secondary
       exact-active-class="text-primary"
@@ -50,6 +49,7 @@ const userSettings = useUserSettings()
         <CommonLocalizedNumber
           keypath="account.followers_count"
           :count="account.followersCount"
+          :hide-number="getPreferences(userSettings, 'hideFollowerCount')"
           font-bold
           :class="isExactActive ? 'text-primary' : 'text-base'"
         />

--- a/components/account/AccountPostsFollowers.vue
+++ b/components/account/AccountPostsFollowers.vue
@@ -34,12 +34,13 @@ const userSettings = useUserSettings()
     >
       <template #default="{ isExactActive }">
         <CommonLocalizedNumber
+          v-if="!getPreferences(userSettings, 'hideFollowerCount')"
           keypath="account.following_count"
           :count="account.followingCount"
-          :hide-number="getPreferences(userSettings, 'hideFollowerCount')"
           font-bold
           :class="isExactActive ? 'text-primary' : 'text-base'"
         />
+        <span v-else>{{ $t('account.following') }}</span>
       </template>
     </NuxtLink>
     <NuxtLink
@@ -50,12 +51,13 @@ const userSettings = useUserSettings()
     >
       <template #default="{ isExactActive }">
         <CommonLocalizedNumber
+          v-if="!getPreferences(userSettings, 'hideFollowerCount')"
           keypath="account.followers_count"
           :count="account.followersCount"
-          :hide-number="getPreferences(userSettings, 'hideFollowerCount')"
           font-bold
           :class="isExactActive ? 'text-primary' : 'text-base'"
         />
+        <span v-else>{{ $t('account.followers') }}</span>
       </template>
     </NuxtLink>
   </div>

--- a/components/account/AccountPostsFollowers.vue
+++ b/components/account/AccountPostsFollowers.vue
@@ -3,6 +3,7 @@ import type { mastodon } from 'masto'
 
 defineProps<{
   account: mastodon.v1.Account
+  isHoverCard?: boolean
 }>()
 
 const userSettings = useUserSettings()
@@ -26,6 +27,7 @@ const userSettings = useUserSettings()
       </template>
     </NuxtLink>
     <NuxtLink
+      v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
       :to="getAccountFollowingRoute(account)"
       replace
       text-secondary exact-active-class="text-primary"
@@ -41,6 +43,7 @@ const userSettings = useUserSettings()
       </template>
     </NuxtLink>
     <NuxtLink
+      v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
       :to="getAccountFollowersRoute(account)"
       replace text-secondary
       exact-active-class="text-primary"

--- a/components/common/LocalizedNumber.vue
+++ b/components/common/LocalizedNumber.vue
@@ -2,6 +2,7 @@
 const props = defineProps<{
   count: number
   keypath: string
+  hideNumber?: boolean
 }>()
 
 defineOptions({
@@ -13,11 +14,14 @@ const { formatHumanReadableNumber, formatNumber, forSR } = useHumanReadableNumbe
 const useSR = $computed(() => forSR(props.count))
 const rawNumber = $computed(() => formatNumber(props.count))
 const humanReadableNumber = $computed(() => formatHumanReadableNumber(props.count))
+
+const hideNumber = $computed(() => props.hideNumber)
 </script>
 
 <template>
   <i18n-t :keypath="keypath" :plural="count" tag="span" class="flex gap-x-1">
-    <CommonTooltip v-if="useSR" :content="rawNumber" placement="bottom">
+    <span v-if="hideNumber" />
+    <CommonTooltip v-else-if="useSR" :content="rawNumber" placement="bottom">
       <span aria-hidden="true" v-bind="$attrs">{{ humanReadableNumber }}</span>
       <span sr-only>{{ rawNumber }}</span>
     </CommonTooltip>

--- a/components/common/LocalizedNumber.vue
+++ b/components/common/LocalizedNumber.vue
@@ -2,7 +2,6 @@
 const props = defineProps<{
   count: number
   keypath: string
-  hideNumber?: boolean
 }>()
 
 defineOptions({
@@ -17,9 +16,8 @@ const humanReadableNumber = $computed(() => formatHumanReadableNumber(props.coun
 </script>
 
 <template>
-  <i18n-t :keypath="keypath" :plural="hideNumber ? 2 : count" tag="span" class="flex gap-x-1">
-    <span v-if="hideNumber" />
-    <CommonTooltip v-else-if="useSR" :content="rawNumber" placement="bottom">
+  <i18n-t :keypath="keypath" :plural="count" tag="span" class="flex gap-x-1">
+    <CommonTooltip v-if="useSR" :content="rawNumber" placement="bottom">
       <span aria-hidden="true" v-bind="$attrs">{{ humanReadableNumber }}</span>
       <span sr-only>{{ rawNumber }}</span>
     </CommonTooltip>

--- a/components/common/LocalizedNumber.vue
+++ b/components/common/LocalizedNumber.vue
@@ -17,7 +17,7 @@ const humanReadableNumber = $computed(() => formatHumanReadableNumber(props.coun
 </script>
 
 <template>
-  <i18n-t :keypath="keypath" :plural="count" tag="span" class="flex gap-x-1">
+  <i18n-t :keypath="keypath" :plural="hideNumber ? 2 : count" tag="span" class="flex gap-x-1">
     <span v-if="hideNumber" />
     <CommonTooltip v-else-if="useSR" :content="rawNumber" placement="bottom">
       <span aria-hidden="true" v-bind="$attrs">{{ humanReadableNumber }}</span>

--- a/components/common/LocalizedNumber.vue
+++ b/components/common/LocalizedNumber.vue
@@ -14,8 +14,6 @@ const { formatHumanReadableNumber, formatNumber, forSR } = useHumanReadableNumbe
 const useSR = $computed(() => forSR(props.count))
 const rawNumber = $computed(() => formatNumber(props.count))
 const humanReadableNumber = $computed(() => formatHumanReadableNumber(props.count))
-
-const hideNumber = $computed(() => props.hideNumber)
 </script>
 
 <template>


### PR DESCRIPTION
From @patak-dev 's idea (see [here](https://github.com/elk-zone/elk/pull/1897#pullrequestreview-1344639293)), I adjusted the wellbeing "Hide following/follower count" feature.

Before changes, when "Hide following/follower count" is enabled, the following count and the follower count are hidden as shown below.
![screenshot_2023-03-17_23:13:49](https://user-images.githubusercontent.com/11942650/225947271-fdcafa06-c815-400a-9da9-3567fefeaa55.jpg)

After changes, when "Hide following/follower count" is enabled, only the numbers are hidden. The text "Following" and "Followers" are kept so that users are still able to click them to view the following list and the follower list.
![screenshot_2023-03-17_23:15:03](https://user-images.githubusercontent.com/11942650/225947311-6e11128e-1408-4acf-8f50-e8e5cd7ea129.jpg)
