### PR TITLE
fix: Position NavBottom with "fixed" instead of "sticky"

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -54,7 +54,7 @@ const isGrayscale = usePreferences('grayscaleMode')
         <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
           <slot />
         </div>
-        <div sticky left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
+        <div style="position: fixed" left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
           <CommonOfflineChecker v-if="isHydrated" />
           <NavBottom v-if="isHydrated" sm:hidden />
         </div>


### PR DESCRIPTION
This fixes a Firefox Android bug (#2039) in which the bottom bar is rendered offset from the actual button location.

Apparently there's a browser bug with bottom-hugging sticky elements. When the browser's nav bar hides, the sticky element looks like it's positioned correctly, but the pointer events pass through it.

It's the same as this issue: https://stackoverflow.com/questions/70893056/mozilla-android-addressbar-conflict-with-sticky-button-on-bottom

But replacing `position: sticky` with `position: fixed` is an easy fix.

These screenshots from the remote debugger show the issue as the browser nav bar hides!

<img src="https://github.com/elk-zone/elk/assets/1120670/31d5e1a9-c6cd-467a-a105-67db33fab2f3" width="375px"/>
<img src="https://github.com/elk-zone/elk/assets/1120670/ec1bb0e5-bdee-4f63-a59e-19700e3261e9" width="375px"/>
