### PR TITLE
fix: check login in zen mode

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -12,6 +12,8 @@ const emit = defineEmits<{
   (event: 'afterEdit'): void
 }>()
 
+const focusEditor = inject<typeof noop>('focus-editor', noop)
+
 const { details, command } = $(props)
 
 const {
@@ -97,8 +99,10 @@ async function deleteAndRedraft() {
 }
 
 function reply() {
+  if (!checkLogin())
+    return
   if (details) {
-    // TODO focus to editor
+    focusEditor()
   }
   else {
     const { key, draft } = getReplyDraft(status)


### PR DESCRIPTION
If a user is in Zen mode and wants to reply a post directly but without logging in, elk does not render the sign-in dialog.