### PR TITLE
feat: expand Mastodon links as preview cards

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   status: mastodon.v1.Status
   details?: boolean
   command?: boolean
+  hideFavoritedAndBoostedBy?: boolean
+  hideMentionAccount?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -176,6 +178,7 @@ function showFavoritedAndBoostedBy() {
         </template>
 
         <CommonDropdownItem
+          v-if="!hideFavoritedAndBoostedBy"
           :text="$t('menu.show_favourited_and_boosted_by')"
           icon="i-ri:hearts-line"
           :command="command"
@@ -254,12 +257,14 @@ function showFavoritedAndBoostedBy() {
             />
           </template>
           <template v-else>
-            <CommonDropdownItem
-              :text="$t('menu.mention_account', [`@${status.account.acct}`])"
-              icon="i-ri:at-line"
-              :command="command"
-              @click="mentionUser(status.account)"
-            />
+            <template v-if="!hideMentionAccount ?? false">
+              <CommonDropdownItem
+                :text="$t('menu.mention_account', [`@${status.account.acct}`])"
+                icon="i-ri:at-line"
+                :command="command"
+                @click="mentionUser(status.account)"
+              />
+            </template>
           </template>
         </template>
       </div>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
   status: mastodon.v1.Status
   details?: boolean
   command?: boolean
+  hideCopyLinkToPost?: boolean
   hideFavoritedAndBoostedBy?: boolean
   hideMentionAccount?: boolean
 }>()
@@ -186,6 +187,7 @@ function showFavoritedAndBoostedBy() {
         />
 
         <CommonDropdownItem
+          v-if="!hideCopyLinkToPost"
           :text="$t('menu.copy_link_to_post')"
           icon="i-ri:link"
           :command="command"

--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -71,7 +71,6 @@ const hideAllMedia = computed(
 <template>
   <div
     space-y-3
-    my-4
     :class="{
       'pt2 pb0.5 px3.5 bg-dm rounded-4 me--1': isDM,
       'ms--3.5 mt--1 ms--1': isDM && context !== 'details',

--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -17,8 +17,8 @@ const gitHubCards = $(usePreferences('experimentalGitHubCards'))
 </script>
 
 <template>
-  <StatusPreviewMastodon v-if="linkToStatus" :link-to-status="linkToStatus" :source-status="status" :card="card" />
-  <LazyStatusPreviewGitHub v-else-if="gitHubCards && providerName.toLowerCase().includes('github')" :card="card" />
-  <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName.toLowerCase().includes('stackblitz')" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+  <LazyStatusPreviewGitHub v-if="gitHubCards && providerName.toLowerCase() === 'gitHub'" :card="card" />
+  <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName.toLowerCase() === 'stackblitz'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+  <StatusPreviewMastodon v-else-if="linkToStatus" :link-to-status="linkToStatus" :source-status="status" :card="card" />
   <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>

--- a/components/status/StatusPreviewCard.vue
+++ b/components/status/StatusPreviewCard.vue
@@ -2,20 +2,23 @@
 import type { mastodon } from 'masto'
 
 const props = defineProps<{
+  status?: mastodon.v1.Status
   card: mastodon.v1.PreviewCard
   /** For the preview image, only the small image mode is displayed */
   smallPictureOnly?: boolean
   /** When it is root card in the list, not appear as a child card */
   root?: boolean
+  linkToStatus?: URL
 }>()
 
-const providerName = props.card.providerName
+const providerName = $computed(() => props.card.providerName ? props.card.providerName : new URL(props.card.url).hostname)
 
 const gitHubCards = $(usePreferences('experimentalGitHubCards'))
 </script>
 
 <template>
-  <LazyStatusPreviewGitHub v-if="gitHubCards && providerName === 'GitHub'" :card="card" />
-  <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName === 'StackBlitz'" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
+  <StatusPreviewMastodon v-if="linkToStatus" :link-to-status="linkToStatus" :source-status="status" :card="card" />
+  <LazyStatusPreviewGitHub v-else-if="gitHubCards && providerName.toLowerCase().includes('github')" :card="card" />
+  <LazyStatusPreviewStackBlitz v-else-if="gitHubCards && providerName.toLowerCase().includes('stackblitz')" :card="card" :small-picture-only="smallPictureOnly" :root="root" />
   <StatusPreviewCardNormal v-else :card="card" :small-picture-only="smallPictureOnly" :root="root" />
 </template>

--- a/components/status/StatusPreviewCardInfo.vue
+++ b/components/status/StatusPreviewCardInfo.vue
@@ -15,20 +15,21 @@ defineProps<{
     max-h-2xl
     flex flex-col
     my-auto
+    p4
     :class="[
       root ? 'flex-gap-1' : 'justify-center sm:justify-start',
     ]"
   >
-    <p text-secondary break-all line-clamp-1>
+    <p text-secondary ws-pre-wrap break-all line-clamp-1>
       {{ provider }}
     </p>
     <strong
       v-if="card.title" font-normal sm:font-medium line-clamp-1
-      break-all
+      break-all ws-pre-wrap
     >{{ card.title }}</strong>
     <p
       v-if="card.description"
-      line-clamp-1 break-all sm:break-words text-secondary :class="[root ? 'sm:line-clamp-2' : '']"
+      line-clamp-1 break-all sm:break-normal text-secondary ws-pre-wrap sm:line-clamp-2
     >
       {{ card.description }}
     </p>

--- a/components/status/StatusPreviewMastodon.vue
+++ b/components/status/StatusPreviewMastodon.vue
@@ -60,7 +60,6 @@ const derivedStatus = $computed(() => {
   } as mastodon.v1.Status
 })
 
-const createdAt = useFormattedDateTime(derivedStatus.createdAt)
 const timeAgoOptions = useTimeAgoOptions(true)
 const timeago = useTimeAgo(() => derivedStatus.createdAt ?? Date.now(), timeAgoOptions)
 </script>
@@ -111,7 +110,7 @@ const timeago = useTimeAgo(() => derivedStatus.createdAt ?? Date.now(), timeAgoO
           </div>
         </div>
         <div flex-auto />
-        <StatusActionsMore v-if="derivedStatus" :status="derivedStatus" :details="false" :command="false" :hide-favorited-and-boosted-by="true" :hide-mention-account="true" me--2 />
+        <StatusActionsMore v-if="derivedStatus" :status="derivedStatus" :details="false" :command="false" :hide-copy-link-to-post="true" :hide-favorited-and-boosted-by="true" :hide-mention-account="true" me--2 />
       </div>
       <!-- Content -->
       <div space-y-3 my-2>
@@ -124,7 +123,8 @@ const timeago = useTimeAgo(() => derivedStatus.createdAt ?? Date.now(), timeAgoO
         <StatusMedia
           v-if="derivedStatus.mediaAttachments?.length > 0"
           :status="derivedStatus"
-          :is-preview="true"
+          :full-size="true"
+          :is-preview="false"
         />
       </div>
       <!-- END -->

--- a/components/status/StatusPreviewMastodon.vue
+++ b/components/status/StatusPreviewMastodon.vue
@@ -41,7 +41,7 @@ const derivedStatus = $computed(() => {
     acct,
     displayName: card.title.replaceAll(/\(@[^\)]+\)/gi, '').trim(),
     bot: false,
-    avatar: 'https://static.fedified.com/avatars/original/missing.png',
+    avatar: 'https://raw.githubusercontent.com/mastodon/mastodon/38c6216082e67581e83d04b3096cdb020ad0edea/public/avatars/original/missing.png',
   }
 
   return {

--- a/components/status/StatusPreviewMastodon.vue
+++ b/components/status/StatusPreviewMastodon.vue
@@ -53,7 +53,7 @@ const derivedStatus = $computed(() => {
     mentions: Array<mastodon.v1.StatusMention>(),
     emojis: Array<mastodon.v1.CustomEmoji>(),
     language: null,
-    content: card.description.replace(/^attached.? ?\d* (?:image|video)?[\n\r]*/gi, '').trim(),
+    content: card.description.replace(/^attached.? ?\d* (?:images?|videos?)?[\n\r]*/gi, '').trim(),
     // account: useAccountByHandle(acct).value ?? placeholderAccount as mastodon.v1.Account,
     account: placeholderAccount as mastodon.v1.Account,
     mediaAttachments: (!possibleMediaAttachment) ? Array<mastodon.v1.MediaAttachment>() : [possibleMediaAttachment],

--- a/components/status/StatusPreviewMastodon.vue
+++ b/components/status/StatusPreviewMastodon.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { mastodon } from 'masto'
+
+const props = withDefaults(defineProps<{
+  card: mastodon.v1.PreviewCard
+  linkToStatus: URL
+  sourceStatus?: mastodon.v1.Status
+  inNotification?: boolean
+}>(), {
+  inNotification: false,
+})
+
+const userSettings = useUserSettings()
+
+// build the Status from Card
+const card = $computed(() => props.card)
+const linkToStatus = $computed(() => props.linkToStatus)
+const sourceStatus = computed(() => props.sourceStatus)
+
+const acct: string = $computed(() => (window.location.hostname === linkToStatus.host) ? linkToStatus.pathname.split('/')[1].replace('@', '') : `${linkToStatus.pathname.split('/')[1].replace('@', '')}@${linkToStatus.hostname}`)
+const username: string = $computed(() => acct.split('@')[0])
+const serverName: string = $computed(() => acct.split('@')[1])
+const possibleMediaAttachment: mastodon.v1.MediaAttachment | undefined = $computed(() => {
+  const hasImageAttachment = (card.description.search(/^attached.? ?\d* +image/gi) !== null)
+  const hasVideoAttachment = (card.description.search(/^attached.? ?\d* +video/gi) !== null)
+
+  if (!hasImageAttachment && !hasVideoAttachment)
+    return undefined
+  return {
+    id: card.image!,
+    type: (hasImageAttachment) ? 'image' : 'video',
+    previewUrl: card.image!,
+    blurhash: card.blurhash,
+  }
+})
+
+const derivedStatus = $computed(() => {
+  const path: string = linkToStatus.pathname
+  const placeholderAccount = {
+    id: '',
+    acct,
+    displayName: card.title.replaceAll(/\(@[^\)]+\)/gi, '').trim(),
+    bot: false,
+    avatar: 'https://static.fedified.com/avatars/original/missing.png',
+  }
+
+  return {
+    id: path.substring(path.lastIndexOf('/') + 1),
+    uri: linkToStatus.toString(),
+    url: linkToStatus.toString(),
+    createdAt: sourceStatus?.value?.createdAt, // this is a filler in lieu of a Masto API call
+    editedAt: null,
+    mentions: Array<mastodon.v1.StatusMention>(),
+    emojis: Array<mastodon.v1.CustomEmoji>(),
+    language: null,
+    content: card.description.replace(/^attached.? ?\d* (?:image|video)?[\n\r]*/gi, '').trim(),
+    // account: useAccountByHandle(acct).value ?? placeholderAccount as mastodon.v1.Account,
+    account: placeholderAccount as mastodon.v1.Account,
+    mediaAttachments: (!possibleMediaAttachment) ? Array<mastodon.v1.MediaAttachment>() : [possibleMediaAttachment],
+  } as mastodon.v1.Status
+})
+
+const createdAt = useFormattedDateTime(derivedStatus.createdAt)
+const timeAgoOptions = useTimeAgoOptions(true)
+const timeago = useTimeAgo(() => derivedStatus.createdAt ?? Date.now(), timeAgoOptions)
+</script>
+
+<template v-if="derivedStatus.account">
+  <div
+    flex flex-col
+    display-block of-hidden
+    bg-code
+    relative
+    w-full
+    justify-start
+    rounded-2xl
+    class="border-width-[0.05rem] border-[var(--c-text-secondary)]"
+  >
+    <div
+      p4 flex flex-col justify-between
+      basis-50 flex-auto min-h-fit max-h-fit
+    >
+      <!-- START -->
+      <!-- Account Info -->
+      <div flex basis-full flex-nowrap items-center space-x-2>
+        <div flex="~ row gap-2" grow flex-nowrap items-center justify-items-start align-baseline min-w-fit max-w-fit font-bold text-primary>
+          <AccountAvatar
+            :account="derivedStatus.account" :square="false"
+            basis-1em flex-auto max-w-5 line-clamp-1 ws-pre-wrap
+          />
+          <AccountDisplayName
+            :account="derivedStatus.account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')"
+            flex-none min-w-fit max-w-fit font-bold line-clamp-1 ws-pre-wrap break-all text-primary
+          />
+          <AccountBotIndicator
+            v-if="derivedStatus.account.bot"
+            flex-none min-w-fit max-w-fit me-1
+          />
+        </div>
+        <div flex="~ row gap-2" shrink min-w-0 flex-nowrap items-start align-baseline max-w-fit class="zen-none">
+          <div flex="~ row gap-0" basis-0 grow min-w-0 flex-nowrap items-start align-baseline max-w-fit line-clamp-1 ws-pre-wrap class="zen-none">
+            <div min-w-content>
+              <span text-secondary>{{ username }}</span>
+            </div>
+            <div v-if="serverName" basis-0 grow min-w-0 max-w-fit flex-nowrap items-start align-baseline>
+              <span line-clamp-1 overflow-x-hidden text-secondary font-thin p0 m0 break-all>@{{ serverName }}</span>
+            </div>
+            <div flex-none items-start align-baseline min-w-fit line-clamp-1 class="zen-none">
+              <span text-secondary text-secondary-light> &bull; {{ timeago }}</span>
+            </div>
+          </div>
+        </div>
+        <div flex-auto />
+        <StatusActionsMore v-if="derivedStatus" :status="derivedStatus" :details="false" :command="false" :hide-favorited-and-boosted-by="true" :hide-mention-account="true" me--2 />
+      </div>
+      <!-- Content -->
+      <div space-y-3 my-2>
+        <NuxtLink v-if="derivedStatus.url" :to="derivedStatus.url" external target="_blank">
+          <StatusBody v-if="derivedStatus" :status="derivedStatus" :with-action="false" class="font-light" />
+        </NuxtLink>
+      </div>
+      <!-- Attachments -->
+      <div v-if="card.image" space-y-3 my-2>
+        <StatusMedia
+          v-if="derivedStatus.mediaAttachments?.length > 0"
+          :status="derivedStatus"
+          :is-preview="true"
+        />
+      </div>
+      <!-- END -->
+      <div flex justify-between>
+        <div />
+        <div text-2xl i-ri:mastodon-fill text-secondary />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
This PR repurposes uses the `card` property from a Mastodon-compatible `Status` object to generate an interactive, styled preview card.

For `Status` objects that contain only text, the result looks like this:

<img width="602" alt="open_more_actions_menu" src="https://github.com/elk-zone/elk/assets/116459476/d7a3d69c-c248-4a7a-a4f9-553dd50bb9bf">


For `Status` objects that contain attachments, the result looks like this:

<img width="653" alt="preview_with_attachments" src="https://github.com/elk-zone/elk/assets/116459476/199a3c56-27f5-4604-945f-fb2c9a3ba5b7">

When the body of the preview card is selected (e.g. mouse click, keyboard command), the original status is opened in a new tab. When the "More actions" menu (top right) is selected, the following options are presented:

<img width="710" alt="expanded_mastodon_preview_card" src="https://github.com/elk-zone/elk/assets/116459476/df55d124-df45-4c0c-9f27-3a2b29941b87">


Note that the option to view the post directly is not available. That's intetional as this implementation specifically avoids making additional API calls. In order to enable the `NuxtLink` element that would handle native navigation, we would need to first lookup the `Status` to ensure that it's been federated to the host server. For the same reason, the option to "Mention" the original author is not available.

ref: https://github.com/elk-zone/elk/pull/456
cc: @ayoayco @patak-dev 