### PR TITLE
fix: Handle failure when fetching user preferences

### DIFF
--- a/composables/users.ts
+++ b/composables/users.ts
@@ -169,7 +169,7 @@ export async function loginTo(masto: ElkMasto, user: Overwrite<UserLogin, { acco
   currentUserHandle.value = me.acct
 }
 
-const accountPreferencesMap = new Map<string, mastodon.v1.Preference>()
+const accountPreferencesMap = new Map<string, Partial<mastodon.v1.Preference>>()
 
 /**
  * @returns `true` when user ticked the preference to always expand posts with content warnings
@@ -193,9 +193,20 @@ export function getHideMediaByDefault(account: mastodon.v1.AccountCredentials) {
 }
 
 export async function fetchAccountInfo(client: mastodon.Client, server: string) {
+  // Try to fetch user preferences if the backend supports it.
+  const fetchPrefs = async (): Promise<Partial<mastodon.v1.Preference>> => {
+    try {
+      return await client.v1.preferences.fetch()
+    }
+    catch (e) {
+      console.warn(`Cannot fetch preferences: ${e}`)
+      return {}
+    }
+  }
+
   const [account, preferences] = await Promise.all([
     client.v1.accounts.verifyCredentials(),
-    client.v1.preferences.fetch(),
+    fetchPrefs(),
   ])
 
   if (!account.acct.includes('@'))


### PR DESCRIPTION
If fetching preferences fail, continue with no known preferences.

Some servers (such as the current latest version of GoToSocial)
has not implemented the `GET /preferences` endpoint. This API call is failing
and causing the whole `fetchAccountInfo` function to throw,
effectively logging the user out.

I've also contacted the GoToSocial guys to quickly write up an endpoint,
but this would be a quicker fix as opposed to all GtS users failing to log into
their instance from Elk (we get logged out immediately after authentication as of now).

Note that some of the preferences shown up in the API,
particularly `reading:expand:media` and `reading:expand:spoilers` doesn't seem
to even have an endpoint where it can be set at the moment.

I don't know what is the standard for "show an error, that is probably not very important
to the user" in the codebase, so I just left a `console.warn` for now. Feel free to edit it 
to the standards.