### PR TITLE
feat(ui): use sticky position on settings mid panel

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -8,12 +8,23 @@ defineProps<{
   noOverflowHidden?: boolean
 }>()
 
+const container = ref()
 const route = useRoute()
+const { height: windowHeight } = useWindowSize()
+const { height: containerHeight } = useElementBounding(container)
 const wideLayout = computed(() => route.meta.wideLayout ?? false)
+const sticky = computed(() => route.path?.startsWith('/settings/'))
+const containerClass = computed(() => {
+  // we keep original behavior when not in settings page and when the window height is smaller than the container height
+  if (!isHydrated.value || !sticky.value || (windowHeight.value < containerHeight.value))
+    return null
+
+  return 'lg:sticky lg:top-0'
+})
 </script>
 
 <template>
-  <div>
+  <div ref="container" :class="containerClass">
     <div
       sticky top-0 z10 backdrop-blur
       pt="[env(safe-area-inset-top,0)]"


### PR DESCRIPTION
This PR configures the main content container to be sticky on settings pages, this way the mid panel will not scroll: added logic to keep current behavior when the content height is smaller than the available vertical space.

https://streamable.com/fdyl2w