### PR TITLE
fix(ui): pwa badge and install prompt now shown

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -47,7 +47,7 @@ const containerClass = computed(() => {
         </div>
         <div flex items-center flex-shrink-0 gap-x-2>
           <slot name="actions" />
-          <PwaBadge lg:hidden />
+          <PwaBadge xl:hidden />
           <NavUser v-if="isHydrated" />
           <NavUserSkeleton v-else />
         </div>
@@ -56,7 +56,7 @@ const containerClass = computed(() => {
         <div hidden />
       </slot>
     </div>
-    <PwaInstallPrompt lg:hidden />
+    <PwaInstallPrompt xl:hidden />
     <div :class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'" m-auto>
       <div hidden :class="{ 'xl:block': $route.name !== 'tag' && !$slots.header }" h-6 />
       <slot />


### PR DESCRIPTION
Right aside is shown using `xl:block` but pwa budge and install prompt using `lg:hidden` and so both hidden when screen between `lg` and `xl`