### PR TITLE
fix(ui): handle empty spoiler text

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -21,7 +21,8 @@ const isFiltered = $computed(() => status.account.id !== currentUser.value?.acco
 
 // check spoiler text or media attachment
 // needed to handle accounts that mark all their posts as sensitive
-const hasSpoilerOrSensitiveMedia = $computed(() => !!status.spoilerText || (status.sensitive && !!status.mediaAttachments.length))
+const spoilerTextPresent = $computed(() => !!status.spoilerText && status.spoilerText.trim().length === 0)
+const hasSpoilerOrSensitiveMedia = $computed(() => spoilerTextPresent || (status.sensitive && !!status.mediaAttachments.length))
 const isSensitiveNonSpoiler = computed(() => status.sensitive && !status.spoilerText && !!status.mediaAttachments.length)
 const hideAllMedia = computed(
   () => {
@@ -40,7 +41,7 @@ const hideAllMedia = computed(
   >
     <StatusBody v-if="(!isFiltered && isSensitiveNonSpoiler) || hideAllMedia" :status="status" :newer="newer" :with-action="!isDetails" :class="isDetails ? 'text-xl' : ''" />
     <StatusSpoiler :enabled="hasSpoilerOrSensitiveMedia || isFiltered" :filter="isFiltered" :sensitive-non-spoiler="isSensitiveNonSpoiler || hideAllMedia" :is-d-m="isDM">
-      <template v-if="status.spoilerText" #spoiler>
+      <template v-if="spoilerTextPresent" #spoiler>
         <p>{{ status.spoilerText }}</p>
       </template>
       <template v-else-if="filterPhrase" #spoiler>


### PR DESCRIPTION
It seems some servers sending empty expoiler text.

closes #2090

![imagen](https://github.com/elk-zone/elk/assets/6311119/10a2c62b-4de4-4240-8dc3-310f2165c9d1)
