### PR TITLE
fix: repeatedly fetching posts, improve federation logic

### DIFF
--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -1,8 +1,16 @@
 import { LRUCache } from 'lru-cache'
 import type { mastodon } from 'masto'
 
+// expire in an hour
 const cache = new LRUCache<string, any>({
   max: 1000,
+  ttl: 3600000,
+  ttlAutopurge: true,
+  allowStaleOnFetchAbort: true,
+  allowStaleOnFetchRejection: true,
+  allowStale: true,
+  noUpdateTTL: true,
+  ttlResolution: 60000,
 })
 
 if (process.dev && process.client)
@@ -17,19 +25,138 @@ function removeCached(key: string) {
   cache.delete(key)
 }
 
-export function fetchStatus(id: string, force = false): Promise<mastodon.v1.Status> {
-  const server = currentServer.value
-  const userId = currentUser.value?.account.id
-  const key = `${server}:${userId}:status:${id}`
-  const cached = cache.get(key)
-  if (cached && !force)
-    return cached
-  const promise = useMastoClient().v1.statuses.fetch(id)
-    .then((status) => {
-      cacheStatus(status)
-      return status
+function generateStatusIdCacheKeyAccessibleToCurrentUser(statusId: string) {
+  return `${currentServer.value}:${currentUser.value?.account.id}:status:${statusId}`
+}
+
+async function federateRemoteStatus(statusUri: string, force = false): Promise<mastodon.v1.Status | null> {
+  if (cache.has(`stop:${statusUri}`)) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.debug(`Skipping further processing for invalid status URI: ${statusUri}`)
+    return Promise.resolve(null)
+  }
+
+  if (statusUri.startsWith(`https://${currentServer.value}`)) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.info(`Local domain is authoritative, so redirecting resolution request for status: ${statusUri}`)
+
+    return fetchStatus(statusUri.split('/').pop() ?? statusUri.replace(`https://${currentServer.value}/`, ''))
+  }
+
+  if (statusUri.search(/^\d+$/) !== -1) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.info(`statusUri parameter was passed an ID, so redirecting resolution request: ${statusUri}`)
+
+    return fetchStatus(statusUri, force)
+  }
+
+  const localStatusIdCacheKey = generateStatusIdCacheKeyAccessibleToCurrentUser(statusUri)
+
+  const cached: mastodon.v1.Status | Promise<mastodon.v1.Status> | undefined | null | number = cache.get(localStatusIdCacheKey, { allowStale: false, updateAgeOnGet: false })
+  if (cached) {
+    if (
+      !!cached
+      && !(typeof cached === 'number')
+      && !(cached instanceof Promise)
+      && (cached.uri === statusUri)
+      && !force
+    ) {
+      return cached
+    }
+    else if (cached instanceof Promise) {
+      return cached
+    }
+    else if (typeof cached === 'number') {
+      if ([401, 403, 418].includes(cached))
+        console.error(`Current user is forbidden or lacks authorization to fetch status: ${statusUri}`)
+      if ([404].includes(cached))
+        console.error(`The requested status URI cannot be found: ${statusUri}`)
+      if ([429].includes(cached))
+        console.error('The request was rate-limited by the Mastodon server')
+      if ([500, 501, 503].includes(cached))
+        console.error('The Mastodon server is unresponsive')
+      return Promise.resolve(null)
+    }
+  }
+
+  const promise = useMastoClient().v2.search({ q: statusUri, type: 'statuses', resolve: (!!currentUser.value), limit: 1 })
+    .then(async (results) => {
+      const post = results.statuses.pop()
+      if (!post) {
+        console.error(`Status could not be federated, perhaps it no longer exists: '${statusUri}'`)
+        cache.set(localStatusIdCacheKey, 404)
+        return Promise.resolve(null)
+      }
+
+      const splitUri = post.account.url.replace('https://', '').split('/@')
+      const accountWebfinger = `${splitUri[1]}@${splitUri[0]}`
+      post.account.acct = accountWebfinger
+
+      cache.set(localStatusIdCacheKey, post)
+      return post
     })
-  cache.set(key, promise)
+    .catch((e) => {
+      console.error(`Encountered error while federating status using URI '${statusUri}' | ${(e as Error)}`)
+      cache.set(localStatusIdCacheKey, null)
+      return Promise.resolve(null)
+    })
+  cache.set(localStatusIdCacheKey, promise)
+  return promise
+}
+
+export async function fetchStatus(statusId: string, force = false): Promise<mastodon.v1.Status | null> {
+  if (cache.has(`stop:${statusId}`)) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.debug(`Skipping further processing for invalid status Id: ${statusId}`)
+    return Promise.resolve(null)
+  }
+
+  // Handle scenario where the value of statusId is actually an URI
+  if (statusId.startsWith('h')) {
+    if (process.dev)
+      // eslint-disable-next-line no-console
+      console.info(`statusId parameter was passed an URI, so redirecting resolution request: ${statusId}`)
+    return federateRemoteStatus(statusId, force)
+  }
+
+  // handle invalid statusId
+  if ((statusId.search(/^\d+$/) === -1)) {
+    console.error(`Malformed or unrecognized Status ID: ${statusId}`)
+    cache.set(`stop:${statusId}`, 418)
+    return Promise.resolve(null)
+  }
+
+  const localStatusIdCacheKey = generateStatusIdCacheKeyAccessibleToCurrentUser(statusId)
+  const cached: mastodon.v1.Status | Promise<mastodon.v1.Status> | undefined | null = cache.get(localStatusIdCacheKey, { allowStale: false, updateAgeOnGet: false })
+  if (cached) {
+    // avoid race condition by returning the existing promise instead of restarting the chain of events all over again
+    if (cached instanceof Promise)
+      return cached
+    if (typeof cached === 'number') {
+      // wait for the cached value to expire before trying again
+      if ([401, 403, 404, 418, 429, 500, 501, 503].includes(cached))
+        return null
+    }
+    else if (cached.id === statusId) {
+      // if we don't care about authoritative values then return cached value
+      if (!force)
+        return cached
+    }
+  }
+
+  const promise = useMastoClient().v1.statuses.fetch(statusId)
+    .then(async (post) => {
+      const splitUri = post.account.url.replace('https://', '').split('/@')
+      const accountWebfinger = `${splitUri[1]}@${splitUri[0]}`
+      post.account.acct = accountWebfinger
+      cache.set(localStatusIdCacheKey, post)
+      return post
+    })
+  cache.set(localStatusIdCacheKey, promise)
   return promise
 }
 

--- a/middleware/1.permalink.global.ts
+++ b/middleware/1.permalink.global.ts
@@ -42,13 +42,15 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
         return getAccountRoute(account)
     }
 
-    // If we're logged in, search for the local id the account or status corresponds to
-    const { accounts, statuses } = await masto.client.value.v2.search({ q: `https:/${to.fullPath}`, resolve: true, limit: 1 })
-    if (statuses[0])
-      return getStatusRoute(statuses[0])
+    if (currentUser.value) {
+      // If we're logged in, search for the local id the account or status corresponds to
+      const { accounts, statuses } = await masto.client.value.v2.search({ q: `https:/${to.fullPath}`, resolve: true, limit: 1 })
+      if (statuses[0])
+        return getStatusRoute(statuses[0])
 
-    if (accounts[0])
-      return getAccountRoute(accounts[0])
+      if (accounts[0])
+        return getAccountRoute(accounts[0])
+    }
   }
   catch (err) {
     console.error(err)

--- a/pages/[[server]]/status/[status].vue
+++ b/pages/[[server]]/status/[status].vue
@@ -5,7 +5,13 @@ definePageMeta({
     const params = to.params
     const id = params.status as string
     const status = await fetchStatus(id)
-    return getStatusRoute(status)
+    if (status)
+      return getStatusRoute(status)
+
+    if (process.dev)
+      console.error(`Status not found: ${id}`)
+
+    return undefined
   },
 })
 </script>


### PR DESCRIPTION
The post/status caching logic is written in a way that triggers multiple fetch requests for the same post, which becomes a problem when rate-limits come into play as well as when there are network bottlenecks (such as those [illustrated here](https://github.com/elk-zone/elk/issues/1374)). The issue is further exacerbated when the post is authored by someone that has been blocked by the user (or vice versa), or when the remote host is down.

This PR improves fetching logic for posts by caching error response codes, and using that information to decide whether to retry fetch attempts. This PR also does a better job of handling requests for remote posts that:
- reference `status.uri` instead of local `status.id` (erroneously) or as a side effect of preview card rendering logic, and
- when permalinks request remoted posts that have not yet been federated to the host instance (or that were purged as part of regular maintenance)

