### PR TITLE
fix: timeline content render receiving undefined when converting to vnode

### DIFF
--- a/composables/content-render.ts
+++ b/composables/content-render.ts
@@ -66,6 +66,9 @@ function nodeToVNode(node: Node): VNode | string | null {
 function treeToVNode(
   input: Node,
 ): VNode | string | null {
+  if (!input)
+    return null
+
   if (input.type === TEXT_NODE)
     return decode(input.value)
 


### PR DESCRIPTION
Checking the toot from this accout https://elk.zone/m.webtoo.ls/@sigridellis@wandering.shop 22h fails (0.8.0 and 0.8.1), `treeToVNode` receiving `undefined`.

We should review the logic to group timeline entries.

/cc @patak-dev 

![imagen](https://user-images.githubusercontent.com/6311119/234085766-3b426204-11f6-4a7c-9cc4-c4c077a724ad.png)

![imagen](https://user-images.githubusercontent.com/6311119/234085807-0ae51a3f-86e9-4907-aae9-f836985b5f98.png)


With changes in this PR:

![imagen](https://user-images.githubusercontent.com/6311119/234085997-0de84b61-5678-4839-befc-17977c2a00eb.png)

