### PR TITLE
VAPID protocol information is wrong

### DIFF
--- a/docs/content/80.pwa.md
+++ b/docs/content/80.pwa.md
@@ -79,9 +79,9 @@ If you cannot see the notification permission prompt, you will need to remove pu
 
 ### Your browser supports Web Push Notifications, but does not seem to implement the VAPID protocol.
 
-If you're receiving this error, it means that your browser doesn't support the VAPID protocol, and you will not be able to receive push notifications.
+If you're receiving this error, it means that either your browser doesn't support the VAPID protocol, or something is preventing the VAPID protocol from working in your browser. The VAPID protocol requires the clock to be set correctly on your computer or device, since this is used for certficate checks. Check that your clock is set to the correct date, time and timezone. After setting it correctly, restart your browser and try again. If it is set correctly, and you still receive this message, then your browser doesn't support the VAPID protocol and you will not be able to receive push notifications.
 
-There is nothing we can do to fix this, you will need to use a browser that supports the VAPID protocol: Chrome, Edge, Safari and Firefox.
+There is nothing we can do to fix this, you will need to use a browser that supports the VAPID protocol: Chrome, Edge, Safari, Firefox and Vivaldi.
 
 ### Install Elk button not working
 


### PR DESCRIPTION
VAPID protocol can be supported but show an error message claiming it is not supported. This happens if your clock is set wrong (eg. if you have it set to the wrong timezone, so the time looks right but actually isn't).