### PR TITLE
feat: prefer en language as top

### DIFF
--- a/components/publish/PublishLanguagePicker.vue
+++ b/components/publish/PublishLanguagePicker.vue
@@ -20,6 +20,10 @@ const languages = $computed(() =>
     ? fuse.search(languageKeyword).map(r => r.item)
     : [...languagesNameList].filter(entry => !userSettings.value.disabledTranslationLanguages.includes(entry.code))
         .sort(({ code: a }, { code: b }) => {
+          // Prefer code en over everything else
+          if (a === 'en')
+            return -1
+
           return a === modelValue ? -1 : b === modelValue ? 1 : a.localeCompare(b)
         }),
 )

--- a/components/publish/PublishLanguagePicker.vue
+++ b/components/publish/PublishLanguagePicker.vue
@@ -20,7 +20,7 @@ const languages = $computed(() =>
     ? fuse.search(languageKeyword).map(r => r.item)
     : [...languagesNameList].filter(entry => !userSettings.value.disabledTranslationLanguages.includes(entry.code))
         .sort(({ code: a }, { code: b }) => {
-          // Prefer code en over everything else
+          // Put English on the top
           if (a === 'en')
             return -1
 


### PR DESCRIPTION
This is a really small but effective change!

Issues like https://github.com/elk-zone/elk/issues/967 are asking for improvements for the language selection. I'm also affected by this myself, because my native language is german but I write posts in english very often.

So english is (I assume) the most common language in the world and many folks write post in english beside their native language. That's why now this PR moves `en` to the top if nothing was searched for manually.

I think this is the most easiest and smallest solution for now we could think of. If we want to improve it further with any smart stuff, we could enhance and iterate later in further PRs.