### PR TITLE
fix: regression with media hidden

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -22,7 +22,7 @@ const isFiltered = $computed(() => status.account.id !== currentUser.value?.acco
 // check spoiler text or media attachment
 // needed to handle accounts that mark all their posts as sensitive
 const hasSpoilerOrSensitiveMedia = $computed(() => !!status.spoilerText || (status.sensitive && !!status.mediaAttachments.length))
-const isSensitiveNonSpoiler = computed(() => status.sensitive && !status.spoilerText)
+const isSensitiveNonSpoiler = computed(() => status.sensitive && !status.spoilerText && !!status.mediaAttachments.length)
 const hideAllMedia = computed(
   () => {
     return currentUser.value ? (getHideMediaByDefault(currentUser.value.account) && !!status.mediaAttachments.length) : false

--- a/locales/tl-PH.json
+++ b/locales/tl-PH.json
@@ -523,7 +523,7 @@
     "replying_to": "Sumasagot kay {0}",
     "show_full_thread": "Ipakita ang buong thread",
     "someone": "isa",
-    "spoiler_media_hidden": "Nakatago and media",
+    "spoiler_media_hidden": "Nakatago ang media",
     "spoiler_show_less": "Ipakita nang mas kaunti",
     "spoiler_show_more": "Ipakita nang mas marami",
     "thread": "Thread",


### PR DESCRIPTION
This PR will fix a regression on my last PR where if a post is sensitive but does not have a media attached, it shows the spoiler UI. Also sneaked in a fix for a typo in the Tagalog translation