### PR TITLE
fix: display background when text is selected

### DIFF
--- a/styles/vars.css
+++ b/styles/vars.css
@@ -1,4 +1,4 @@
-:root {
+:root, :root::selection {
   --c-border: #eee;
   --c-border-dark: #dccfcf;
   --c-border-code: #ddd;


### PR DESCRIPTION
https://github.com/elk-zone/elk/issues/2147

When writing tweets or entering text into an input field, there is no feedback when selecting text using a keyboard shortcut.