### PR TITLE
fix(a11y): make the bottom menu button focusable and navigable with a11y label

### DIFF
--- a/components/nav/NavBottom.vue
+++ b/components/nav/NavBottom.vue
@@ -43,14 +43,15 @@ const { notifications } = useNotifications()
       </NuxtLink>
     </template>
     <NavBottomMoreMenu v-slot="{ toggleVisible, show }" v-model="moreMenuVisible" flex flex-row items-center place-content-center h-full flex-1 cursor-pointer>
-      <label
+      <button
         flex items-center place-content-center h-full flex-1 class="select-none"
         :class="show ? '!text-primary' : ''"
+        aria-label="More menu"
+        @click="toggleVisible"
       >
-        <input type="checkbox" z="-1" absolute inset-0 opacity-0 @click="toggleVisible">
         <span v-show="show" i-ri:close-fill />
         <span v-show="!show" i-ri:more-fill />
-      </label>
+      </button>
     </NavBottomMoreMenu>
   </nav>
 </template>

--- a/components/nav/NavBottom.vue
+++ b/components/nav/NavBottom.vue
@@ -49,8 +49,7 @@ const { notifications } = useNotifications()
         aria-label="More menu"
         @click="toggleVisible"
       >
-        <span v-show="show" i-ri:close-fill />
-        <span v-show="!show" i-ri:more-fill />
+        <span :class="show ? 'i-ri:close-fill' : 'i-ri:more-fill' />"
       </button>
     </NavBottomMoreMenu>
   </nav>

--- a/components/nav/NavBottom.vue
+++ b/components/nav/NavBottom.vue
@@ -49,7 +49,7 @@ const { notifications } = useNotifications()
         aria-label="More menu"
         @click="toggleVisible"
       >
-        <span :class="show ? 'i-ri:close-fill' : 'i-ri:more-fill' />"
+        <span :class="show ? 'i-ri:close-fill' : 'i-ri:more-fill'" />
       </button>
     </NavBottomMoreMenu>
   </nav>


### PR DESCRIPTION
fix #1422 

Hi, this is the follow-up PR of #1867

This changes the `<label>` to `<button>` so that users can focus on it and also can open the menu panel by Enter/Space key. I think this doesn't change anything visually.

I'm not sure why the original invisible `<input>` was needed for the click event (I guess it could be attached to `<label>` too?). I believe the same functionality is available now via the `<button>`'s click event so removed it.

**Before**
<img width="404" alt="Screenshot 2023-07-21 at 16 47 27" src="https://github.com/elk-zone/elk/assets/1425259/d012e1f3-4f74-41c0-93f3-0cff9e719ada">

**After**
<img width="425" alt="Screenshot 2023-07-21 at 16 46 58" src="https://github.com/elk-zone/elk/assets/1425259/0e6bc160-0a1a-4091-98b6-0560c83aed59">


Ideally, we can improve the menu items by following the appropriate ARIA menu role coding guide (ARIA: menu role - Accessibility | MDN - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role) so that those who use accessibility tool can operate the menu more easily. But it requires more detailed work so I'll leave it for future work.