### PR TITLE
feat: compose button

### DIFF
--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -34,15 +34,22 @@ router.afterEach(() => {
       </div>
     </NuxtLink>
     <div
-      hidden xl:flex items-center me-8 mt-2
-      :class="{ 'pointer-events-none op0': !back || back === '/', 'xl:flex': $route.name !== 'tag' }"
+      hidden xl:flex items-center me-8 mt-2 gap-1
     >
-      <NuxtLink
-        :aria-label="$t('nav.back')"
-        @click="$router.go(-1)"
-      >
-        <div i-ri:arrow-left-line class="rtl-flip" btn-text />
-      </NuxtLink>
+      <CommonTooltip :content="$t('nav.back')">
+        <NuxtLink
+          :aria-label="$t('nav.back')"
+          :class="{ 'pointer-events-none op0': !back || back === '/', 'xl:flex': $route.name !== 'tag' }"
+          @click="$router.go(-1)"
+        >
+          <div text-xl i-ri:arrow-left-line class="rtl-flip" btn-text />
+        </NuxtLink>
+      </CommonTooltip>
+      <CommonTooltip :content="$t('action.compose')">
+        <button :aria-label="$t('action.compose')" btn-action-icon @click="openPublishDialog('compose')">
+          <div text-xl i-ri:quill-pen-line user-only class="rtl-flip" btn-text />
+        </button>
+      </CommonTooltip>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Adds a Compose button next to the back arrow on large screens.

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/583075/235372143-bf9efd3b-54ee-42b3-b45d-10365031846b.png">

Some users are having issues finding the Compose route. We discussed a while ago that we should bring back a button in the sidebar.