### PR TITLE
fix: saving profile data breaks cache

### DIFF
--- a/pages/settings/profile/appearance.vue
+++ b/pages/settings/profile/appearance.vue
@@ -71,6 +71,12 @@ const { submit, submitting } = submitter(async ({ dirtyFields }) => {
     return
   }
 
+  const server = currentUser.value!.server
+
+  if (!res.account.acct.includes('@'))
+    res.account.acct = `${res.account.acct}@${server}`
+
+  cacheAccount(res.account, server, true)
   currentUser.value!.account = res.account
   reset()
 })


### PR DESCRIPTION
We need to add `@server` to the acct account response and override account cache, check:
- https://github.com/elk-zone/elk/blob/main/composables/users.ts#L147
- https://github.com/elk-zone/elk/blob/main/composables/users.ts#L172

closes #1879