### PR TITLE
fix: emoji sizing

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -34,25 +34,17 @@ body {
   display: none;
 }
 
-.custom-emoji {
-  display: inline-block;
-  vertical-align: text-bottom;
-}
-
 .content-editor img.custom-emoji,
-.custom-emoji img {
-  max-height: 1.3em;
-  max-width: 1.3em;
-  object-fit: contain;
-}
-
+.custom-emoji img,
 .iconify-emoji {
   display: inline-block;
+  height: 1.2em;
+  width: 1.2em;
+  margin-right: 0.075em;
+  margin-left: 0.075em;
+  object-fit: contain;
   overflow: hidden;
-  max-height: 1.2em;
-  max-width: 1.2em;
-  vertical-align: text-bottom;
-  margin: 0 0.1em;
+  vertical-align: -20%;
 }
 
 .iconify-emoji-padded {


### PR DESCRIPTION
Fixes #1983

@userquin @cyberalien maybe you could check this one? I don't know why we were using different sizes for custom emojis and for normal ones, and why we were using max-width/max-height instead of direct width/height.

The forest repro looks good after this PR
<img width="798" alt="image" src="https://user-images.githubusercontent.com/583075/233866760-d4177fc5-27b1-41a9-a003-37add4442e0e.png">
