### PR TITLE
feat: show followers from account's instance

### DIFF
--- a/pages/[[server]]/@[account]/index/following.vue
+++ b/pages/[[server]]/@[account]/index/following.vue
@@ -14,6 +14,20 @@ if (account) {
   useHydratedHead({
     title: () => `${t('account.following')} | ${getDisplayName(account)} (@${account.acct})`,
   })
+
+  const currentUserInstance = currentUser.value?.account.url.split('/@')[0]
+  const accountInstance = account.url.split('/@')[0]
+
+  if (currentUserInstance !== accountInstance) {
+    const otherMasto = createMasto()
+    otherMasto.setParams({ url: accountInstance })
+
+    const otherAccount = await otherMasto.client.value.v1.accounts.lookup({ acct: account.acct })
+
+    const otherPaginator = otherMasto.client.value.v1.accounts.listFollowing(otherAccount.id, {})
+
+    console.log((await otherPaginator.next()).value)
+  }
 }
 </script>
 


### PR DESCRIPTION
@danielroe here you can see how it would be possible to additionally load the rest of the paginator if the account is not part of the instance you are currently have your own account

Questions:
- how could it be possible to merge the paginators?
- should we cache other mastodon clients or create them always on demand?
- should we try somehow to merge the paginators? (this could also help for some other features if we find a way to merge paginators in general)
- or should we add e.g. a button at the bottom to load them if wanted?
- maybe we don't need to load the paginator of the instance from your own account at all but just directly use the account's instance :thinking: :eyes: (does they include always all?)

For fast communication: https://discord.com/channels/1044887051155292200/1104389271877587004