### PR TITLE
chore: replace deprecated fetchV1Instance with V2

### DIFF
--- a/composables/masto/masto.ts
+++ b/composables/masto/masto.ts
@@ -1,6 +1,6 @@
 import type { Pausable } from '@vueuse/core'
 import type { CreateClientParams, WsEvents, mastodon } from 'masto'
-import { createClient, fetchV1Instance } from 'masto'
+import { createClient, fetchV2Instance } from 'masto'
 import type { Ref } from 'vue'
 import type { ElkInstance } from '../users'
 import type { Mutable } from '~/types/utils'
@@ -38,18 +38,18 @@ export function mastoLogin(masto: ElkMasto, user: Pick<UserLogin, 'server' | 'to
 
   const server = user.server
   const url = `https://${server}`
-  const instance: ElkInstance = reactive(getInstanceCache(server) || { uri: server, accountDomain: server })
+  const instance: ElkInstance = reactive(getInstanceCache(server) ?? { domain: server, accountDomain: server })
   setParams({
     url,
     accessToken: user?.token,
     disableVersionCheck: true,
-    streamingApiUrl: instance?.urls?.streamingApi,
+    streamingApiUrl: instance?.configuration?.urls?.streamingApi,
   })
 
-  fetchV1Instance({ url }).then((newInstance) => {
+  fetchV2Instance({ url }).then((newInstance) => {
     Object.assign(instance, newInstance)
     setParams({
-      streamingApiUrl: newInstance.urls.streamingApi,
+      streamingApiUrl: newInstance.configuration.urls.streamingApi,
     })
     instanceStorage.value[server] = newInstance
   })

--- a/composables/users.ts
+++ b/composables/users.ts
@@ -1,4 +1,3 @@
-import { withoutProtocol } from 'ufo'
 import type { mastodon } from 'masto'
 import type { EffectScope, Ref } from 'vue'
 import type { MaybeRefOrGetter, RemovableRef } from '@vueuse/core'
@@ -45,14 +44,13 @@ function initializeUsers(): Promise<Ref<UserLogin[]> | RemovableRef<UserLogin[]>
 const users = process.server ? initializeUsers() as Ref<UserLogin[]> | RemovableRef<UserLogin[]> : await initializeUsers()
 const nodes = useLocalStorage<Record<string, any>>(STORAGE_KEY_NODES, {}, { deep: true })
 const currentUserHandle = useLocalStorage<string>(STORAGE_KEY_CURRENT_USER_HANDLE, mock ? mock.user.account.id : '')
-export const instanceStorage = useLocalStorage<Record<string, mastodon.v1.Instance>>(STORAGE_KEY_SERVERS, mock ? mock.server : {}, { deep: true })
+export const instanceStorage = useLocalStorage<Record<string, mastodon.v2.Instance>>(STORAGE_KEY_SERVERS, mock ? mock.server : {}, { deep: true })
 
-export type ElkInstance = Partial<mastodon.v1.Instance> & {
-  uri: string
+export type ElkInstance = Partial<Omit<mastodon.v2.Instance, 'domain'>> & Pick<mastodon.v2.Instance, 'domain'> & {
   /** support GoToSocial */
   accountDomain?: string | null
 }
-export function getInstanceCache(server: string): mastodon.v1.Instance | undefined {
+export function getInstanceCache(server: string): mastodon.v2.Instance | undefined {
   return instanceStorage.value[server]
 }
 
@@ -70,7 +68,7 @@ const publicInstance = ref<ElkInstance | null>(null)
 export const currentInstance = computed<null | ElkInstance>(() => currentUser.value ? instanceStorage.value[currentUser.value.server] ?? null : publicInstance.value)
 
 export function getInstanceDomain(instance: ElkInstance) {
-  return instance.accountDomain || withoutProtocol(instance.uri)
+  return instance.accountDomain ?? instance.domain
 }
 
 export const publicServer = ref('')


### PR DESCRIPTION
fetchV1Instance [is deprecated](https://docs.joinmastodon.org/methods/instance/#v1).
This PR replaces it with its V2 equivalent