### PR TITLE
fix: use `purpose: any` for normal pwa icon

### DIFF
--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -93,12 +93,13 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
           src: 'pwa-512x512.png',
           sizes: '512x512',
           type: 'image/png',
+          purpose: 'any',
         },
         {
           src: 'maskable-icon.png',
           sizes: '512x512',
           type: 'image/png',
-          purpose: 'any maskable',
+          purpose: 'maskable',
         },
       ],
       share_target: {

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -141,12 +141,13 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
           src: 'pwa-512x512.png',
           sizes: '512x512',
           type: 'image/png',
+          purpose: 'any',
         },
         {
           src: 'maskable-icon.png',
           sizes: '512x512',
           type: 'image/png',
-          purpose: 'any maskable',
+          purpose: 'maskable',
         },
       ],
       share_target: {


### PR DESCRIPTION
This adds the `any` purpose to our normal PWA icon and reserves `maskable` for just the maskable icon. It looks like this should improve rendering of the PWA icon.

See https://docs.pwabuilder.com/#/builder/manifest?id=icons.