### PR TITLE
fix: Show lock indicator with the correct state

### DIFF
--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -23,7 +23,7 @@ const { account, as = 'div' } = defineProps<{
     <div flex="~ col" shrink pt-1 h-full overflow-hidden justify-center leading-none select-none>
       <div flex="~" gap-2>
         <AccountDisplayName :account="account" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
-        <AccountLockIndicator v-if="account.bot" text-xs />
+        <AccountLockIndicator v-if="account.locked" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
       </div>
       <AccountHandle :account="account" text-secondary-light />

--- a/components/search/SearchAccountInfo.vue
+++ b/components/search/SearchAccountInfo.vue
@@ -14,7 +14,7 @@ defineProps<{
     <div flex="~ col gap1" shrink h-full overflow-hidden leading-none>
       <div flex="~" gap-2>
         <AccountDisplayName :account="account" line-clamp-1 ws-pre-wrap break-all text-base />
-        <AccountLockIndicator v-if="account.bot" text-xs />
+        <AccountLockIndicator v-if="account.locked" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
       </div>
       <AccountHandle text-sm :account="account" text-secondary-light />

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -155,7 +155,7 @@ const forceShow = ref(false)
             </AccountHoverWrapper>
             <div flex-auto />
             <div v-show="!getPreferences(userSettings, 'zenMode')" text-sm text-secondary flex="~ row nowrap" hover:underline whitespace-nowrap>
-              <AccountLockIndicator v-if="status.account.bot" me-2 />
+              <AccountLockIndicator v-if="status.account.locked" me-2 />
               <AccountBotIndicator v-if="status.account.bot" me-2 />
               <div flex="~ gap1" items-center>
                 <StatusVisibilityIndicator v-if="status.visibility !== 'public'" :status="status" />


### PR DESCRIPTION
Currently on Canary there is a issue whereby the locked account indicator shows up when a account is marked as a bot. This PR resolves that issue by modifying the state to check if the account is locked.