### PR TITLE
feat: view-transition-api

### DIFF
--- a/components/account/AccountAvatar.vue
+++ b/components/account/AccountAvatar.vue
@@ -1,18 +1,29 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-defineProps<{
+const { account, status } = defineProps<{
   account: mastodon.v1.Account
   square?: boolean
+  status?: mastodon.v1.Status
 }>()
 
 const loaded = $ref(false)
 const error = $ref(false)
+
+const viewTransitionStyle = computed(() => {
+  if (!status)
+    return
+
+  const targets = getViewTransitionTargets().value
+  if (targets.statusId === status.id && targets.accountId === account.id)
+    return { 'view-transition-name': 'account-avatar' }
+})
 </script>
 
 <template>
   <img
     :key="account.avatar"
+    v-bind="$attrs"
     width="400"
     height="400"
     select-none
@@ -21,8 +32,7 @@ const error = $ref(false)
     loading="lazy"
     class="account-avatar"
     :class="(loaded ? 'bg-base' : 'bg-gray:10') + (square ? ' ' : ' rounded-full')"
-    :style="{ 'clip-path': square ? `url(#avatar-mask)` : 'none' }"
-    v-bind="$attrs"
+    :style="{ 'clip-path': square ? `url(#avatar-mask)` : 'none', ...viewTransitionStyle }"
     @load="loaded = true"
     @error="error = true"
   >

--- a/components/account/AccountBigAvatar.vue
+++ b/components/account/AccountBigAvatar.vue
@@ -6,12 +6,13 @@ import type { mastodon } from 'masto'
 
 defineProps<{
   account: mastodon.v1.Account
+  status?: mastodon.v1.Status
   square?: boolean
 }>()
 </script>
 
 <template>
   <div :key="account.avatar" v-bind="$attrs" :style="{ 'clip-path': square ? `url(#avatar-mask)` : 'none' }" :class="{ 'rounded-full': !square }" bg-base w-54px h-54px flex items-center justify-center>
-    <AccountAvatar :account="account" w-48px h-48px :square="square" />
+    <AccountAvatar :account="account" :status="status" w-48px h-48px :square="square" />
   </div>
 </template>

--- a/components/account/AccountDisplayName.vue
+++ b/components/account/AccountDisplayName.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { account, hideEmojis = false } = defineProps<{
+const { account, hideEmojis = false, status } = defineProps<{
   account: mastodon.v1.Account
   hideEmojis?: boolean
+  status?: mastodon.v1.Status
 }>()
+
+const viewTransitionStyle = computed(() => {
+  if (!status)
+    return
+
+  const targets = getViewTransitionTargets().value
+  if (targets.statusId === status.id && targets.accountId === account.id)
+    return { 'view-transition-name': 'account-display-name' }
+})
 </script>
 
 <template>
   <ContentRich
+    :style="viewTransitionStyle"
     :content="getDisplayName(account, { rich: true })"
     :emojis="account.emojis"
     :hide-emojis="hideEmojis"

--- a/components/account/AccountHandle.vue
+++ b/components/account/AccountHandle.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { account } = defineProps<{
+const { account, status } = defineProps<{
   account: mastodon.v1.Account
+  status?: mastodon.v1.Status
 }>()
-
 const serverName = $computed(() => getServerName(account))
+
+const viewTransitionStyle = computed(() => {
+  if (!status)
+    return
+
+  const targets = getViewTransitionTargets().value
+  if (targets.statusId === status.id && targets.accountId === account.id)
+    return { 'view-transition-name': 'account-handle' }
+})
 </script>
 
 <template>
-  <p line-clamp-1 whitespace-pre-wrap break-all text-secondary-light leading-tight dir="ltr">
+  <p :style="viewTransitionStyle" line-clamp-1 whitespace-pre-wrap break-all text-secondary-light leading-tight dir="ltr">
     <!-- fix: #274 only line-clamp-1 can be used here, using text-ellipsis is not valid -->
     <span text-secondary>{{ getShortHandle(account) }}</span>
     <span v-if="serverName" text-secondary-light>@{{ serverName }}</span>

--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -7,6 +7,7 @@ defineOptions({
 
 const { account, as = 'div' } = defineProps<{
   account: mastodon.v1.Account
+  status?: mastodon.v1.Status
   as?: string
   hoverCard?: boolean
   square?: boolean
@@ -18,15 +19,15 @@ const { account, as = 'div' } = defineProps<{
 <template>
   <component :is="as" flex gap-3 v-bind="$attrs">
     <AccountHoverWrapper :disabled="!hoverCard" :account="account">
-      <AccountBigAvatar :account="account" shrink-0 :square="square" />
+      <AccountBigAvatar :account="account" :status="status" shrink-0 :square="square" />
     </AccountHoverWrapper>
     <div flex="~ col" shrink pt-1 h-full overflow-hidden justify-center leading-none select-none>
       <div flex="~" gap-2>
-        <AccountDisplayName :account="account" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
+        <AccountDisplayName :account="account" :status="status" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
         <AccountLockIndicator v-if="account.bot" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
       </div>
-      <AccountHandle :account="account" text-secondary-light />
+      <AccountHandle :account="account" :status="status" text-secondary-light />
     </div>
   </component>
 </template>

--- a/components/account/AccountInlineInfo.vue
+++ b/components/account/AccountInlineInfo.vue
@@ -5,6 +5,7 @@ const { link = true, avatar = true } = defineProps<{
   account: mastodon.v1.Account
   link?: boolean
   avatar?: boolean
+  status?: mastodon.v1.Status
 }>()
 
 const userSettings = useUserSettings()
@@ -24,8 +25,8 @@ export default {
       v-bind="$attrs"
       min-w-0 flex gap-2 items-center
     >
-      <AccountAvatar v-if="avatar" :account="account" w-5 h-5 />
-      <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" line-clamp-1 ws-pre-wrap break-all />
+      <AccountAvatar v-if="avatar" :account="account" :status="status" w-5 h-5 />
+      <AccountDisplayName :account="account" :status="status" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" line-clamp-1 ws-pre-wrap break-all />
     </NuxtLink>
   </AccountHoverWrapper>
 </template>

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -21,6 +21,20 @@ const containerClass = computed(() => {
 
   return 'lg:sticky lg:top-0'
 })
+
+function goBack() {
+  const router = useRouter()
+
+  if (document.startViewTransition === undefined) {
+    router.go(-1)
+  }
+  else {
+    document.startViewTransition(() => new Promise((resolve) => {
+      router.go(-1)
+      setTimeout(resolve, 100)
+    }))
+  }
+}
 </script>
 
 <template>
@@ -36,7 +50,7 @@ const containerClass = computed(() => {
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
             :aria-label="$t('nav.back')"
-            @click="$router.go(-1)"
+            @click="goBack()"
           >
             <div i-ri:arrow-left-line class="rtl-flip" />
           </NuxtLink>

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -15,6 +15,18 @@ onMounted(() => {
 router.afterEach(() => {
   back.value = router.options.history.state.back
 })
+
+function goBack() {
+  if (document.startViewTransition === undefined) {
+    router.go(-1)
+  }
+  else {
+    document.startViewTransition(() => new Promise((resolve) => {
+      router.go(-1)
+      setTimeout(resolve, 100)
+    }))
+  }
+}
 </script>
 
 <template>
@@ -40,7 +52,7 @@ router.afterEach(() => {
         <NuxtLink
           :aria-label="$t('nav.back')"
           :class="{ 'pointer-events-none op0': !back || back === '/', 'xl:flex': $route.name !== 'tag' }"
-          @click="$router.go(-1)"
+          @click="goBack()"
         >
           <div text-xl i-ri:arrow-left-line class="rtl-flip" btn-text />
         </NuxtLink>

--- a/components/status/StatusAccountDetails.vue
+++ b/components/status/StatusAccountDetails.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { account, link = true } = defineProps<{
-  account: mastodon.v1.Account
+const { status, link = true } = defineProps<{
+  status: mastodon.v1.Status
   link?: boolean
 }>()
 
@@ -11,11 +11,11 @@ const userSettings = useUserSettings()
 
 <template>
   <NuxtLink
-    :to="link ? getAccountRoute(account) : undefined"
+    :to="link ? getAccountRoute(status.account) : undefined"
     flex="~ col" min-w-0 md:flex="~ row gap-2" md:items-center
     text-link-rounded
   >
-    <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
-    <AccountHandle :account="account" class="zen-none" />
+    <AccountDisplayName :account="status.account" :status="status" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
+    <AccountHandle :account="status.account" :status="status" class="zen-none" />
   </NuxtLink>
 </template>

--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -31,10 +31,15 @@ function reply() {
   else
     navigateToStatus({ status, focusReply: true })
 }
+
+const viewTransitionStyle = computed(() => {
+  if (getViewTransitionTargets().value.statusId === props.status.id)
+    return { 'view-transition-name': 'status-actions' }
+})
 </script>
 
 <template>
-  <div flex justify-between items-center class="status-actions">
+  <div flex justify-between items-center class="status-actions" :style="viewTransitionStyle">
     <div flex-1>
       <StatusActionButton
         :content="$t('action.reply')"

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -106,11 +106,11 @@ const forceShow = ref(false)
           <div absolute top-1 ms-24px w-32px h-32px rounded-full>
             <AccountHoverWrapper :account="rebloggedBy">
               <NuxtLink :to="getAccountRoute(rebloggedBy)">
-                <AccountAvatar :account="rebloggedBy" />
+                <AccountAvatar :account="rebloggedBy" :status="status" />
               </NuxtLink>
             </AccountHoverWrapper>
           </div>
-          <AccountInlineInfo font-bold :account="rebloggedBy" :avatar="false" text-sm />
+          <AccountInlineInfo font-bold :account="rebloggedBy" :avatar="false" :status="status" text-sm />
         </div>
       </div>
     </slot>
@@ -137,7 +137,7 @@ const forceShow = ref(false)
           </div>
           <AccountHoverWrapper :account="status.account">
             <NuxtLink :to="getAccountRoute(status.account)" rounded-full>
-              <AccountBigAvatar :account="status.account" />
+              <AccountBigAvatar :account="status.account" :status="status" />
             </NuxtLink>
           </AccountHoverWrapper>
 
@@ -151,7 +151,7 @@ const forceShow = ref(false)
           <!-- Account Info -->
           <div flex items-center space-x-1>
             <AccountHoverWrapper :account="status.account">
-              <StatusAccountDetails :account="status.account" />
+              <StatusAccountDetails :status="status" />
             </AccountHoverWrapper>
             <div flex-auto />
             <div v-show="!getPreferences(userSettings, 'zenMode')" text-sm text-secondary flex="~ row nowrap" hover:underline whitespace-nowrap>

--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -29,6 +29,10 @@ const hideAllMedia = computed(
     return currentUser.value ? (getHideMediaByDefault(currentUser.value.account) && !!status.mediaAttachments.length) : false
   },
 )
+const viewTransitionStyle = computed(() => {
+  if (getViewTransitionTargets().value.statusId === status.id)
+    return { 'view-transition-name': 'status-content' }
+})
 </script>
 
 <template>
@@ -38,6 +42,7 @@ const hideAllMedia = computed(
       'pt2 pb0.5 px3.5 bg-dm rounded-4 me--1': isDM,
       'ms--3.5 mt--1 ms--1': isDM && context !== 'details',
     }"
+    :style="viewTransitionStyle"
   >
     <StatusBody v-if="(!isFiltered && isSensitiveNonSpoiler) || hideAllMedia" :status="status" :newer="newer" :with-action="!isDetails" :class="isDetails ? 'text-xl' : ''" />
     <StatusSpoiler :enabled="hasSpoilerOrSensitiveMedia || isFiltered" :filter="isFiltered" :sensitive-non-spoiler="isSensitiveNonSpoiler || hideAllMedia" :is-d-m="isDM">

--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -34,7 +34,7 @@ useHydratedHead({
     <StatusActionsMore :status="status" absolute inset-ie-2 top-2 @after-edit="$emit('refetchStatus')" />
     <NuxtLink :to="getAccountRoute(status.account)" rounded-full hover:bg-active transition-100 pe5 me-a>
       <AccountHoverWrapper :account="status.account">
-        <AccountInfo :account="status.account" />
+        <AccountInfo :account="status.account" :status="status" />
       </AccountHoverWrapper>
     </NuxtLink>
     <StatusContent :status="status" :newer="newer" context="details" />

--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -18,13 +18,27 @@ function onclick(evt: MouseEvent | KeyboardEvent) {
     go(evt)
 }
 
-function go(evt: MouseEvent | KeyboardEvent) {
+async function go(evt: MouseEvent | KeyboardEvent) {
   if (evt.metaKey || evt.ctrlKey) {
     window.open(statusRoute.href)
   }
   else {
+    const targets = getViewTransitionTargets()
+    targets.value.statusId = props.status.id
+    targets.value.accountId = props.status.account.id
     cacheStatus(props.status)
-    router.push(statusRoute)
+
+    await nextTick()
+
+    if (document.startViewTransition === undefined) {
+      router.push(statusRoute)
+    }
+    else {
+      document.startViewTransition(() => new Promise((resolve) => {
+        router.push(statusRoute)
+        setTimeout(resolve, 100)
+      }))
+    }
   }
 }
 </script>

--- a/composables/viewTransition.ts
+++ b/composables/viewTransition.ts
@@ -1,0 +1,11 @@
+interface ViewTransitionTargets {
+  statusId: null | string
+  accountId: null | string
+}
+
+export function getViewTransitionTargets() {
+  return useState('viewTransitionTargets', () => ({
+    statusId: null,
+    accountId: null,
+  } as ViewTransitionTargets))
+}

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -16,7 +16,7 @@ const main = ref<ComponentPublicInstance | null>(null)
 
 const { data: status, pending, refresh: refreshStatus } = useAsyncData(
   `status:${id}`,
-  () => fetchStatus(id, true),
+  () => fetchStatus(id, false),
   { watch: [isHydrated], immediate: isHydrated.value, default: () => shallowRef() },
 )
 const { client } = $(useMasto())

--- a/shims.d.ts
+++ b/shims.d.ts
@@ -4,6 +4,8 @@ declare global {
       test?: boolean
     }
   }
+
+  interface Document { startViewTransition: Function | undefined }
 }
 
 export {}


### PR DESCRIPTION
In this PR I created a demo for the (very) new [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).

This API allows web applications to animate complex layout shifts with relative ease and achieve a very native like look. This PR is only a rough demo of the feature, it can be improved a lot if this is something that the core Elk maintaners and the community would like to see.

The API is currently only available in desktop and android Chrome, for other browsers everything should work like before.

### How does it look?
Currently only the change between the feed and a specific post is animated.

https://github.com/elk-zone/elk/assets/40771359/ed5d3f4f-2599-45fa-831c-81facdb1368d

### Hacks/Changes/Problems:
These hacks and problems can be eliminated with some more work (in theory).

- There is a 100ms delay when opening a post or when returning from it to the feed
- The forced refresh of the status cache when opening a status had to be removed
- The reduce motion user settings is currently ignored (very easy to implement)
- Z-indexes can cause trouble (posts can hover over the header-nav while being animated)
- There are some visual glitches/there is room for the improvement of the animation

More information on this API can be found here: https://developer.chrome.com/docs/web-platform/view-transitions/