### PR TITLE
fix(i18n): update portuguese from Portugal translation

### DIFF
--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -627,4 +627,3 @@
     "unlisted_desc": "Visível por todos, mas não incluída nas funcionalidades de divulgação"
   }
 }
-

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -497,6 +497,10 @@
     "uploading": "A carregar..."
   },
   "status": {
+    "account": {
+      "suspended_message": "A conta de estado foi suspensa.",
+      "suspended_show": "Mostrar conteúdo mesmo assim?"
+    },
     "boosted_by": "Partilhada Por",
     "edited": "Editada {0}",
     "favourited_by": "Adicionada Aos Favoritos Por",
@@ -623,3 +627,4 @@
     "unlisted_desc": "Visível por todos, mas não incluída nas funcionalidades de divulgação"
   }
 }
+


### PR DESCRIPTION
Add and translate 2 new keys:
- status.account.suspended_message
- status.account.suspended_show
