### PR TITLE
feat: height responsive sidebar

### DIFF
--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -6,11 +6,11 @@ const { notifications } = useNotifications()
 </script>
 
 <template>
-  <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full mt-1>
+  <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full mt-1 overflow-y-auto>
     <SearchWidget lg:ms-1 lg:me-5 hidden xl:block />
     <NavSideItem :text="$t('nav.search')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:search-line" hidden sm:block xl:hidden :command="command" />
 
-    <div shrink hidden sm:block mt-2 />
+    <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.home')" to="/home" icon="i-ri:home-5-line" user-only :command="command" />
     <NavSideItem :text="$t('nav.notifications')" to="/notifications" icon="i-ri:notification-4-line" user-only :command="command">
       <template #icon>
@@ -27,13 +27,24 @@ const { notifications } = useNotifications()
     <NavSideItem :text="$t('nav.bookmarks')" to="/bookmarks" icon="i-ri:bookmark-line" user-only :command="command" />
     <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-line" user-only :command="command" />
 
-    <div shrink hidden sm:block mt-4 />
+    <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.explore')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:hashtag" :command="command" xs:hidden sm:hidden xl:block />
     <NavSideItem :text="$t('nav.local')" :to="isHydrated ? `/${currentServer}/public/local` : '/public/local'" icon="i-ri:group-2-line " :command="command" />
     <NavSideItem :text="$t('nav.federated')" :to="isHydrated ? `/${currentServer}/public` : '/public'" icon="i-ri:earth-line" :command="command" />
     <NavSideItem :text="$t('nav.lists')" :to="isHydrated ? `/${currentServer}/lists` : '/lists'" icon="i-ri:list-check" user-only :command="command" />
 
-    <div shrink hidden sm:block mt-4 />
+    <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.settings')" to="/settings" icon="i-ri:settings-3-line" :command="command" />
   </nav>
 </template>
+
+<style scoped>
+  .spacer {
+    margin-top: 0.5em;
+  }
+  @media screen and ( max-height: 820px ) {
+    .spacer {
+      margin-top: 0;
+    }
+  }
+</style>

--- a/components/nav/NavSideItem.vue
+++ b/components/nav/NavSideItem.vue
@@ -55,9 +55,10 @@ const noUserVisual = computed(() => isHydrated.value && props.userOnly && !curre
   >
     <CommonTooltip :disabled="!isMediumOrLargeScreen" :content="text" placement="right">
       <div
+        class="item"
         flex items-center gap4
         w-fit rounded-3
-        px2 py2 mx3 sm:mxa
+        px2 mx3 sm:mxa
         xl="ml0 mr5 px5 w-auto"
         transition-100
         elk-group-hover="bg-active" group-focus-visible:ring="2 current"
@@ -72,3 +73,22 @@ const noUserVisual = computed(() => isHydrated.value && props.userOnly && !curre
     </CommonTooltip>
   </NuxtLink>
 </template>
+
+<style scoped>
+  .item {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  @media screen and ( max-height: 820px ) {
+    .item {
+      padding-top: 0.25rem;
+      padding-bottom: 0.25rem;
+    }
+  }
+  @media screen and ( max-height: 720px ) {
+    .item {
+      padding-top: 0.05rem;
+      padding-bottom: 0.05rem;
+    }
+  }
+</style>


### PR DESCRIPTION
A vertical scrollbar can appear in the left sidebar if the screen isn't large enough. We currently have a lot of spacing. After this PR, the spacing will be collapsed if the height of the screen is small.

Note: I did this with CSS as I don't know how to do it with unocss. We could merge and if later someone wants to rework this in a more idiomatic way, we could update it.

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/583075/235374200-364afc05-61ca-4cdd-9ff7-82363f593eb9.png">
