### PR TITLE
chore: change pwa module name

### DIFF
--- a/modules/pwa/index.ts
+++ b/modules/pwa/index.ts
@@ -11,7 +11,7 @@ import { type LocalizedWebManifest, createI18n, pwaLocales } from './i18n'
 export * from './types'
 export default defineNuxtModule<VitePWANuxtOptions>({
   meta: {
-    name: 'pwa',
+    name: 'elk-pwa',
     configKey: 'pwa',
   },
   defaults: nuxt => ({


### PR DESCRIPTION
Nuxt DevTools shows we're using `nuxt/pwa` module instead custom one.

![nuxt-pwa](https://user-images.githubusercontent.com/6311119/229515500-3bc21068-45d2-46ff-b04c-43c686643444.png)

With this change:


![nuxt-elk-pwa](https://user-images.githubusercontent.com/6311119/229515647-6553a46d-5489-43a6-b28f-2b222af2397f.png)
