### PR TITLE
chore: bump to pwa plugin 0.16.4

### DIFF
--- a/docs/content/80.pwa.md
+++ b/docs/content/80.pwa.md
@@ -185,3 +185,46 @@ To debug the PWA service worker in your mobile browser, you will need to:
   - Click on Clear site data button
   - Go to `Application > Service Workers` and check the current service worker is missing or has the status deleted or reduntant.
 6) Disable port forwarding: open the "Port forwarding..." modal again on the `chrome://inspect/#devices` page and either uncheck the "Enable port forwarding" option or remove the entry from the list and click "Done". 
+
+## PWA web manifest and related applications
+
+When adding your application to the `related_applications` PWA web manifest property, you will need some info about them.
+
+### Microsoft Store
+
+Elk is available on Microsoft Store, you can find it in the following url: [Elk](https://www.microsoft.com/store/apps/9N8GZJZQZJZB).
+
+If you want to add your app published in the Microsoft Store as a related application, check the following link: https://learn.microsoft.com/en-us/mem/configmgr/protect/deploy-use/find-a-pfn-for-per-app-vpn#find-a-pfn-if-the-app-is-not-installed-on-a-computer.
+
+To add your application to the related application entry:
+- locate `Store ID`: for Elk it is `9N8GZJZQZJZB`
+- visit the following url (replace `9PNZMMXQHQZ5` with your `Store ID`): https://bspmts.mp.microsoft.com/v1/public/catalog/Retail/Products/9PNZMMXQHQZ5/applockerdata
+
+From the previous url, you will get a json file as response:
+```json
+{
+  "packageFamilyName": "53213ElkTeam.Elk_6x2f3wfg7gnst",
+  "packageIdentityName": "53213ElkTeam.Elk",
+  "windowsPhoneLegacyId": "cf793b8f-863a-45cd-936c-11519a995096",
+  "publisherCertificateName": "CN=B976409D-CB14-4908-A1DF-47FAA5352A5B"
+}
+```
+
+Use the `packageFamilyName` value as the `id` in your `related_applications` entry, for Elk results in (replace `9PNZMMXQHQZ5` with your `Store ID` in the url entry):
+```json
+{
+  "related_applications": [{
+    "platform": "windows",
+    "url": "https://www.microsoft.com/store/apps/9PNZMMXQHQZ5",
+    "id": "53213ElkTeam.Elk_6x2f3wfg7gnst"
+  }]
+}
+```
+
+## PlayStore
+
+WIP
+
+## Apple Store
+
+WIP

--- a/docs/content/80.pwa.md
+++ b/docs/content/80.pwa.md
@@ -221,6 +221,8 @@ Use the `packageFamilyName` value as the `id` in your `related_applications` ent
 }
 ```
 
+<!--
+
 ## PlayStore
 
 WIP
@@ -228,3 +230,5 @@ WIP
 ## Apple Store
 
 WIP
+
+-->

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -124,15 +124,16 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
     edge_side_panel: {
       preferred_width: 480,
     },
-    prefer_related_applications: true,
-    related_applications: [{
+  }
+
+  if (env === 'release') {
+    manifestEntries.prefer_related_applications = true
+    manifestEntries.related_applications = [{
       platform: 'windows',
       url: 'https://www.microsoft.com/store/apps/9PNZMMXQHQZ5',
       id: '9PNZMMXQHQZ5',
-    }],
+    }]
   }
-
-  // TODO: add related_applications, only when env === 'release'
 
   const locales: RequiredWebManifestEntry[] = await Promise.all(
     pwaLocales

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -131,7 +131,7 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
     manifestEntries.related_applications = [{
       platform: 'windows',
       url: 'https://www.microsoft.com/store/apps/9PNZMMXQHQZ5',
-      id: '9PNZMMXQHQZ5',
+      id: '53213ElkTeam.Elk_6x2f3wfg7gnst',
     }]
   }
 

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -124,6 +124,12 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
     edge_side_panel: {
       preferred_width: 480,
     },
+    prefer_related_applications: true,
+    related_applications: [{
+      platform: 'windows',
+      url: 'https://www.microsoft.com/store/apps/9PNZMMXQHQZ5',
+      id: '9PNZMMXQHQZ5',
+    }],
   }
 
   // TODO: add related_applications, only when env === 'release'

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -117,6 +117,13 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
         ],
       },
     },
+    handle_links: 'preferred',
+    launch_handler: {
+      client_mode: ['navigate-existing', 'auto'],
+    },
+    edge_side_panel: {
+      preferred_width: 480,
+    },
   }
 
   // TODO: add related_applications, only when env === 'release'

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ufo": "^1.1.2",
     "ultrahtml": "^1.2.0",
     "unimport": "^3.0.7",
-    "vite-plugin-pwa": "^0.16.0",
+    "vite-plugin-pwa": "^0.16.4",
     "vue-advanced-cropper": "^2.8.8",
     "vue-virtual-scroller": "2.0.0-beta.8",
     "workbox-build": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^3.0.7
         version: 3.0.7(rollup@2.79.1)
       vite-plugin-pwa:
-        specifier: ^0.16.0
-        version: 0.16.0(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
+        specifier: ^0.16.4
+        version: 0.16.4(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
       vue-advanced-cropper:
         specifier: ^2.8.8
         version: 2.8.8(vue@3.3.4)
@@ -13848,8 +13848,8 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-pwa@0.16.0(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0):
-    resolution: {integrity: sha512-E+AQRzHxqNU4ZhEeR8X37/foZB+ezJEhXauE/mcf1UITY6k2Pa1dtlFl+BQu57fTdiVlWim5S0Qy44Yap93Dkg==}
+  /vite-plugin-pwa@0.16.4(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0):
+    resolution: {integrity: sha512-lmwHFIs9zI2H9bXJld/zVTbCqCQHZ9WrpyDMqosICDV0FVnCJwniX1NMDB79HGTIZzOQkY4gSZaVTJTw6maz/Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0


### PR DESCRIPTION
This PR also includes:
- add `edge_side_panel` entry to pwa manifest: https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/sidebar#enable-sidebar-support-of-pwas-in-microsoft-edge
- add `handle_links` and `launch_handler` entries to pwa manifest to handle shorcuts links properly, rn open a new Elk client
- enabled `prefer_related_applications`
- add `related_applications` with MS Store entry

~~On draft, just for testing we've configured last 2 pwa manifest entries properly, I need to change it only when `env === 'release'`.~~

~~Still on draft, awaiting MS confirmation related apps entry is ok.~~ We'll use url from data reported by Daniel, we can check it only when released.

EDIT: I'm testing it in desktop and Android clients, maybe I need to change shortcuts icons: check Elk pwa channel in Discord, shortcuts icons seems to be ok.