### PR TITLE
docs: fix image URLs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ We use [Docus](https://docus.dev) as the site generator and deploy through Netli
 5. Run `npm install`
    Note: Run this from the project's `docs` folder, not the root of the repository on your machine!
 6. Run `npm run dev` to launch a preview
-7. Visit `localhost:3000/docs/` to see a live preview of the docs
+7. Visit `localhost:3000/` to see a live preview of the docs
 
 ### Contributing
 

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -21,7 +21,7 @@ Elk
 An in-progress, nimble Mastodon web client
 
 #support
-![Screenshot of Elk](/docs/screenshot.png)
+![Screenshot of Elk](/screenshot.png)
 
 #extra
 ::list

--- a/docs/content/1.guide/1.index.md
+++ b/docs/content/1.guide/1.index.md
@@ -98,8 +98,8 @@ Some include:
 
 We want to thank the generous sponsoring and help of:
 
-[![NuxtLabs](/docs/images/nuxtlabs.svg)](https://nuxtlabs.com/)
-[![StackBlitz](/docs/images/stackblitz.svg)](https://stackblitz.com/)
+[![NuxtLabs](/images/nuxtlabs.svg)](https://nuxtlabs.com/)
+[![StackBlitz](/images/stackblitz.svg)](https://stackblitz.com/)
 
 And all the companies and individuals sponsoring Elk Team members.
 

--- a/docs/content/2.deployment/1.netlify.md
+++ b/docs/content/2.deployment/1.netlify.md
@@ -9,7 +9,7 @@ For this guide we're going to use Netlify for hosting the app, and Cloudflare fo
 In order to use Netlify with Elk, we'll need to fork the Elk repo.
 
 Fork the repository from [https://github.com/elk-zone/elk](https://github.com/elk-zone/elk). Make sure you deselect "Copy the main branch only" if you want to use the stable `release` branch.
-![The settings to use for forking the Elk repository](/docs/images/selfhosting-guide/github-fork.png)
+![The settings to use for forking the Elk repository](/images/selfhosting-guide/github-fork.png)
 
 ## Importing the Elk repo into Netlify
 
@@ -28,7 +28,7 @@ Go to "KV" and create a new namespace.
 Then go to "Overview" and click on API tokens. We want to create an API token that will let Elk modify our newly made Worker. Click on "Create token" and then in the Custom token section click "Get started".
 
 The only permission that we'll need is to edit the Workers KV Storage.
-![The settings to use for the CloudFlare API token](/docs/images/selfhosting-guide/cf-api-token-settings.png)
+![The settings to use for the CloudFlare API token](/images/selfhosting-guide/cf-api-token-settings.png)
 
 Save the newly made token in a safe spot. Keep the tab open while we'll configure the environment variables on Netlify.
 


### PR DESCRIPTION
It looks like https://docs.elk.zone/ has several image path errors like the one below.

<img width="329" alt="Screenshot 2023-07-25 at 11 56 25" src="https://github.com/elk-zone/elk/assets/1425259/9502cf35-498a-4499-bd0a-58e7cfa97aec">

I assume that the server URL was moved from the path `/docs/` to the current subdomain `docs.elk.zone` at some point.🙂 Simply deleting the `docs/` prefix solved the issue.