### PR TITLE
fix: detect Takahe hashtags correctly

### DIFF
--- a/composables/misc.ts
+++ b/composables/misc.ts
@@ -1,7 +1,7 @@
 import type { mastodon } from 'masto'
 
 export const UserLinkRE = /^(?:https:\/)?\/([^/]+)\/@([^/]+)$/
-export const TagLinkRE = /^https?:\/\/([^/]+)\/tags\/([^/]+)$/
+export const TagLinkRE = /^https?:\/\/([^/]+)\/tags\/([^/]+)\/?$/
 export const HTMLTagRE = /<[^>]+>/g
 
 export function getDataUrlFromArr(arr: Uint8ClampedArray, w: number, h: number) {


### PR DESCRIPTION
Takahē hashtag links always end with a trailing slash which Elk's regex didn't recognize. With this change hashtag URLs are allowed to have an optional trailing slash.

i.e. `https://takahe.social/tags/takahe/`