### PR TITLE
fix: user acct not respecting domain

### DIFF
--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -59,12 +59,12 @@ export function fetchAccountById(id?: string | null): Promise<mastodon.v1.Accoun
 export async function fetchAccountByHandle(acct: string): Promise<mastodon.v1.Account> {
   const server = currentServer.value
   const userId = currentUser.value?.account.id
-  const userAcct = acct.endsWith(`@${server}`) ? acct.slice(0, -server.length - 1) : acct
+  const domain = currentInstance.value ? getInstanceDomain(currentInstance.value) : undefined
+  const userAcct = (domain && acct.endsWith(`@${domain}`)) ? acct.slice(0, -domain.length - 1) : acct
   const key = `${server}:${userId}:account:${userAcct}`
   const cached = cache.get(key)
   if (cached)
     return cached
-  const domain = currentInstance.value ? getInstanceDomain(currentInstance.value) : undefined
 
   async function lookupAccount() {
     const client = useMastoClient()

--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -43,7 +43,7 @@ export function fetchAccountById(id?: string | null): Promise<mastodon.v1.Accoun
   const cached = cache.get(key)
   if (cached)
     return cached
-  const domain = currentInstance.value ? getInstanceDomain(currentInstance.value) : null
+  const domain = getInstanceDomainFromServer(server)
   const promise = useMastoClient().v1.accounts.fetch(id)
     .then((r) => {
       if (r.acct && !r.acct.includes('@') && domain)
@@ -59,7 +59,7 @@ export function fetchAccountById(id?: string | null): Promise<mastodon.v1.Accoun
 export async function fetchAccountByHandle(acct: string): Promise<mastodon.v1.Account> {
   const server = currentServer.value
   const userId = currentUser.value?.account.id
-  const domain = currentInstance.value ? getInstanceDomain(currentInstance.value) : undefined
+  const domain = getInstanceDomainFromServer(server)
   const userAcct = (domain && acct.endsWith(`@${domain}`)) ? acct.slice(0, -domain.length - 1) : acct
   const key = `${server}:${userId}:account:${userAcct}`
   const cached = cache.get(key)

--- a/composables/users.ts
+++ b/composables/users.ts
@@ -210,8 +210,7 @@ export async function fetchAccountInfo(client: mastodon.Client, server: string) 
   ])
 
   if (!account.acct.includes('@')) {
-    const instance = getInstanceCache(server)
-    const webDomain = instance ? getInstanceDomain(instance) : server
+    const webDomain = getInstanceDomainFromServer(server)
     account.acct = `${account.acct}@${webDomain}`
   }
 
@@ -220,6 +219,12 @@ export async function fetchAccountInfo(client: mastodon.Client, server: string) 
 
   cacheAccount(account, server, true)
   return account
+}
+
+export function getInstanceDomainFromServer(server: string) {
+  const instance = getInstanceCache(server)
+  const webDomain = instance ? getInstanceDomain(instance) : server
+  return webDomain
 }
 
 export async function refreshAccountInfo() {


### PR DESCRIPTION
We were constructing the `acct` for the active user as `handle@server` instead of `handle@domain` (for example `vite@m.webtoo.ls` instead of `vite@webtoo.ls`). You can reproduce by hovering over your account on the user picker, and if you click on it in the URL you'll see a URL like `https://elk.zone/m.webtoo.ls/@elk@m.webtoo.ls` instead of `https://elk.zone/m.webtoo.ls/@elk`.

@userquin, in the end, we had everything in place to respect the instance domain (using `uri` in Mastodon and also supporting GoToSocial). This was also used as the key in local storage so there is backward compat code.