### PR TITLE
fix: add domain when querying for user on GoToSocial

### DIFF
--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -69,10 +69,10 @@ export async function fetchAccountByHandle(acct: string): Promise<mastodon.v1.Ac
   async function lookupAccount() {
     const client = useMastoClient()
     let account: mastodon.v1.Account
-    if (!isGotoSocial.value)
+    if (!isGotoSocial.value) // TODO: GoToSocial will support this endpoint from 0.10.0
       account = await client.v1.accounts.lookup({ acct: userAcct })
     else
-      account = (await client.v1.search({ q: `@${userAcct}`, type: 'accounts' })).accounts[0]
+      account = (await client.v1.search({ q: `@${userAcct}@${domain}`, type: 'accounts' })).accounts[0]
 
     if (account.acct && !account.acct.includes('@') && domain)
       account.acct = `${account.acct}@${domain}`


### PR DESCRIPTION
Per the documentation (https://docs.gotosocial.org/en/latest/api/swagger/)
we need to include the `@domain` so that the user resolved to
is unique (otherwise GtS can return accounts from different domains
sharing the same username).

Aside, from 0.10.0 GtS also provides a `/accounts/lookup` endpoint,
so we can remove this special case when it is out.
