### PR TITLE
docs(fix): pwa plugin link

### DIFF
--- a/docs/content/80.pwa.md
+++ b/docs/content/80.pwa.md
@@ -117,7 +117,7 @@ On wide screens, the PWA prompt for update will be shown as a prompt on the righ
 
 PWA prompt for update will take preference over PWA installation prompt, so if there is a new version of Elk available, the PWA prompt for update will be shown instead of the PWA installation prompt.
 
-All previous UI components don't have any logic, all them will use the logic provided by the [PWA plugin](https://github.com/elk-zone/elk/blob/main/plugins/pwa.client.ts).
+All previous UI components don't have any logic, all them will use the logic provided by the [PWA plugin](https://github.com/elk-zone/elk/blob/main/modules/pwa/runtime/pwa-plugin.client.ts).
 
 ### Service Worker
 


### PR DESCRIPTION
PR #1758  moves PWA plugin to add pwa plugin stub when PWA disabled, now it is located on pwa module runtime folder