### PR TITLE
fix: only add domain when none was provided

### DIFF
--- a/composables/cache.ts
+++ b/composables/cache.ts
@@ -69,10 +69,13 @@ export async function fetchAccountByHandle(acct: string): Promise<mastodon.v1.Ac
   async function lookupAccount() {
     const client = useMastoClient()
     let account: mastodon.v1.Account
-    if (!isGotoSocial.value) // TODO: GoToSocial will support this endpoint from 0.10.0
+    if (!isGotoSocial.value) { // TODO: GoToSocial will support this endpoint from 0.10.0
       account = await client.v1.accounts.lookup({ acct: userAcct })
-    else
-      account = (await client.v1.search({ q: `@${userAcct}@${domain}`, type: 'accounts' })).accounts[0]
+    }
+    else {
+      const userAcctDomain = userAcct.includes('@') ? userAcct : `${userAcct}@${domain}`
+      account = (await client.v1.search({ q: `@${userAcctDomain}`, type: 'accounts' })).accounts[0]
+    }
 
     if (account.acct && !account.acct.includes('@') && domain)
       account.acct = `${account.acct}@${domain}`


### PR DESCRIPTION
This follows #2221.

I made a bug where I added the domain into the query regardless of the original query, so it was not working when we hit an URL like `https://elk.zone/gts.example.com/user@example.com`.

I'm just doing a simple "does the query contains a `@` check" to add the domain, I wonder if it's enough.

Sorry for the last sloppy PR :pensive: 