### PR TITLE
fix(pwa): configure `zone.elk` in web manifest id

### DIFF
--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -71,7 +71,7 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
 
   const manifestEntries: Partial<ManifestOptions> = {
     scope: '/',
-    id: '/',
+    id: 'zone.elk',
     start_url: '/',
     orientation: 'natural',
     display: 'standalone',

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -71,7 +71,7 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
 
   const manifestEntries: Partial<ManifestOptions> = {
     scope: '/',
-    id: 'zone.elk',
+    id: 'elk.zone',
     start_url: '/',
     orientation: 'natural',
     display: 'standalone',


### PR DESCRIPTION
It seems vite node (h3) broken using `dev:mocked:pwa:ssl`, I'm getting an http 500 error while fetching `__nuxt_vite_node__/manifest`, cannot test in Samsung Browser without https, service worker not detected/installed:
```shell
500

fetch failed (https://localhost:5314/__nuxt_vite_node__/manifest)

at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async $fetchRaw2 (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/node_modules/.pnpm/ofetch@1.1.1/node_modules/ofetch/dist/shared/ofetch.d438bb6f.mjs:215:14)
at async $fetch2 (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/node_modules/.pnpm/ofetch@1.1.1/node_modules/ofetch/dist/shared/ofetch.d438bb6f.mjs:239:15)
at async /D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/.nuxt/dev/index.mjs:1050:20
at async /D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/.nuxt/dev/index.mjs:1138:64
at async /D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/.nuxt/dev/index.mjs:616:22
at async Object.handler (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/node_modules/.pnpm/h3@1.7.1/node_modules/h3/dist/index.mjs:1284:19)
at async toNodeHandle (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/node_modules/.pnpm/h3@1.7.1/node_modules/h3/dist/index.mjs:1359:7)
at async Object.ufetch [as localFetch] (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/node_modules/.pnpm/unenv@1.5.1/node_modules/unenv/runtime/fetch/index.mjs:9:17)
at async Object.errorhandler [as onError] (/D:/work/projects/userquin/GitHub/elk-zone/elk-fix-pwa-installed-links/.nuxt/dev/index.mjs:707:30)
```

closes #1435
closes #2198 
