### PR TITLE
feat: greater privacy until user is logged in

### DIFF
--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -8,8 +8,8 @@ const { account } = defineProps<{
 const relationship = $(useRelationship(account))
 </script>
 
-<template>
-  <div v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+<template v-if="currentUser && account">
+  <div v-if="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
     <div flex="~ gap2" items-center>
       <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
         <AccountInfo :account="account" />

--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -17,7 +17,7 @@ defineOptions({
 <!-- This is sometimes (like in the sidebar) used directly as a button, and sometimes, like in follow notifications, as a link. I think this component may need a second refactor that either lets an implementation pass in a link or an action and adapt to what's passed in, or the implementations need to be updated to wrap in the action they want to take and this be just the layout for these items -->
 <template>
   <component :is="as" flex gap-3 v-bind="$attrs">
-    <AccountHoverWrapper :disabled="!hoverCard" :account="account">
+    <AccountHoverWrapper :disabled="!hoverCard || !currentUser" :account="account">
       <AccountBigAvatar :account="account" shrink-0 :square="square" />
     </AccountHoverWrapper>
     <div flex="~ col" shrink pt-1 h-full overflow-hidden justify-center leading-none select-none>

--- a/components/account/AccountInlineInfo.vue
+++ b/components/account/AccountInlineInfo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { link = true, avatar = true } = defineProps<{
-  account: mastodon.v1.Account
+const { link = true, avatar = true, account } = defineProps<{
+  account?: mastodon.v1.Account
   link?: boolean
   avatar?: boolean
 }>()
@@ -16,16 +16,29 @@ export default {
 }
 </script>
 
-<template>
-  <AccountHoverWrapper :account="account">
+<template v-if="account">
+  <template v-if="currentUser">
+    <AccountHoverWrapper :account="account" :disabled="!currentUser">
+      <NuxtLink
+        :to="link && account ? getAccountRoute(account) : undefined"
+        :class="link ? 'text-link-rounded -ml-1.5rem pl-1.5rem rtl-(ml0 pl-0.5rem -mr-1.5rem pr-1.5rem)' : ''"
+        v-bind="$attrs"
+        min-w-0 flex gap-2 items-center
+      >
+        <AccountAvatar v-if="account && avatar" :account="account" w-5 h-5 />
+        <AccountDisplayName v-if="account" :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" line-clamp-1 ws-pre-wrap break-all />
+      </NuxtLink>
+    </AccountHoverWrapper>
+  </template>
+  <template v-else>
     <NuxtLink
-      :to="link ? getAccountRoute(account) : undefined"
+      :to="undefined"
       :class="link ? 'text-link-rounded -ml-1.5rem pl-1.5rem rtl-(ml0 pl-0.5rem -mr-1.5rem pr-1.5rem)' : ''"
-      v-bind="$attrs"
       min-w-0 flex gap-2 items-center
+      @click.prevent="checkLogin()"
     >
-      <AccountAvatar v-if="avatar" :account="account" w-5 h-5 />
-      <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" line-clamp-1 ws-pre-wrap break-all />
+      <AccountAvatar v-if="account && avatar" :account="account" w-5 h-5 />
+      <AccountDisplayName v-if="account" :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" line-clamp-1 ws-pre-wrap break-all />
     </NuxtLink>
-  </AccountHoverWrapper>
+  </template>
 </template>

--- a/components/account/AccountMoved.vue
+++ b/components/account/AccountMoved.vue
@@ -14,15 +14,28 @@ defineProps<{
     </div>
 
     <div flex>
-      <NuxtLink :to="getAccountRoute(account.moved!)">
-        <AccountInfo :account="account.moved!" />
-      </NuxtLink>
-      <div flex-auto />
-      <div flex items-center>
-        <NuxtLink :to="getAccountRoute(account.moved as any)" btn-solid inline-block h-fit>
-          {{ $t('account.go_to_profile') }}
+      <template v-if="currentUser">
+        <NuxtLink :to="getAccountRoute(account.moved!)">
+          <AccountInfo :account="account.moved!" />
         </NuxtLink>
-      </div>
+        <div flex-auto />
+        <div flex items-center>
+          <NuxtLink :to="getAccountRoute(account.moved as any)" btn-solid inline-block h-fit>
+            {{ $t('account.go_to_profile') }}
+          </NuxtLink>
+        </div>
+      </template>
+      <template v-else>
+        <NuxtLink :to="undefined" @click.prevent="checkLogin()">
+          <AccountInfo :account="account.moved!" />
+        </NuxtLink>
+        <div flex-auto />
+        <div flex items-center>
+          <NuxtLink :to="undefined" btn-solid inline-block h-fit @click.prevent="checkLogin()">
+            {{ $t('account.go_to_profile') }}
+          </NuxtLink>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/components/account/AccountPostsFollowers.vue
+++ b/components/account/AccountPostsFollowers.vue
@@ -11,68 +11,70 @@ const userSettings = useUserSettings()
 
 <template>
   <div flex gap-5>
-    <NuxtLink
-      :to="getAccountRoute(account)"
-      replace
-      text-secondary
-      exact-active-class="text-primary"
-    >
-      <template #default="{ isExactActive }">
-        <CommonLocalizedNumber
-          keypath="account.posts_count"
-          :count="account.statusesCount"
-          font-bold
-          :class="isExactActive ? 'text-primary' : 'text-base'"
-        />
-      </template>
-    </NuxtLink>
-    <NuxtLink
-      v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
-      :to="getAccountFollowingRoute(account)"
-      replace
-      text-secondary exact-active-class="text-primary"
-    >
-      <template #default="{ isExactActive }">
-        <template
-          v-if="!getPreferences(userSettings, 'hideFollowerCount')"
-        >
+    <template v-if="currentUser">
+      <NuxtLink
+        :to="getAccountRoute(account)"
+        replace
+        text-secondary
+        exact-active-class="text-primary"
+      >
+        <template #default="{ isExactActive }">
           <CommonLocalizedNumber
-            v-if="account.followingCount >= 0"
-            keypath="account.following_count"
-            :count="account.followingCount"
+            keypath="account.posts_count"
+            :count="account.statusesCount"
             font-bold
             :class="isExactActive ? 'text-primary' : 'text-base'"
           />
-          <div v-else flex gap-x-1>
-            <span font-bold text-base>Hidden</span>
-            <span>{{ $t('account.following') }}</span>
-          </div>
         </template>
-        <span v-else>{{ $t('account.following') }}</span>
-      </template>
-    </NuxtLink>
-    <NuxtLink
-      v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
-      :to="getAccountFollowersRoute(account)"
-      replace text-secondary
-      exact-active-class="text-primary"
-    >
-      <template #default="{ isExactActive }">
-        <template v-if="!getPreferences(userSettings, 'hideFollowerCount')">
-          <CommonLocalizedNumber
-            v-if="account.followersCount >= 0"
-            keypath="account.followers_count"
-            :count="account.followersCount"
-            font-bold
-            :class="isExactActive ? 'text-primary' : 'text-base'"
-          />
-          <div v-else flex gap-x-1>
-            <span font-bold text-base>Hidden</span>
-            <span>{{ $t('account.followers') }}</span>
-          </div>
+      </NuxtLink>
+      <NuxtLink
+        v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
+        :to="getAccountFollowingRoute(account)"
+        replace
+        text-secondary exact-active-class="text-primary"
+      >
+        <template #default="{ isExactActive }">
+          <template
+            v-if="!getPreferences(userSettings, 'hideFollowerCount')"
+          >
+            <CommonLocalizedNumber
+              v-if="account.followingCount >= 0"
+              keypath="account.following_count"
+              :count="account.followingCount"
+              font-bold
+              :class="isExactActive ? 'text-primary' : 'text-base'"
+            />
+            <div v-else flex gap-x-1>
+              <span font-bold text-base>Hidden</span>
+              <span>{{ $t('account.following') }}</span>
+            </div>
+          </template>
+          <span v-else>{{ $t('account.following') }}</span>
         </template>
-        <span v-else>{{ $t('account.followers') }}</span>
-      </template>
-    </NuxtLink>
+      </NuxtLink>
+      <NuxtLink
+        v-if="!(isHoverCard && getPreferences(userSettings, 'hideFollowerCount'))"
+        :to="getAccountFollowersRoute(account)"
+        replace text-secondary
+        exact-active-class="text-primary"
+      >
+        <template #default="{ isExactActive }">
+          <template v-if="!getPreferences(userSettings, 'hideFollowerCount')">
+            <CommonLocalizedNumber
+              v-if="account.followersCount >= 0"
+              keypath="account.followers_count"
+              :count="account.followersCount"
+              font-bold
+              :class="isExactActive ? 'text-primary' : 'text-base'"
+            />
+            <div v-else flex gap-x-1>
+              <span font-bold text-base>Hidden</span>
+              <span>{{ $t('account.followers') }}</span>
+            </div>
+          </template>
+          <span v-else>{{ $t('account.followers') }}</span>
+        </template>
+      </NuxtLink>
+    </template>
   </div>
 </template>

--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -13,8 +13,13 @@ defineExpose({
   input,
 })
 
+const isUserLoggedIn = ref<boolean>(currentUser.value !== undefined)
+
 const results = computed(() => {
   if (query.value.length === 0)
+    return []
+
+  else if (!isUserLoggedIn.value && !checkLogin())
     return []
 
   const results = [

--- a/components/status/StatusAccountDetails.vue
+++ b/components/status/StatusAccountDetails.vue
@@ -10,12 +10,25 @@ const userSettings = useUserSettings()
 </script>
 
 <template>
-  <NuxtLink
-    :to="link ? getAccountRoute(account) : undefined"
-    flex="~ col" min-w-0 md:flex="~ row gap-2" md:items-center
-    text-link-rounded
-  >
-    <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
-    <AccountHandle :account="account" class="zen-none" />
-  </NuxtLink>
+  <template v-if="currentUser">
+    <NuxtLink
+      :to="link ? getAccountRoute(account) : undefined"
+      flex="~ col" min-w-0 md:flex="~ row gap-2" md:items-center
+      text-link-rounded
+    >
+      <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
+      <AccountHandle :account="account" class="zen-none" />
+    </NuxtLink>
+  </template>
+  <template v-else>
+    <NuxtLink
+      :to="undefined"
+      flex="~ col" min-w-0 md:flex="~ row gap-2" md:items-center
+      text-link-rounded
+      @click.prevent="checkLogin()"
+    >
+      <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
+      <AccountHandle :account="account" class="zen-none" />
+    </NuxtLink>
+  </template>
 </template>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -35,6 +35,10 @@ const isAuthor = $computed(() => status.account.id === currentUser.value?.accoun
 const { client } = $(useMasto())
 
 function getPermalinkUrl(status: mastodon.v1.Status) {
+  // check login
+  if (!checkLogin())
+    return
+
   const url = getStatusPermalinkRoute(status)
   if (url)
     return `${location.origin}/${url}`
@@ -42,6 +46,10 @@ function getPermalinkUrl(status: mastodon.v1.Status) {
 }
 
 async function copyLink(status: mastodon.v1.Status) {
+  // check login
+  if (!checkLogin())
+    return
+
   const url = getPermalinkUrl(status)
   if (url)
     await clipboard.copy(url)
@@ -61,6 +69,10 @@ async function shareLink(status: mastodon.v1.Status) {
 }
 
 async function deleteStatus() {
+  // check login
+  if (!checkLogin())
+    return
+
   if (await openConfirmDialog({
     title: t('confirm.delete_posts.title'),
     confirm: t('confirm.delete_posts.confirm'),
@@ -78,6 +90,10 @@ async function deleteStatus() {
 }
 
 async function deleteAndRedraft() {
+  // check login
+  if (!checkLogin())
+    return
+
   // TODO confirm to delete
   if (process.dev) {
     // eslint-disable-next-line no-alert
@@ -96,6 +112,10 @@ async function deleteAndRedraft() {
 }
 
 function reply() {
+  // check login
+  if (!checkLogin())
+    return
+
   if (details) {
     // TODO focus to editor
   }
@@ -106,6 +126,10 @@ function reply() {
 }
 
 async function editStatus() {
+  // check login
+  if (!checkLogin())
+    return
+
   await openPublishDialog(`edit-${status.id}`, {
     ...await getDraftFromStatus(status),
     editingStatus: status,
@@ -114,6 +138,10 @@ async function editStatus() {
 }
 
 function showFavoritedAndBoostedBy() {
+  // check login
+  if (!checkLogin())
+    return
+
   openFavoridedBoostedByDialog(status.id)
 }
 </script>

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -70,7 +70,7 @@ const forceShow = ref(false)
 </script>
 
 <template>
-  <StatusLink :status="status" :hover="hover">
+  <StatusLink :status="status" :hover="hover && currentUser !== undefined">
     <!-- Upper border -->
     <div :h="showUpperBorder ? '1px' : '0'" w-auto bg-border mb-1 />
 
@@ -104,11 +104,20 @@ const forceShow = ref(false)
         >
           <div i-ri:repeat-fill me-46px text-green w-16px h-16px class="status-boosted" />
           <div absolute top-1 ms-24px w-32px h-32px rounded-full>
-            <AccountHoverWrapper :account="rebloggedBy">
-              <NuxtLink :to="getAccountRoute(rebloggedBy)">
-                <AccountAvatar :account="rebloggedBy" />
-              </NuxtLink>
-            </AccountHoverWrapper>
+            <template v-if="currentUser">
+              <AccountHoverWrapper :account="rebloggedBy">
+                <NuxtLink :to="getAccountRoute(rebloggedBy)">
+                  <AccountAvatar :account="rebloggedBy" />
+                </NuxtLink>
+              </AccountHoverWrapper>
+            </template>
+            <template v-else>
+              <AccountHoverWrapper :account="rebloggedBy" disabled>
+                <NuxtLink :to="undefined" @click.prevent="checkLogin()">
+                  <AccountAvatar :account="rebloggedBy" />
+                </NuxtLink>
+              </AccountHoverWrapper>
+            </template>
           </div>
           <AccountInlineInfo font-bold :account="rebloggedBy" :avatar="false" text-sm />
         </div>
@@ -135,12 +144,20 @@ const forceShow = ref(false)
           <div v-if="collapseRebloggedBy" absolute flex items-center justify-center top--6px px-2px py-3px rounded-full bg-base>
             <div i-ri:repeat-fill text-green w-16px h-16px />
           </div>
-          <AccountHoverWrapper :account="status.account">
-            <NuxtLink :to="getAccountRoute(status.account)" rounded-full>
-              <AccountBigAvatar :account="status.account" />
-            </NuxtLink>
-          </AccountHoverWrapper>
-
+          <template v-if="currentUser">
+            <AccountHoverWrapper :account="status.account">
+              <NuxtLink :to="getAccountRoute(status.account)" rounded-full>
+                <AccountBigAvatar :account="status.account" />
+              </NuxtLink>
+            </AccountHoverWrapper>
+          </template>
+          <template v-else>
+            <AccountHoverWrapper :account="status.account" disabled>
+              <NuxtLink :to="undefined" rounded-full @click.prevent="checkLogin()">
+                <AccountBigAvatar :account="status.account" />
+              </NuxtLink>
+            </AccountHoverWrapper>
+          </template>
           <div v-if="connectReply" w-full h-full flex mt--3px justify-center>
             <div w-1px border="x base" mb-9 />
           </div>
@@ -150,7 +167,7 @@ const forceShow = ref(false)
         <div flex="~ col 1" min-w-0>
           <!-- Account Info -->
           <div flex items-center space-x-1>
-            <AccountHoverWrapper :account="status.account">
+            <AccountHoverWrapper :account="status.account" :disabled="!currentUser">
               <StatusAccountDetails :account="status.account" />
             </AccountHoverWrapper>
             <div flex-auto />
@@ -160,11 +177,20 @@ const forceShow = ref(false)
                 <StatusVisibilityIndicator v-if="status.visibility !== 'public'" :status="status" />
                 <div flex>
                   <CommonTooltip :content="createdAt">
-                    <NuxtLink :title="status.createdAt" :href="statusRoute.href" @click.prevent="go($event)">
-                      <time text-sm ws-nowrap hover:underline :datetime="status.createdAt">
-                        {{ timeago }}
-                      </time>
-                    </NuxtLink>
+                    <template v-if="currentUser">
+                      <NuxtLink :title="status.createdAt" :href="statusRoute.href" @click.prevent="go($event)">
+                        <time text-sm ws-nowrap hover:underline :datetime="status.createdAt">
+                          {{ timeago }}
+                        </time>
+                      </NuxtLink>
+                    </template>
+                    <template v-else>
+                      <NuxtLink :to="undefined" :title="status.createdAt" @click.prevent="checkLogin()">
+                        <time text-sm ws-nowrap hover:underline :datetime="status.createdAt">
+                          {{ timeago }}
+                        </time>
+                      </NuxtLink>
+                    </template>
                   </CommonTooltip>
                   <StatusEditIndicator :status="status" inline />
                 </div>

--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -32,11 +32,20 @@ useHydratedHead({
 <template>
   <div :id="`status-${status.id}`" flex flex-col gap-2 pt2 pb1 ps-3 pe-4 relative :lang="status.language ?? undefined" aria-roledescription="status-details">
     <StatusActionsMore :status="status" absolute inset-ie-2 top-2 @after-edit="$emit('refetchStatus')" />
-    <NuxtLink :to="getAccountRoute(status.account)" rounded-full hover:bg-active transition-100 pe5 me-a>
-      <AccountHoverWrapper :account="status.account">
-        <AccountInfo :account="status.account" />
-      </AccountHoverWrapper>
-    </NuxtLink>
+    <template v-if="currentUser">
+      <NuxtLink :to="getAccountRoute(status.account)" rounded-full hover:bg-active transition-100 pe5 me-a>
+        <AccountHoverWrapper :account="status.account">
+          <AccountInfo :account="status.account" />
+        </AccountHoverWrapper>
+      </NuxtLink>
+    </template>
+    <template v-else>
+      <NuxtLink :to="undefined" rounded-full hover:bg-active transition-100 pe5 me-a @click.prevent="checkLogin()">
+        <AccountHoverWrapper :account="status.account" disabled>
+          <AccountInfo :account="status.account" />
+        </AccountHoverWrapper>
+      </NuxtLink>
+    </template>
     <StatusContent :status="status" :newer="newer" context="details" />
     <div flex="~ gap-1" items-center text-secondary text-sm>
       <div flex>

--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -19,6 +19,10 @@ function onclick(evt: MouseEvent | KeyboardEvent) {
 }
 
 function go(evt: MouseEvent | KeyboardEvent) {
+  // check login
+  if (!checkLogin())
+    return
+
   if (evt.metaKey || evt.ctrlKey) {
     window.open(statusRoute.href)
   }


### PR DESCRIPTION
Community (open) Elk instances can be source of data leakage to bad actors and to web scrapers who seek to circumvent Mastodon's discoverability settings.

This PR seeks to mitigate the risk of inadvertent and/or unauthorized disclosure by requiring users to log in before:
- [X] running a search
- [X] navigating to account profiles
- [X] navigating to status details

This PR preserves the existing permalink structure. If a user knows the path to a public post or profile, then they will be served the corresponding page. If, however, the user seeks to navigate from that page to another post or profile, they will be prompted to log-in:

- [X] On public posts, unauthenticated users will no longer be able to see who interacted with the post, nor will they be able to copy the permalink. This will make unauthorized crawling of social graphs more challenging
- [X] On public profile pages, unauthenticated users will no longer see follower, following, or total posts (nor be able to explore relationships)