### PR TITLE
fix: unicode emojis when editing

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -145,7 +145,6 @@ export function convertMastodonHTML(html: string, customEmojis: Record<string, m
   const tree = parseMastodonHTML(html, {
     emojis: customEmojis,
     markdown: true,
-    replaceUnicodeEmoji: false,
     convertMentionLink: true,
   })
   return render(tree)


### PR DESCRIPTION
Fixes #1932
Fixes #1994

@antfu do you recall why we wanted to preserve unicode emojis here? It seems that converting them is the right thing to do so TipTap can properly handle them.