### PR TITLE
feat(docs): allow edit any locale file

### DIFF
--- a/config/i18n.ts
+++ b/config/i18n.ts
@@ -9,12 +9,12 @@ interface LocaleObjectData extends LocaleObject {
   pluralRule?: PluralizationRule
 }
 
-const countryLocaleVariants: Record<string, LocaleObjectData[]> = {
+export const countryLocaleVariants: Record<string, (LocaleObjectData & { country?: boolean }) []> = {
   ar: [
     // ar.json contains ar-EG translations
     // { code: 'ar-DZ', name: 'Arabic (Algeria)' },
     // { code: 'ar-BH', name: 'Arabic (Bahrain)' },
-    { code: 'ar-EG', name: 'العربية' },
+    { country: true, code: 'ar-EG', name: 'العربية' },
     // { code: 'ar-EG', name: 'Arabic (Egypt)' },
     // { code: 'ar-IQ', name: 'Arabic (Iraq)' },
     // { code: 'ar-JO', name: 'Arabic (Jordan)' },
@@ -32,13 +32,13 @@ const countryLocaleVariants: Record<string, LocaleObjectData[]> = {
   ],
   en: [
     // en.json contains en-US translations
-    { code: 'en-US', name: 'English (US)' },
+    { country: true, code: 'en-US', name: 'English (US)' },
     { code: 'en-GB', name: 'English (UK)' },
   ],
   ca: [
     // ca.json contains ca-ES translations
     // { code: 'ca-AD', name: 'Català (Andorra)' },
-    { code: 'ca-ES', name: 'Català (Espanya)' },
+    { country: true, code: 'ca-ES', name: 'Català (Espanya)' },
     { code: 'ca-valencia', name: 'Català (valencià)' },
     // { code: 'ca-FR', name: 'Català (França)' },
     // { code: 'ca-IT', name: 'Català (Itàlia)' },
@@ -52,7 +52,7 @@ const countryLocaleVariants: Record<string, LocaleObjectData[]> = {
     // { code: 'es-CR', name: 'Español (Costa Rica)' },
     // { code: 'es-DO', name: 'Español (República Dominicana)' },
     // { code: 'es-EC', name: 'Español (Ecuador)' },
-    { code: 'es-ES', name: 'Español (España)' },
+    { country: true, code: 'es-ES', name: 'Español (España)' },
     // TODO: Support es-419, if we include spanish country variants remove also fix on utils/language.ts module
     { code: 'es-419', name: 'Español (Latinoamérica)' },
     // { code: 'es-GT', name: 'Español (Guatemala)' },
@@ -69,7 +69,7 @@ const countryLocaleVariants: Record<string, LocaleObjectData[]> = {
   ],
   pt: [
     // pt.json contains pt-PT translations
-    { code: 'pt-PT', name: 'Português (Portugal)' },
+    { country: true, code: 'pt-PT', name: 'Português (Portugal)' },
     { code: 'pt-BR', name: 'Português (Brasil)' },
   ],
 }

--- a/docs/components/global/TranslationState.vue
+++ b/docs/components/global/TranslationState.vue
@@ -107,7 +107,7 @@ async function copyToClipboard() {
         </tr>
       </thead>
       <tbody>
-        <template v-for="({ title, file, translated, missing, outdated, total, isSource }, key) in localesStatuses" :key="key">
+        <template v-for="({ title, useFile, translated, missing, outdated, total, isSource }, key) in localesStatuses" :key="key">
           <tr
             v-if="totalReference > 0"
             :class="[{ expandable: !isSource }]"
@@ -121,10 +121,24 @@ async function copyToClipboard() {
               </div>
             </td>
             <template v-if="isSource">
-              <td colspan="5" class="source-text">
+              <td colspan="4" class="source-text">
                 <div>
                   {{ total }} keys as source
                 </div>
+              </td>
+              <td>
+                <NuxtLink
+                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
+                  target="_blank"
+                  class="codeflow"
+                  title="Raise a PR with Codeflow (opens in new window)"
+                  @click.stop
+                >
+                  Edit
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+                    <path fill="currentColor" d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h14v-7h2v7q0 .825-.587 1.413Q19.825 21 19 21Zm4.7-5.3l-1.4-1.4L17.6 5H14V3h7v7h-2V6.4Z" />
+                  </svg>
+                </NuxtLink>
               </td>
             </template>
             <template v-else>
@@ -140,8 +154,7 @@ async function copyToClipboard() {
               <td><strong>{{ `${total}` }}</strong></td>
               <td>
                 <NuxtLink
-                  v-if="outdated.length > 0 || missing.length > 0"
-                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${file}`"
+                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
                   target="_blank"
                   class="codeflow"
                   title="Raise a PR with Codeflow (opens in new window)"

--- a/docs/types.ts
+++ b/docs/types.ts
@@ -1,6 +1,7 @@
 export interface LocaleEntry {
   title: string
   file: string
+  useFile: string
   translated: string[]
   missing: string[]
   outdated: string[]

--- a/locales/es.json
+++ b/locales/es.json
@@ -98,6 +98,8 @@
     "error": "ERROR",
     "fetching": "Cargando...",
     "in": "en",
+    "no_bookmarks": "Sin publicaciones marcadas todavía",
+    "no_favourites": "Sin publicaciones favoritas todavía",
     "not_found": "404 No Encontrado",
     "offline_desc": "Al parecer no tienes conexión a internet. Por favor, comprueba tu conexión a la red."
   },
@@ -211,7 +213,7 @@
         "title": "Acciones"
       },
       "media": {
-        "title": "Media"
+        "title": "Multimedia"
       },
       "navigation": {
         "go_to_home": "Inicio",
@@ -293,6 +295,7 @@
     "followed_you_count": "{0} personas te siguieron|{0} persona te siguió|{0} personas te siguieron",
     "missing_type": "MISSING notification.type:",
     "reblogged_post": "retooteó tu publicación",
+    "reported": "{0} reportó {1}",
     "request_to_follow": "ha solicitado seguirte",
     "signed_up": "registrado",
     "update_status": "ha actualizado su publicación"
@@ -444,12 +447,14 @@
       "hide_boost_count": "Ocultar contador de retoots",
       "hide_favorite_count": "Ocultar número de publicaciones favoritas",
       "hide_follower_count": "Ocultar número de seguidores",
+      "hide_news": "Ocultar noticias",
       "hide_reply_count": "Ocultar número de respuestas",
       "hide_translation": "Ocultar traducción",
       "hide_username_emojis": "Ocultar emojis en el nombre de usuario",
       "hide_username_emojis_description": "Oculta los emojis de los nombres de usuarios en la línea de tiempo. Los emojis permanecerán visibles en sus perfiles.",
       "label": "Preferencias",
       "title": "Funcionalidades experimentales",
+      "use_star_favorite_icon": "Utilizar icono de estrella para favoritos",
       "user_picker": "Selector de usuarios",
       "virtual_scroll": "Desplazamiento virtual",
       "wellbeing": "Bienestar",
@@ -523,6 +528,7 @@
     "replying_to": "Respondiendo a {0}",
     "show_full_thread": "Mostrar hilo completo",
     "someone": "alguien",
+    "spoiler_media_hidden": "Multimedia oculta",
     "spoiler_show_less": "Mostrar menos",
     "spoiler_show_more": "Mostrar más",
     "thread": "Hilo",


### PR DESCRIPTION
This PR includes:
- add country file flag to country variants
- allow edit any translation file, no matter the state
- allow edit `en-US` translation
- included missing entries in `es` locale
- edit country translation file when required

/cc @patak-dev @mrcego 