### PR TITLE
fix: account resolution, subdomains, routing logic

### DIFF
--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -7,11 +7,16 @@ const props = defineProps<{
   disabled?: boolean
 }>()
 
-const account = computed(() => props.account || (props.handle ? useAccountByHandle(props.handle!) : undefined))
+const account = ref<mastodon.v1.Account | null>(null)
+
 const userSettings = useUserSettings()
 
 defineOptions({
   inheritAttrs: false,
+})
+
+onMounted(async () => {
+  account.value = props.account || await fetchAccountByHandle(props.handle)
 })
 </script>
 

--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -18,6 +18,7 @@ const { t } = useI18n()
 const { client } = $(useMasto())
 const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 
+const accountServerName = $computed(() => getServerName(account))
 async function toggleMute() {
   if (!relationship!.muting && await openConfirmDialog({
     title: t('confirm.mute_account.title', [account.acct]),
@@ -48,14 +49,14 @@ async function toggleBlockUser() {
 
 async function toggleBlockDomain() {
   if (!relationship!.domainBlocking && await openConfirmDialog({
-    title: t('confirm.block_domain.title', [getServerName(account)]),
+    title: t('confirm.block_domain.title', [accountServerName]),
     confirm: t('confirm.block_domain.confirm'),
     cancel: t('confirm.block_domain.cancel'),
   }) !== 'confirm')
     return
 
   relationship!.domainBlocking = !relationship!.domainBlocking
-  await client.v1.domainBlocks[relationship!.domainBlocking ? 'block' : 'unblock'](getServerName(account))
+  await client.v1.domainBlocks[relationship!.domainBlocking ? 'block' : 'unblock'](accountServerName)
 }
 
 async function toggleReblogs() {
@@ -176,17 +177,17 @@ async function removeUserNote() {
             @click="toggleBlockUser()"
           />
 
-          <template v-if="getServerName(account) !== currentServer">
+          <template v-if="accountServerName !== currentServer">
             <CommonDropdownItem
               v-if="!relationship?.domainBlocking"
-              :text="$t('menu.block_domain', [getServerName(account)])"
+              :text="$t('menu.block_domain', [accountServerName])"
               icon="i-ri:shut-down-line"
               :command="command"
               @click="toggleBlockDomain()"
             />
             <CommonDropdownItem
               v-else
-              :text="$t('menu.unblock_domain', [getServerName(account)])"
+              :text="$t('menu.unblock_domain', [accountServerName])"
               icon="i-ri:restart-line"
               :command="command"
               @click="toggleBlockDomain()"

--- a/components/status/StatusReplyingTo.vue
+++ b/components/status/StatusReplyingTo.vue
@@ -9,13 +9,16 @@ const {
   isSelfReply: boolean
 }>()
 
-const isSelf = $computed(() => status.inReplyToAccountId === status.account.id)
-const account = isSelf ? computed(() => status.account) : useAccountById(status.inReplyToAccountId)
+const account = ref<mastodon.v1.Account | null>(null)
+
+onMounted(async () => {
+  account.value = (status && status.inReplyToAccountId === status.account.id) ? status.account : await fetchAccountById(status.inReplyToAccountId)
+})
 </script>
 
 <template>
   <NuxtLink
-    v-if="status.inReplyToId"
+    v-if="account && status.inReplyToId"
     flex="~ gap2" items-center h-auto text-sm text-secondary
     :to="getStatusInReplyToRoute(status)"
     :title="$t('status.replying_to', [account ? getDisplayName(account) : $t('status.someone')])"

--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -17,6 +17,55 @@ function removeCached(key: string) {
   cache.delete(key)
 }
 
+export function extractAccountWebfinger(webfingerOrUriOrUrl: string) {
+  if (webfingerOrUriOrUrl.includes('/tags/'))
+    return null
+
+  const preNormalized = webfingerOrUriOrUrl.replace('https://', '').replace(`/${currentServer.value}/@`, '')
+  if (preNormalized.replace(/^@+/i, '').search(/^[\w]+@[a-z0-9][\w\.]+\.[a-z]+$/ig) === 0)
+    return preNormalized.replace(/^@+/i, '')
+
+  const normalizedValue = preNormalized.replace('https://', '')
+    .replace('/users/', '/@')
+    .replace('/u/', '/@')
+    .replace('@@', '@')
+    .replace(/^@+/i, '')
+    .replace(/\/statuses\/[0-9a-z\/]+$/ig, '')
+
+  if (normalizedValue.includes('/@')) {
+    const splitValue = normalizedValue.split('/@')
+    return `${splitValue[1]}@${splitValue[0]}`
+  }
+  else if (
+    !normalizedValue.includes('/')
+    && !normalizedValue.startsWith('@')
+    && normalizedValue.includes('@')
+    && normalizedValue.indexOf('@') === normalizedValue.lastIndexOf('@')
+  ) {
+    return normalizedValue
+  }
+  else if (normalizedValue.search(/^[a-z0-9_]{1,30}$/i) === 0) {
+    // see https://github.com/mastodon/mastodon/blob/25c66fa640962a4d54d59a3f53516ab6dcb1dae6/app/models/concerns/omniauthable.rb#L95
+    return normalizedValue
+  }
+  else {
+    if (process.dev)
+      console.warn(`Malformed account URI or URL: ${webfingerOrUriOrUrl}`)
+    return null
+  }
+}
+
+function generateAccountWebfingerCacheKeyAccessibleToCurrentUser(webfingerOrUriOrUrl: string) {
+  const normalizedValue = extractAccountWebfinger(webfingerOrUriOrUrl)
+  if (!normalizedValue)
+    return null
+  return `${currentServer.value}:${currentUser.value?.account.id}:account:${normalizedValue}`
+}
+
+function generateAccountIdCacheKey(accountId: string) {
+  return `${currentServer.value}:${currentUser.value?.account.id}:account:${accountId}`
+}
+
 export function fetchStatus(id: string, force = false): Promise<mastodon.v1.Status> {
   const server = currentServer.value
   const userId = currentUser.value?.account.id
@@ -33,59 +82,185 @@ export function fetchStatus(id: string, force = false): Promise<mastodon.v1.Stat
   return promise
 }
 
-export function fetchAccountById(id?: string | null): Promise<mastodon.v1.Account | null> {
-  if (!id)
+async function federateRemoteAccount(webfingerOrUriOrUrl: string, force = false): Promise<mastodon.v1.Account | null> {
+  const accountWebfinger = extractAccountWebfinger(webfingerOrUriOrUrl)
+  if (!accountWebfinger)
     return Promise.resolve(null)
 
-  const server = currentServer.value
-  const userId = currentUser.value?.account.id
-  const key = `${server}:${userId}:account:${id}`
-  const cached = cache.get(key)
-  if (cached)
-    return cached
-  const domain = getInstanceDomainFromServer(server)
-  const promise = useMastoClient().v1.accounts.fetch(id)
-    .then((r) => {
-      if (r.acct && !r.acct.includes('@') && domain)
-        r.acct = `${r.acct}@${domain}`
+  if (accountWebfinger.includes(currentServer.value)) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.info(`Local domain is authoritative, so redirecting resolution request for account: ${accountWebfinger}`)
 
-      cacheAccount(r, server, true)
-      return r
+    return fetchAccountByHandle(accountWebfinger, force)
+  }
+
+  const cacheKeyAuthoritativeAccount = generateAccountWebfingerCacheKeyAccessibleToCurrentUser(accountWebfinger)!
+
+  const cachedAuthoritative: mastodon.v1.Account | Promise<mastodon.v1.Account> | undefined | null | number = cache.get(cacheKeyAuthoritativeAccount, { allowStale: false, updateAgeOnGet: false })
+
+  if (cachedAuthoritative) {
+    if (
+      !!cachedAuthoritative
+      && !(typeof cachedAuthoritative === 'number')
+      && !(cachedAuthoritative instanceof Promise)
+      && (cachedAuthoritative.acct === accountWebfinger)
+      && !force
+    ) {
+      return cachedAuthoritative
+    }
+    else if (cachedAuthoritative instanceof Promise) {
+      return cachedAuthoritative
+    }
+    else if (typeof cachedAuthoritative === 'number') {
+      if ([401, 403, 418].includes(cachedAuthoritative))
+        console.error(`Current user is forbidden or lacks authorization to fetch account: ${webfingerOrUriOrUrl}`)
+      if ([404].includes(cachedAuthoritative))
+        console.error(`The requested account Webfinger address cannot be found: ${webfingerOrUriOrUrl}`)
+      if ([429].includes(cachedAuthoritative))
+        console.error('The request was rate-limited by the Mastodon server')
+      if ([500, 501, 503].includes(cachedAuthoritative))
+        console.error('The Mastodon server is unresponsive')
+      return Promise.resolve(null)
+    }
+  }
+
+  const promise = useMastoClient().v2.search({ q: accountWebfinger, type: 'accounts', resolve: (!!currentUser.value), limit: 1 })
+    .then((results) => {
+      const account = results.accounts.pop()
+      if (!account) {
+        console.error(`Account could not be federated, perhaps it no longer exists: '${accountWebfinger}'`)
+        cache.set(cacheKeyAuthoritativeAccount, 404)
+        return Promise.resolve(null)
+      }
+
+      account.acct = accountWebfinger
+      // Intentionally overriding cached value because this should be the most recent
+      cache.set(cacheKeyAuthoritativeAccount, account)
+      return account
     })
-  cache.set(key, promise)
+    .catch((e) => {
+      console.error(`Encountered error while federating account using Webfinger address '${accountWebfinger}' | ${(e as Error).message}`)
+      cache.set(cacheKeyAuthoritativeAccount, null)
+      return Promise.resolve(null)
+    })
+  cache.set(cacheKeyAuthoritativeAccount, promise)
   return promise
 }
 
-export async function fetchAccountByHandle(acct: string): Promise<mastodon.v1.Account> {
-  const server = currentServer.value
-  const userId = currentUser.value?.account.id
-  const domain = getInstanceDomainFromServer(server)
-  const userAcct = (domain && acct.endsWith(`@${domain}`)) ? acct.slice(0, -domain.length - 1) : acct
-  const key = `${server}:${userId}:account:${userAcct}`
-  const cached = cache.get(key)
-  if (cached)
-    return cached
+function fetchAccountById(accountId?: string | null, force = false): Promise<mastodon.v1.Account | null> {
+  if (!accountId || accountId.trim() === '')
+    return Promise.resolve(null)
 
-  async function lookupAccount() {
-    const client = useMastoClient()
-    let account: mastodon.v1.Account
-    if (!isGotoSocial.value)
-      account = await client.v1.accounts.lookup({ acct: userAcct })
-    else
-      account = (await client.v1.search({ q: `@${userAcct}`, type: 'accounts' })).accounts[0]
-
-    if (account.acct && !account.acct.includes('@') && domain)
-      account.acct = `${account.acct}@${domain}`
-    return account
+  const cacheKeyAccountId = generateAccountIdCacheKey(accountId)
+  const cachedAccountLocallyAccessibleToCurrentUser: mastodon.v1.Account | Promise<mastodon.v1.Account> | undefined | null | number = cache.get(cacheKeyAccountId)
+  if (cachedAccountLocallyAccessibleToCurrentUser) {
+    // avoid race condition by returning the existing promise instead of restarting the chain of events all over again
+    if (cachedAccountLocallyAccessibleToCurrentUser instanceof Promise)
+      return cachedAccountLocallyAccessibleToCurrentUser
+    if (typeof cachedAccountLocallyAccessibleToCurrentUser === 'number') {
+      // wait for the cached value to expire before trying again
+      if ([401, 403, 418].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`Current user is forbidden or lacks authorization to fetch account id: ${accountId}`)
+      if ([404].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`The requested account id cannot be found: ${accountId}`)
+      if ([429].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`Rate-limiting interrupted request for account id: ${accountId}`)
+      if ([500, 501, 503].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`Unresponsive Mastodon server encountered while fetching account id: ${accountId}`)
+      return Promise.resolve(null)
+    }
+    if (
+      (cachedAccountLocallyAccessibleToCurrentUser.id === accountId)
+      && !force
+      && cachedAccountLocallyAccessibleToCurrentUser.url.includes(currentServer.value)
+    ) {
+      // if we already cached the authoritative value, then return that
+      return Promise.resolve(cachedAccountLocallyAccessibleToCurrentUser)
+    }
   }
 
-  const account = lookupAccount()
-    .then((r) => {
-      cacheAccount(r, server, true)
-      return r
+  const promise = useMastoClient().v1.accounts.fetch(accountId)
+    .then((account) => {
+      const accountWebfinger = extractAccountWebfinger(account.url)
+      if (!accountWebfinger) {
+        console.error(`Malformed or invalid account Webfinger address: ${account.url}`)
+        return null
+      }
+      account.acct = accountWebfinger
+      cache.set(cacheKeyAccountId, account)
+      return account
     })
-  cache.set(key, account)
-  return account
+    .catch((e) => {
+      console.error(`Encountered error while fetching account Id '${accountId}' | ${(e as Error).message}`)
+      cache.set(cacheKeyAccountId, 404)
+      return Promise.resolve(null)
+    })
+  cache.set(cacheKeyAccountId, promise)
+  return promise
+}
+
+export async function fetchAccountByHandle(str: string, force = false): Promise<mastodon.v1.Account | null> {
+  const accountWebfinger = extractAccountWebfinger(str)
+  if (!accountWebfinger) {
+    console.error(`Malformed or invalid account handle: ${str}`)
+    return Promise.resolve(null)
+  }
+  const cacheKeyWebfingerAccount = generateAccountWebfingerCacheKeyAccessibleToCurrentUser(accountWebfinger)!
+  const cachedAccountLocallyAccessibleToCurrentUser: mastodon.v1.Account | Promise<mastodon.v1.Account> | undefined | null | number = cache.get(cacheKeyWebfingerAccount, { allowStale: false, updateAgeOnGet: false })
+
+  if (cachedAccountLocallyAccessibleToCurrentUser) {
+    if (
+      !!cachedAccountLocallyAccessibleToCurrentUser
+      && !(typeof cachedAccountLocallyAccessibleToCurrentUser === 'number')
+      && !(cachedAccountLocallyAccessibleToCurrentUser instanceof Promise)
+      && (cachedAccountLocallyAccessibleToCurrentUser.acct === accountWebfinger)
+    ) {
+      // if the cached version is authoritative, then return it
+      if (!force && (cachedAccountLocallyAccessibleToCurrentUser.url.includes(currentServer.value)))
+        return cachedAccountLocallyAccessibleToCurrentUser
+    }
+    else if (cachedAccountLocallyAccessibleToCurrentUser instanceof Promise) {
+      return cachedAccountLocallyAccessibleToCurrentUser
+    }
+    else if (typeof cachedAccountLocallyAccessibleToCurrentUser === 'number') {
+      if ([401, 403, 418].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`Current user is forbidden or lacks authorization to fetch account: ${accountWebfinger}`)
+      if ([404].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error(`The requested account Webfinger address cannot be found: ${accountWebfinger}`)
+      if ([429].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error('The request was rate-limited by the Mastodon server')
+      if ([500, 501, 503].includes(cachedAccountLocallyAccessibleToCurrentUser))
+        console.error('The Mastodon server is unresponsive')
+      return Promise.resolve(null)
+    }
+  }
+
+  const promise = useMastoClient().v1.accounts.lookup({ acct: parseAcctFromPerspectiveOfCurrentServer(str) ?? str })
+    .then((account) => {
+      account.acct = accountWebfinger
+
+      cache.set(cacheKeyWebfingerAccount, account)
+      const cacheKeyAccountId = generateAccountIdCacheKey(account.id)
+      cache.set(cacheKeyAccountId, account)
+
+      return account
+    })
+    .catch((e) => {
+      if (!accountWebfinger.includes(currentServer.value)) {
+        if (process.dev)
+          // eslint-disable-next-line no-console
+          console.info(`Remote domain is authoritative, so redirecting resolution request for account: ${accountWebfinger}`)
+
+        return federateRemoteAccount(accountWebfinger)
+      }
+      if (process.dev)
+        console.error(`Encountered error while fetching account: '${accountWebfinger}' | ${(e as Error).message}`)
+      cache.set(cacheKeyWebfingerAccount, 404)
+      return Promise.resolve(null)
+    })
+  cache.set(cacheKeyWebfingerAccount, promise)
+  return promise
 }
 
 export function useAccountByHandle(acct: string) {
@@ -106,9 +281,7 @@ export function removeCachedStatus(id: string, server = currentServer.value) {
   removeCached(`${server}:${userId}:status:${id}`)
 }
 
-export function cacheAccount(account: mastodon.v1.Account, server = currentServer.value, override?: boolean) {
-  const userId = currentUser.value?.account.id
-  const userAcct = account.acct.endsWith(`@${server}`) ? account.acct.slice(0, -server.length - 1) : account.acct
-  setCached(`${server}:${userId}:account:${account.id}`, account, override)
-  setCached(`${server}:${userId}:account:${userAcct}`, account, override)
+export function cacheAccount(account: mastodon.v1.Account, override?: boolean) {
+  setCached(generateAccountIdCacheKey(account.id)!, account, override)
+  setCached(generateAccountWebfingerCacheKeyAccessibleToCurrentUser(account.url)!, account, override)
 }

--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -82,7 +82,7 @@ export function fetchStatus(id: string, force = false): Promise<mastodon.v1.Stat
   return promise
 }
 
-function federateRemoteAccount(webfingerOrUriOrUrl: string, force = false): mastodon.v1.Account | Promise<mastodon.v1.Account | null> {
+function federateRemoteAccount(webfingerOrUriOrUrl: string, force = false): Promise<mastodon.v1.Account | null> {
   const accountWebfinger = extractAccountWebfinger(webfingerOrUriOrUrl)
   if (!accountWebfinger) {
     if (process.dev)
@@ -111,7 +111,7 @@ function federateRemoteAccount(webfingerOrUriOrUrl: string, force = false): mast
       && (cachedAuthoritative.acct === accountWebfinger)
       && !force
     ) {
-      return cachedAuthoritative
+      return Promise.resolve(cachedAuthoritative)
     }
     else if (cachedAuthoritative instanceof Promise) {
       return cachedAuthoritative
@@ -173,7 +173,7 @@ function federateRemoteAccount(webfingerOrUriOrUrl: string, force = false): mast
   return promise
 }
 
-export function fetchAccountById(accountId?: string | null, force = false): mastodon.v1.Account | Promise<mastodon.v1.Account | null> {
+export function fetchAccountById(accountId?: string | null, force = false): Promise<mastodon.v1.Account | null> {
   if (!accountId || accountId.trim() === '')
     return Promise.resolve(null)
 
@@ -220,7 +220,7 @@ export function fetchAccountById(accountId?: string | null, force = false): mast
       && cachedAccountLocallyAccessibleToCurrentUser.url.includes(currentServer.value)
     ) {
       // if we already cached the authoritative value, then return that
-      return cachedAccountLocallyAccessibleToCurrentUser
+      return Promise.resolve(cachedAccountLocallyAccessibleToCurrentUser)
     }
   }
 
@@ -244,7 +244,7 @@ export function fetchAccountById(accountId?: string | null, force = false): mast
   return promise
 }
 
-export function fetchAccountByHandle(str?: string, force = false): mastodon.v1.Account | Promise<mastodon.v1.Account | null> {
+export function fetchAccountByHandle(str?: string, force = false): Promise<mastodon.v1.Account | null> {
   if (!str || str.trim() === '')
     return Promise.resolve(null)
 
@@ -265,7 +265,7 @@ export function fetchAccountByHandle(str?: string, force = false): mastodon.v1.A
     ) {
       // if the cached version is authoritative, then return it
       if (!force && (cachedAccountLocallyAccessibleToCurrentUser.url.includes(currentServer.value)))
-        return cachedAccountLocallyAccessibleToCurrentUser
+        return Promise.resolve(cachedAccountLocallyAccessibleToCurrentUser)
     }
     else if (cachedAccountLocallyAccessibleToCurrentUser instanceof Promise) {
       return cachedAccountLocallyAccessibleToCurrentUser

--- a/composables/content-render.ts
+++ b/composables/content-render.ts
@@ -4,6 +4,7 @@ import { Fragment, h, isVNode } from 'vue'
 import type { VNode } from 'vue'
 import { RouterLink } from 'vue-router'
 import { decode } from 'tiny-decode'
+import type { mastodon } from 'masto'
 import type { ContentParseOptions } from './content-parse'
 import { parseMastodonHTML } from './content-parse'
 import ContentCode from '~/components/content/ContentCode.vue'
@@ -33,15 +34,15 @@ export function contentToVNode(
   if (options?.hideEmojis && textContents.length === 0)
     tree = parseMastodonHTML(content, { ...options, hideEmojis: false })
 
-  return h(Fragment, (tree.children as Node[] || []).map(n => treeToVNode(n)))
+  return h(Fragment, (tree.children as Node[] || []).map(n => treeToVNode(n, options?.status ?? options?.inReplyToStatus)))
 }
 
-function nodeToVNode(node: Node): VNode | string | null {
+function nodeToVNode(node: Node, status?: mastodon.v1.Status): VNode | string | null {
   if (node.type === TEXT_NODE)
     return node.value
 
   if (node.name === 'mention-group')
-    return h(ContentMentionGroup, node.attributes, () => node.children.map(treeToVNode))
+    return h(ContentMentionGroup, node.attributes, () => node.children.map((n: Node) => treeToVNode(n, status)))
 
   if ('children' in node) {
     if (node.name === 'a' && (node.attributes.href?.startsWith('/') || node.attributes.href?.startsWith('.'))) {
@@ -51,13 +52,13 @@ function nodeToVNode(node: Node): VNode | string | null {
       return h(
         RouterLink as any,
         attrs,
-        () => node.children.map(treeToVNode),
+        () => node.children.map((n: Node) => treeToVNode(n, status)),
       )
     }
     return h(
       node.name,
       node.attributes,
-      node.children.map(treeToVNode),
+      node.children.map((n: Node) => treeToVNode(n, status)),
     )
   }
   return null
@@ -65,6 +66,7 @@ function nodeToVNode(node: Node): VNode | string | null {
 
 function treeToVNode(
   input: Node,
+  status?: mastodon.v1.Status,
 ): VNode | string | null {
   if (!input)
     return null
@@ -73,17 +75,17 @@ function treeToVNode(
     return decode(input.value)
 
   if ('children' in input) {
-    const node = handleNode(input)
+    const node = handleNode(input, status)
     if (node == null)
       return null
     if (isVNode(node))
       return node
-    return nodeToVNode(node)
+    return nodeToVNode(node, status)
   }
   return null
 }
 
-function handleMention(el: Node) {
+function handleMention(el: Node, status?: mastodon.v1.Status) {
   // Redirect mentions to the user page
   if (el.name === 'a' && el.attributes.class?.includes('mention')) {
     const href = el.attributes.href as string | undefined
@@ -98,9 +100,9 @@ function handleMention(el: Node) {
         const matchUser = href.match(UserLinkRE)
         if (matchUser) {
           const [, server, username] = matchUser
-          const handle = (parseAcctFromPerspectiveOfCurrentServer(href) ?? username)
+          const handle = (deriveMentionHandle(href, status) ?? username)
           el.attributes.href = `/${server}/@${handle}`
-          return h(AccountHoverWrapper, { handle, class: 'inline-block' }, () => nodeToVNode(el))
+          return h(AccountHoverWrapper, { handle, class: 'inline-block' }, () => nodeToVNode(el, status))
         }
       }
     }
@@ -120,6 +122,6 @@ function handleCodeBlock(el: Node) {
   }
 }
 
-function handleNode(el: Node) {
-  return handleCodeBlock(el) || handleMention(el) || el
+function handleNode(el: Node, status?: mastodon.v1.Status) {
+  return handleCodeBlock(el) || handleMention(el, status) || el
 }

--- a/composables/content-render.ts
+++ b/composables/content-render.ts
@@ -86,19 +86,22 @@ function treeToVNode(
 function handleMention(el: Node) {
   // Redirect mentions to the user page
   if (el.name === 'a' && el.attributes.class?.includes('mention')) {
-    const href = el.attributes.href
+    const href = el.attributes.href as string | undefined
     if (href) {
-      const matchUser = href.match(UserLinkRE)
-      if (matchUser) {
-        const [, server, username] = matchUser
-        const handle = `${username}@${server.replace(/(.+\.)(.+\..+)/, '$2')}`
-        el.attributes.href = `/${server}/@${username}`
-        return h(AccountHoverWrapper, { handle, class: 'inline-block' }, () => nodeToVNode(el))
-      }
       const matchTag = href.match(TagLinkRE)
       if (matchTag) {
         const [, , name] = matchTag
         el.attributes.href = `/${currentServer.value}/tags/${name}`
+      }
+      // Only do this if the user is logged in and a tag match failed
+      else if (currentUser.value !== undefined) {
+        const matchUser = href.match(UserLinkRE)
+        if (matchUser) {
+          const [, server, username] = matchUser
+          const handle = (parseAcctFromPerspectiveOfCurrentServer(href) ?? username)
+          el.attributes.href = `/${server}/@${handle}`
+          return h(AccountHoverWrapper, { handle, class: 'inline-block' }, () => nodeToVNode(el))
+        }
       }
     }
   }

--- a/composables/masto/account.ts
+++ b/composables/masto/account.ts
@@ -18,10 +18,7 @@ export function getShortHandle({ acct }: mastodon.v1.Account) {
 }
 
 export function getServerName(account: mastodon.v1.Account) {
-  if (account.acct?.includes('@'))
-    return account.acct.split('@')[1]
-  // We should only lack the server name if we're on the same server as the account
-  return currentInstance.value ? getInstanceDomain(currentInstance.value) : ''
+  return account.url.replace('https://', '').split('/')[0]
 }
 
 export function getFullHandle(account: mastodon.v1.Account) {
@@ -38,6 +35,22 @@ export function toShortHandle(fullHandle: string) {
   if (fullHandle.endsWith(`@${server}`))
     return fullHandle.slice(0, -server.length - 1)
   return fullHandle
+}
+
+export function rawAcctToResolvedAccount(acct: string) {
+  return fetchAccountByHandle(`@${acct}`)
+}
+
+export function getAcctFromPerspectiveOfCurrentServer(account: mastodon.v1.Account) {
+  return `${account.username}@${getServerName(account)}`.replace(`@${currentServer.value}`, '')
+}
+
+export function parseAcctFromPerspectiveOfCurrentServer(webfingerOrUriOrUrl: string) {
+  // see https://github.com/mastodon/mastodon/blob/25c66fa640962a4d54d59a3f53516ab6dcb1dae6/app/models/concerns/omniauthable.rb#L95
+  if (webfingerOrUriOrUrl.search(/^@[a-z0-9_]{1,30}$/i) === 0)
+    return webfingerOrUriOrUrl
+
+  return extractAccountWebfinger(webfingerOrUriOrUrl)?.replace(`@${currentServer.value}`, '') ?? undefined
 }
 
 export function extractAccountHandle(account: mastodon.v1.Account) {

--- a/composables/masto/account.ts
+++ b/composables/masto/account.ts
@@ -22,19 +22,8 @@ export function getServerName(account: mastodon.v1.Account) {
 }
 
 export function getFullHandle(account: mastodon.v1.Account) {
-  const handle = `@${account.acct}`
-  if (!currentUser.value || account.acct.includes('@'))
-    return handle
-  return `${handle}@${getServerName(account)}`
-}
-
-export function toShortHandle(fullHandle: string) {
-  if (!currentUser.value)
-    return fullHandle
-  const server = currentUser.value.server
-  if (fullHandle.endsWith(`@${server}`))
-    return fullHandle.slice(0, -server.length - 1)
-  return fullHandle
+  const handle = `@${account.username}@${getServerName(account)}`
+  return (currentUser.value?.server) ? handle.replace(`@${currentUser.value?.server}`, '') : handle
 }
 
 export function rawAcctToResolvedAccount(acct: string) {
@@ -60,11 +49,4 @@ export function extractAccountHandle(account: mastodon.v1.Account) {
     handle = handle.slice(0, -uri.length - 1)
 
   return handle
-}
-
-export function useAccountHandle(account: mastodon.v1.Account, fullServer = true) {
-  return computed(() => fullServer
-    ? getFullHandle(account)
-    : getShortHandle(account),
-  )
 }

--- a/composables/masto/account.ts
+++ b/composables/masto/account.ts
@@ -1,5 +1,5 @@
 import type { mastodon } from 'masto'
-import type { type ShallowUnwrapRef, UnwrapNestedRefs, UnwrapRef } from 'vue'
+import type { ShallowUnwrapRef, UnwrapNestedRefs, UnwrapRef } from 'vue'
 
 export function getDisplayName(account: mastodon.v1.Account, options?: { rich?: boolean }) {
   const displayName = account.displayName || account.username || account.acct || ''

--- a/composables/masto/routes.ts
+++ b/composables/masto/routes.ts
@@ -1,7 +1,8 @@
 import { withoutProtocol } from 'ufo'
 import type { mastodon } from 'masto'
+import type { ShallowUnwrapRef, UnwrapNestedRefs, UnwrapRef } from 'vue'
 
-export function getAccountRoute(account: mastodon.v1.Account) {
+export function getAccountRoute(account: mastodon.v1.Account | ShallowUnwrapRef<mastodon.v1.Account> | UnwrapRef<mastodon.v1.Account> | UnwrapNestedRefs<mastodon.v1.Account>) {
   return useRouter().resolve({
     name: 'account-index',
     params: {
@@ -10,7 +11,7 @@ export function getAccountRoute(account: mastodon.v1.Account) {
     },
   })
 }
-export function getAccountFollowingRoute(account: mastodon.v1.Account) {
+export function getAccountFollowingRoute(account: mastodon.v1.Account | ShallowUnwrapRef<mastodon.v1.Account> | UnwrapRef<mastodon.v1.Account> | UnwrapNestedRefs<mastodon.v1.Account>) {
   return useRouter().resolve({
     name: 'account-following',
     params: {
@@ -19,7 +20,7 @@ export function getAccountFollowingRoute(account: mastodon.v1.Account) {
     },
   })
 }
-export function getAccountFollowersRoute(account: mastodon.v1.Account) {
+export function getAccountFollowersRoute(account: mastodon.v1.Account | ShallowUnwrapRef<mastodon.v1.Account> | UnwrapRef<mastodon.v1.Account> | UnwrapNestedRefs<mastodon.v1.Account>) {
   return useRouter().resolve({
     name: 'account-followers',
     params: {

--- a/composables/masto/routes.ts
+++ b/composables/masto/routes.ts
@@ -6,7 +6,7 @@ export function getAccountRoute(account: mastodon.v1.Account) {
     name: 'account-index',
     params: {
       server: currentServer.value,
-      account: extractAccountHandle(account),
+      account: getAcctFromPerspectiveOfCurrentServer(account),
     },
   })
 }
@@ -15,7 +15,7 @@ export function getAccountFollowingRoute(account: mastodon.v1.Account) {
     name: 'account-following',
     params: {
       server: currentServer.value,
-      account: extractAccountHandle(account),
+      account: getAcctFromPerspectiveOfCurrentServer(account),
     },
   })
 }
@@ -24,7 +24,7 @@ export function getAccountFollowersRoute(account: mastodon.v1.Account) {
     name: 'account-followers',
     params: {
       server: currentServer.value,
-      account: extractAccountHandle(account),
+      account: getAcctFromPerspectiveOfCurrentServer(account),
     },
   })
 }
@@ -38,7 +38,7 @@ export function getStatusRoute(status: mastodon.v1.Status) {
     name: 'status',
     params: {
       server: currentServer.value,
-      account: extractAccountHandle(status.account),
+      account: getAcctFromPerspectiveOfCurrentServer(status.account),
       status: status.id,
     },
   })

--- a/composables/users.ts
+++ b/composables/users.ts
@@ -217,7 +217,7 @@ export async function fetchAccountInfo(client: mastodon.Client, server: string) 
   // TODO: lazy load preferences
   accountPreferencesMap.set(account.acct, preferences)
 
-  cacheAccount(account, server, true)
+  cacheAccount(account, true)
   return account
 }
 

--- a/pages/[[server]]/@[account]/index.vue
+++ b/pages/[[server]]/@[account]/index.vue
@@ -4,11 +4,10 @@ definePageMeta({
 })
 
 const params = useRoute().params
-const accountName = $(computedEager(() => toShortHandle(params.account as string)))
 
 const { t } = useI18n()
 
-const { data: account, pending, refresh } = $(await useAsyncData(() => fetchAccountByHandle(accountName).catch(() => null), { immediate: process.client, default: () => shallowRef() }))
+const { data: account, pending, refresh } = $(await useAsyncData(() => rawAcctToResolvedAccount(params.account as string).catch(() => null), { immediate: process.client, default: () => shallowRef() }))
 const relationship = $computed(() => account ? useRelationship(account).value : undefined)
 
 const userSettings = useUserSettings()
@@ -48,7 +47,7 @@ onReactivated(() => {
     </template>
 
     <CommonNotFound v-else>
-      {{ $t('error.account_not_found', [`@${accountName}`]) }}
+      {{ $t('error.account_not_found') }}
     </CommonNotFound>
   </MainContent>
 </template>

--- a/pages/[[server]]/@[account]/index/followers.vue
+++ b/pages/[[server]]/@[account]/index/followers.vue
@@ -8,7 +8,7 @@ definePageMeta({ name: 'account-followers' })
 const account = await fetchAccountByHandle(handle)
 const paginator = account ? useMastoClient().v1.accounts.listFollowers(account.id, {}) : null
 
-const isSelf = useSelfAccount(account)
+const isSelf = account ? useSelfAccount(account) : undefined
 
 if (account) {
   useHydratedHead({
@@ -18,7 +18,7 @@ if (account) {
 </script>
 
 <template>
-  <template v-if="paginator">
+  <template v-if="paginator && account">
     <AccountPaginator :paginator="paginator" :relationship-context="isSelf ? 'followedBy' : undefined" context="followers" :account="account" />
   </template>
 </template>

--- a/pages/[[server]]/@[account]/index/following.vue
+++ b/pages/[[server]]/@[account]/index/following.vue
@@ -8,7 +8,7 @@ definePageMeta({ name: 'account-following' })
 const account = await fetchAccountByHandle(handle)
 const paginator = account ? useMastoClient().v1.accounts.listFollowing(account.id, {}) : null
 
-const isSelf = useSelfAccount(account)
+const isSelf = account ? useSelfAccount(account) : undefined
 
 if (account) {
   useHydratedHead({
@@ -18,7 +18,7 @@ if (account) {
 </script>
 
 <template>
-  <template v-if="paginator">
+  <template v-if="paginator && account">
     <AccountPaginator :paginator="paginator" :relationship-context="isSelf ? 'following' : undefined" context="following" :account="account" />
   </template>
 </template>

--- a/pages/[[server]]/@[account]/index/index.vue
+++ b/pages/[[server]]/@[account]/index/index.vue
@@ -14,7 +14,7 @@ function reorderAndFilter(items: mastodon.v1.Status[]) {
   return reorderedTimeline(items, 'account')
 }
 
-const paginator = useMastoClient().v1.accounts.listStatuses(account.id, { limit: 30, excludeReplies: true })
+const paginator = account ? useMastoClient().v1.accounts.listStatuses(account.id, { limit: 30, excludeReplies: true }) : undefined
 
 if (account) {
   useHydratedHead({
@@ -26,6 +26,8 @@ if (account) {
 <template>
   <div>
     <AccountTabs />
-    <TimelinePaginator :paginator="paginator" :preprocess="reorderAndFilter" context="account" :account="account" />
+    <template v-if="paginator && account">
+      <TimelinePaginator :paginator="paginator" :preprocess="reorderAndFilter" context="account" :account="account" />
+    </template>
   </div>
 </template>

--- a/pages/[[server]]/@[account]/index/media.vue
+++ b/pages/[[server]]/@[account]/index/media.vue
@@ -7,7 +7,7 @@ const handle = $(computedEager(() => params.account as string))
 
 const account = await fetchAccountByHandle(handle)
 
-const paginator = useMastoClient().v1.accounts.listStatuses(account.id, { onlyMedia: true, excludeReplies: false })
+const paginator = account ? useMastoClient().v1.accounts.listStatuses(account.id, { onlyMedia: true, excludeReplies: false }) : undefined
 
 if (account) {
   useHydratedHead({
@@ -19,6 +19,8 @@ if (account) {
 <template>
   <div>
     <AccountTabs />
-    <TimelinePaginator :paginator="paginator" :preprocess="reorderedTimeline" context="account" :account="account" />
+    <template v-if="paginator && account">
+      <TimelinePaginator :paginator="paginator" :preprocess="reorderedTimeline" context="account" :account="account" />
+    </template>
   </div>
 </template>

--- a/pages/[[server]]/@[account]/index/with_replies.vue
+++ b/pages/[[server]]/@[account]/index/with_replies.vue
@@ -7,7 +7,7 @@ const handle = $(computedEager(() => params.account as string))
 
 const account = await fetchAccountByHandle(handle)
 
-const paginator = useMastoClient().v1.accounts.listStatuses(account.id, { excludeReplies: false })
+const paginator = account ? useMastoClient().v1.accounts.listStatuses(account.id, { excludeReplies: false }) : undefined
 
 if (account) {
   useHydratedHead({
@@ -19,6 +19,8 @@ if (account) {
 <template>
   <div>
     <AccountTabs />
-    <TimelinePaginator :paginator="paginator" :preprocess="reorderedTimeline" context="account" :account="account" />
+    <template v-if="paginator && account">
+      <TimelinePaginator :paginator="paginator" :preprocess="reorderedTimeline" context="account" :account="account" />
+    </template>
   </div>
 </template>

--- a/pages/settings/profile/appearance.vue
+++ b/pages/settings/profile/appearance.vue
@@ -76,7 +76,7 @@ const { submit, submitting } = submitter(async ({ dirtyFields }) => {
   if (!res.account.acct.includes('@'))
     res.account.acct = `${res.account.acct}@${server}`
 
-  cacheAccount(res.account, server, true)
+  cacheAccount(res.account, true)
   currentUser.value!.account = res.account
   reset()
 })


### PR DESCRIPTION
This PR closes several related issues by standardizing and cleaning up the Mastodon account resolution logic with a particular emphasis on centralizing the account ID and account URI parsing logic. It also handles edge cases that were previously missing (e.g. attempting to lookup tags using the Mastodon API accounts lookup endpoint. The end result fixes the following open issues

- [X] [Exposing subdomain in handles](https://github.com/elk-zone/elk/issues/1794)
- [X] [Permalink failure due to errors during remote account lookup and resolution](https://github.com/elk-zone/elk/issues/888)

Closes: https://github.com/elk-zone/elk/issues/888
Closes: https://github.com/elk-zone/elk/issues/1636
Closes: https://github.com/elk-zone/elk/issues/1794