### PR TITLE
fix: Update command key in keyboard shortcuts modal

### DIFF
--- a/components/magickeys/MagickeysKeyboardShortcuts.vue
+++ b/components/magickeys/MagickeysKeyboardShortcuts.vue
@@ -21,6 +21,9 @@ interface ShortcutItemGroup {
   items: ShortcutItem[]
 }
 
+const isMac = useIsMac()
+const modifierKeyName = $computed(() => isMac.value ? '⌘' : 'Ctrl')
+
 const shortcutItemGroups: ShortcutItemGroup[] = [
   {
     name: t('magic_keys.groups.navigation.title'),
@@ -52,7 +55,7 @@ const shortcutItemGroups: ShortcutItemGroup[] = [
     items: [
       {
         description: t('magic_keys.groups.actions.command_mode'),
-        shortcut: { keys: ['cmd', '/'], isSequence: false },
+        shortcut: { keys: [modifierKeyName, '/'], isSequence: false },
       },
       {
         description: t('magic_keys.groups.actions.compose'),


### PR DESCRIPTION
Replaces incorrect reference to `cmd` key in `MagickeysKeyboardShortcuts` with proper platform key on non-macOS devices.

Old display (see _Actions -> Command mode_):

![image](https://github.com/elk-zone/elk/assets/5669055/487d6ca5-48bd-4054-adf8-4573a3cf62f7)

New display

![image](https://github.com/elk-zone/elk/assets/5669055/ea8194e5-9c3b-40bb-adcd-39d48162c6a6)