### PR TITLE
feat: review compose buttons

### DIFF
--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -27,7 +27,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
     <NavSideItem :text="$t('nav.bookmarks')" to="/bookmarks" icon="i-ri:bookmark-line" user-only :command="command" />
 
     <div class="spacer" shrink hidden sm:block />
-    <NavSideItem :text="$t('action.compose')" to="/compose" user-only :command="command" font-bold>
+    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-fill" user-only :command="command" font-bold>
       <template #icon>
         <div class="i-ri:quill-pen-fill" text-xl text-primary />
       </template>

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -27,7 +27,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
     <NavSideItem :text="$t('nav.bookmarks')" to="/bookmarks" icon="i-ri:bookmark-line" user-only :command="command" />
 
     <div class="spacer" shrink hidden sm:block />
-    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-fill" user-only :command="command" font-bold />
+    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-line" user-only :command="command" />
 
     <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.explore')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:hashtag" :command="command" xs:hidden sm:hidden xl:block />

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -27,11 +27,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
     <NavSideItem :text="$t('nav.bookmarks')" to="/bookmarks" icon="i-ri:bookmark-line" user-only :command="command" />
 
     <div class="spacer" shrink hidden sm:block />
-    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-fill" user-only :command="command" font-bold>
-      <template #icon>
-        <div class="i-ri:quill-pen-fill" text-xl text-primary />
-      </template>
-    </NavSideItem>
+    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-fill" user-only :command="command" font-bold />
 
     <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.explore')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:hashtag" :command="command" xs:hidden sm:hidden xl:block />

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -25,7 +25,13 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
     <NavSideItem :text="$t('nav.conversations')" to="/conversations" icon="i-ri:at-line" user-only :command="command" />
     <NavSideItem :text="$t('nav.favourites')" to="/favourites" :icon="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'" user-only :command="command" />
     <NavSideItem :text="$t('nav.bookmarks')" to="/bookmarks" icon="i-ri:bookmark-line" user-only :command="command" />
-    <NavSideItem :text="$t('action.compose')" to="/compose" icon="i-ri:quill-pen-line" user-only :command="command" />
+
+    <div class="spacer" shrink hidden sm:block />
+    <NavSideItem :text="$t('action.compose')" to="/compose" user-only :command="command" font-bold>
+      <template #icon>
+        <div class="i-ri:quill-pen-fill" text-xl text-primary />
+      </template>
+    </NavSideItem>
 
     <div class="spacer" shrink hidden sm:block />
     <NavSideItem :text="$t('nav.explore')" :to="isHydrated ? `/${currentServer}/explore` : '/explore'" icon="i-ri:hashtag" :command="command" xs:hidden sm:hidden xl:block />

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -45,15 +45,6 @@ router.afterEach(() => {
           <div text-xl i-ri:arrow-left-line class="rtl-flip" btn-text />
         </NuxtLink>
       </CommonTooltip>
-      <CommonTooltip :content="$t('action.compose')">
-        <NuxtLink
-          to="/compose"
-          :aria-label="$t('action.compose')"
-          btn-action-icon
-        >
-          <div text-xl i-ri:quill-pen-line user-only class="rtl-flip" btn-text />
-        </NuxtLink>
-      </CommonTooltip>
     </div>
   </div>
 </template>


### PR DESCRIPTION
We received feedback that:
- It is confusing to have two Compose buttons + the upper publish widget (after adding the one at the top)
- We add the compose button because it was difficult to spot "compose" after we added it to the sidebar as a route instead of a button.

This PR removes the new compose button at the top and instead makes the "compose" on the sidebar more prominent and different from the rest:
- a new spacer above it
- only one using a fill icon, and the icon is always primary (like the button above)
- text is bold

I think this is a good middle ground to try. I would still prefer to avoid using a big orange Compose button on the sidebar. I think it is too distracting (the reason that pushes us in the route direction)

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/583075/236643638-9fbb20b3-7318-4a21-ad28-ee4431d1c698.png">
