### PR TITLE
feat: search back to the right

### DIFF
--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -7,7 +7,6 @@ const { notifications } = useNotifications()
 
 <template>
   <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full mt-1 overflow-y-auto>
-    <SearchWidget lg:ms-1 lg:me-5 hidden xl:block />
     <NavSideItem :text="$t('nav.search')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:search-line" hidden sm:block xl:hidden :command="command" />
 
     <div class="spacer" shrink hidden sm:block />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -62,6 +62,7 @@ const isGrayscale = usePreferences('grayscaleMode')
       <aside v-if="isHydrated && !wideLayout" class="hidden lg:w-1/5 xl:w-1/4 sm:none xl:block native:w-full zen-hide">
         <div sticky top-0 h-100dvh flex="~ col" gap-2 py3 ms-2>
           <slot name="right">
+            <SearchWidget mt-4 mx-1 hidden xl:block />
             <div flex-auto />
 
             <PwaPrompt />


### PR DESCRIPTION
It doesn't seems we'll be adding things on the right sidebar for a while more, and moving the search widget to the left was a controversial move from the start.

I'm thinking we should move it back to the right, at least until we have more things in that sidebar to justify the move.

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/583075/236609162-2d63025c-b5e7-4073-93f6-bc833b4c1aad.png">
