### PR TITLE
fix: scrolling and random layout shifts

### DIFF
--- a/components/drawer/DrawerContent.vue
+++ b/components/drawer/DrawerContent.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const info = useBuildInfo()
+</script>
+
+<template>
+  <nav>
+    <div hidden lg="h-full grid grid-rows-[minmax(0,93vh)_auto] gap-4 overflow-hidden">
+      <div flex-auto />
+      <div hidden lg="grid flex-col sticky bottom-0 bg-base h-fit">
+        <PwaPrompt />
+        <PwaInstallPrompt />
+        <LazyCommonPreviewPrompt v-if="info.env === 'preview'" />
+        <NavFooter />
+      </div>
+    </div>
+  </nav>
+</template>

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -31,7 +31,7 @@ const containerClass = computed(() => {
       bg="[rgba(var(--rgb-bg-base),0.7)]"
       class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(135%+(100vw-1200px)/2)]"
     >
-      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
+      <div flex justify-between px5 py2 class="native:xl:flex" border="b base">
         <div flex gap-3 items-center :overflow-hidden="!noOverflowHidden ? '' : false" py2 w-full>
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
@@ -57,8 +57,11 @@ const containerClass = computed(() => {
       </slot>
     </div>
     <PwaInstallPrompt xl:hidden />
-    <div :class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'" m-auto>
-      <div hidden :class="{ 'xl:block': $route.name !== 'tag' && !$slots.header }" h-6 />
+    <div
+      :class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'" m-auto
+      overflow-y-scroll h-100dvh
+    >
+      <div hidden :class="{ 'xl:block': $route.name !== 'tag' && !$slots.header }" />
       <slot />
     </div>
   </div>

--- a/components/nav/NavBottom.vue
+++ b/components/nav/NavBottom.vue
@@ -8,7 +8,7 @@ const { notifications } = useNotifications()
 <template>
   <nav
     h-14 border="t base" flex flex-row text-xl
-    of-y-scroll scrollbar-hide overscroll-none
+    sticky bottom-0 left-0 right-0 overscroll-none small="hidden"
     class="after-content-empty after:(h-[calc(100%+0.5px)] w-0.1px pointer-events-none)"
   >
     <!-- These weird styles above are used for scroll locking, don't change it unless you know exactly what you're doing. -->

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -7,7 +7,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 </script>
 
 <template>
-  <nav sm:px3 flex="~ col gap2" shrink text-size-base leading-normal md:text-lg h-full mt-1 overflow-y-auto>
+  <nav flex="~ col gap2" shrink text-size-base leading-normal md:text-lg place-content-start overflow-y-auto overscroll-contain overflow-x-hidden>
     <NavSideItem :text="$t('nav.search')" to="/search" icon="i-ri:search-line" xl:hidden :command="command" />
 
     <div class="spacer" shrink xl:hidden />

--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -1,5 +1,9 @@
 <script setup>
 const { busy, oauth, singleInstanceServer } = useSignIn()
+
+const route = useRoute()
+
+const isUserAdjustingSettings = computed(() => route.path?.startsWith('/settings'))
 </script>
 
 <template>
@@ -19,23 +23,25 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
     </template>
   </VDropdown>
   <template v-else>
-    <button
-      v-if="singleInstanceServer"
-      flex="~ row"
-      gap-x-1 items-center justify-center btn-solid text-sm px-2 py-1 xl:hidden
-      :disabled="busy"
-      @click="oauth()"
-    >
-      <span v-if="busy" aria-hidden="true" block animate animate-spin preserve-3d class="rtl-flip">
-        <span block i-ri:loader-2-fill aria-hidden="true" />
-      </span>
-      <span v-else aria-hidden="true" block i-ri:login-circle-line class="rtl-flip" />
-      <i18n-t keypath="action.sign_in_to">
-        <strong>{{ currentServer }}</strong>
-      </i18n-t>
-    </button>
-    <button v-else btn-solid text-sm px-2 py-1 text-center xl:hidden @click="openSigninDialog()">
-      {{ $t('action.sign_in') }}
-    </button>
+    <template v-if="!isUserAdjustingSettings">
+      <button
+        v-if="singleInstanceServer"
+        flex="~ row"
+        gap-x-1 items-center justify-center btn-solid text-sm px-2 py-1 xl:hidden
+        :disabled="busy"
+        @click="oauth()"
+      >
+        <span v-if="busy" aria-hidden="true" block animate animate-spin preserve-3d class="rtl-flip">
+          <span block i-ri:loader-2-fill aria-hidden="true" />
+        </span>
+        <span v-else aria-hidden="true" block i-ri:login-circle-line class="rtl-flip" />
+        <i18n-t keypath="action.sign_in_to">
+          <strong>{{ currentServer }}</strong>
+        </i18n-t>
+      </button>
+      <button v-else btn-solid text-sm px-2 py-1 text-center xl:hidden @click="openSigninDialog()">
+        {{ $t('action.sign_in') }}
+      </button>
+    </template>
   </template>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,6 @@
 import { usePreferences } from '~/composables/settings'
 
 const route = useRoute()
-const info = useBuildInfo()
 
 const wideLayout = computed(() => route.meta.wideLayout ?? false)
 
@@ -12,24 +11,98 @@ const showUserPicker = logicAnd(
 )
 
 const isGrayscale = usePreferences('grayscaleMode')
+
+const appContainerRef = ref()
+
+const { width: appContainerWidth } = useElementBounding(appContainerRef)
+
+const shouldRenderRightNav = computed(() => ((!route.path?.startsWith('/settings')) && (appContainerWidth.value > 1024)))
+
+const isUserAdjustingSettings = computed(() => route.path?.startsWith('/settings'))
+const appContainerClass = computed(() => {
+  if (!route.path?.startsWith('/settings'))
+    return null
+
+  if (appContainerWidth.value < 1280)
+    return 'flex w-full h-100dvh justify-center grid grid-cols-[minmax(70px,80px)_600px_0px]'
+
+  return 'flex w-full h-100dvh justify-center grid grid-cols-[275px_auto_0px]'
+})
 </script>
 
 <template>
-  <div h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''" data-tauri-drag-region>
-    <main flex w-full mxa lg:max-w-80rem class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_minmax(600px,2fr)_1fr]">
-      <aside class="native:w-auto w-1/8 md:w-1/6 lg:w-1/5 xl:w-1/4 zen-hide" hidden sm:flex justify-end xl:me-4 native:me-0 relative>
-        <div sticky top-0 w-20 xl:w-100 h-100dvh flex="~ col" lt-xl-items-center>
+  <div
+    ref="appContainerRef" h-full :data-mode="isHydrated && isGrayscale ? 'grayscale' : ''"
+    data-tauri-drag-region
+    sm="ml-0 pl-0"
+    overflow-y-hidden
+    overscroll-y-contain
+  >
+    <main
+      overflow-y-hidden
+      overscroll-y-contain
+      content-between w-full
+      class="native:grid native:sm:grid-cols-[auto_1fr] native:lg:grid-cols-[auto_minmax(600px,3fr)_2fr"
+      sm="flex w-full justify-center"
+      md="flex w-full h-100dvh justify-center grid-cols-[minmax(70px,80px)_minmax(600px,2fr)]"
+      lg="flex w-full h-100dvh justify-center grid grid-cols-[minmax(70px,80px)_600px_minmax(275px,390px)]"
+      xl="flex w-full h-100dvh justify-center grid grid-cols-[minmax(275px,1fr)_600px_auto]"
+      :class="appContainerClass"
+    >
+      <!-- LEFT NAV -->
+      <aside
+        v-if="isHydrated"
+        class="zen-hide"
+        hidden justify-start
+        native="me-0 w-auto"
+        sm="flex mx-0 px-0 max-w-80px"
+        xl="w-275px max-w-full"
+      >
+        <div
+          flex="~ col" lt-lg-items-center
+          sm="w-80px"
+          xl="w-275px max-w-full"
+        >
           <slot name="left">
-            <div flex="~ col" overflow-y-auto justify-between h-full max-w-full overflow-x-hidden>
-              <NavTitle />
-              <NavSide command />
-              <div flex-auto />
-              <div v-if="isHydrated" flex flex-col sticky bottom-0 bg-base>
-                <div hidden xl:block>
-                  <UserSignInEntry v-if="!currentUser" />
+            <div sticky top-0>
+              <NavTitle
+                sm="w-fit mr-10px"
+                xl="w-full mr-0"
+              />
+              <NavSide
+                command flex-col flex-auto flex-basis-lg
+                mt0 mb0
+                sm="w-80px min-h-10vh max-h-80vh"
+                xl="w-275px min-h-10vh max-h-80vh"
+              />
+              <!-- USER SIGN-IN -->
+              <div shrink flex-basis-78px />
+              <div
+                v-if="isHydrated" bg-base flex-grow flex-basis
+                sm="w-70px min-h-70px"
+                xl="w-275px min-h-10vh max-h-80vh"
+                pb8 mb8
+              >
+                <div hidden xl="block" p0 m0>
+                  <UserSignInEntry v-if="!currentUser" p0 m0 />
                 </div>
-                <div v-if="currentUser" p6 pb8 w-full>
-                  <div hidden xl-block>
+                <div v-if="currentUser" p0 m0>
+                  <div xl="hidden" px6 pt4>
+                    <CommonTooltip :disabled="!isMediumOrLargeScreen" :content="$t('action.switch_account')" placement="right">
+                      <div
+                        class="item"
+                        flex gap4
+                        rounded-3
+                        sm="max-w-70px w-content justify-center mx0"
+                        xl="items-center justify-start ml0 mr5 px5 w-auto"
+                        transition-100
+                        elk-group-hover="bg-active" group-focus-visible:ring="2 current"
+                      >
+                        <UserDropdown xl:hidden />
+                      </div>
+                    </CommonTooltip>
+                  </div>
+                  <div hidden xl="block" p6 w-full>
                     <UserPicker v-if="showUserPicker" />
                     <div v-else flex="~" items-center justify-between>
                       <NuxtLink
@@ -43,33 +116,58 @@ const isGrayscale = usePreferences('grayscaleMode')
                       <UserDropdown />
                     </div>
                   </div>
-                  <UserDropdown xl:hidden />
                 </div>
               </div>
             </div>
           </slot>
         </div>
+        <div class="spacer" max-h-full grow />
       </aside>
-      <div w-full min-h-screen :class="isHydrated && wideLayout ? 'xl:w-full sm:w-600px' : 'sm:w-600px md:shrink-0'" border-base>
-        <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
+      <!-- MAIN -->
+      <div
+        v-if="isHydrated" id="__main" h-100vh overscroll-none overflow-hidden
+        min-w-280px w-full
+        sm="max-w-full"
+        md="min-w-600px"
+        :class="isUserAdjustingSettings ? 'md:max-w-600px lg:max-w-600px xl:max-w-[calc(980px-2rem)] xl:mx-0 xl:px-0' : 'md:max-w-600px'"
+      >
+        <div
+          overflow-y-hidden overscroll-y-none
+          min-w-280px w-full
+          sm="max-w-full"
+          md="min-w-600px"
+          :class="isUserAdjustingSettings ? 'md:max-w-600px lg:max-w-fit xl:max-w-[calc(980px-2rem)] xl:mx-0 xl:px-0' : 'md:max-w-600px'"
+        >
           <slot />
         </div>
         <div sticky left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
           <CommonOfflineChecker v-if="isHydrated" />
-          <NavBottom v-if="isHydrated" sm:hidden />
+          <NavBottom v-if="isHydrated" sm="hidden" />
         </div>
       </div>
-      <aside v-if="isHydrated && !wideLayout" class="hidden lg:w-1/5 xl:w-1/4 sm:none xl:block native:w-full zen-hide">
-        <div sticky top-0 h-100dvh flex="~ col" gap-2 py3 ms-2>
-          <slot name="right">
-            <SearchWidget mt-4 mx-1 hidden xl:block />
-            <div flex-auto />
-
-            <PwaPrompt />
-            <PwaInstallPrompt />
-            <LazyCommonPreviewPrompt v-if="info.env === 'preview'" />
-            <NavFooter />
-          </slot>
+      <!-- RIGHT DRAWER -->
+      <aside
+        v-if="shouldRenderRightNav && isHydrated && !wideLayout"
+        hidden justify-start
+        native="me-0 w-auto"
+        xl="block mx-0 px-0 min-w-275px max-w-390px h-100vh"
+      >
+        <div
+          flex="~ col" lt-lg-items-center hidden
+          overscroll-y-contain
+          lg="block h-100dh pb0 ps4 pt2 min-w-275px max-w-390px"
+          xl="block py0 ps2 pt2 w-350px max-w-full"
+        >
+          <template v-if="shouldRenderRightNav">
+            <slot name="right">
+              <div v-show="!isUserAdjustingSettings" hidden overscroll-y-contain xl="block sticky top-0 my0 mx0 pt0 pb2" overflow-hidden>
+                <div hidden xl="grid grid-rows-[auto_minmax(80vh,93vh)] gap-4">
+                  <SearchWidget hidden xl="block sticky" />
+                  <DrawerContent hidden xl="block overflow-y-hidden" />
+                </div>
+              </div>
+            </slot>
+          </template>
         </div>
       </aside>
     </main>

--- a/styles/global.css
+++ b/styles/global.css
@@ -2,6 +2,9 @@ html {
   font-size: var(--font-size, 15px);
   width: 100%;
   width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 
 @font-face {
@@ -20,9 +23,14 @@ html {
   background: var(--c-bg-selection);
 }
 
-/* Force vertical scrollbar to be always visible to avoid layout shift while loading the content */
 body {
-  overflow-y: scroll;
+  height: 100vh;
+  width: 100vw;
+  margin: 0;
+  padding: 0;
+  overscroll-behavior-y: contain;
+  overscroll-behavior-x: none;
+  overscroll-behavior-block: contain;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -162,12 +170,15 @@ em-emoji-picker {
   }
 }
 
-html,
-body,
+/* Force vertical scrollbar to be always visible to avoid layout shift while loading the content */
 #__nuxt {
   height: 100vh;
+  width: 100vw;
   margin: 0;
   padding: 0;
+  overflow-y: scroll;
+  overscroll-behavior-y: contain;
+  overscroll-behavior-block: contain;
 }
 
 html.dark {

--- a/styles/scrollbars.css
+++ b/styles/scrollbars.css
@@ -1,25 +1,3 @@
-* {
-  scrollbar-color: #8885 var(--c-border);
-}
-
 ::-webkit-scrollbar {
-  width: 10px;
-}
-
-::-webkit-scrollbar:horizontal {
-  height: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--c-border);
-  border-radius: 1px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #8885;
-  border-radius: 1px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #8886;
+  width: normal;
 }


### PR DESCRIPTION
This re-works the default layout to address random layout shifts during loading and routing. It also unwraps the nested containers within the MainContent component, which is responsible for the mid-flight updates that cause flickering while scrolling.

By reworking the layout in this way, we're able to preserve the timeline state as the user navigates into-and-out-of status details and as they go from one timeline to another. It also isolates the third column, which would enable features such as remote timelines or a notification drawer.

Closes: https://github.com/elk-zone/elk/issues/1082