### PR TITLE
feat: add roles into account header and info

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -167,6 +167,7 @@ const personalNoteMaxLength = 2000
         <div flex="~ col gap1" pt2>
           <div flex gap2 items-center>
             <AccountDisplayName :account="account" font-bold sm:text-2xl text-xl />
+            <AccountRoleIndicator v-for="role in account.roles" :key="role.id" :role="role" />
             <AccountLockIndicator v-if="account.locked" show-label />
             <AccountBotIndicator v-if="account.bot" show-label />
           </div>

--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -23,6 +23,7 @@ const { account, as = 'div' } = defineProps<{
     <div flex="~ col" shrink pt-1 h-full overflow-hidden justify-center leading-none select-none>
       <div flex="~" gap-2>
         <AccountDisplayName :account="account" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
+        <AccountRoleIndicator v-for="role in account.roles" :key="role.id" :role="role" />
         <AccountLockIndicator v-if="account.locked" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
       </div>

--- a/components/account/AccountRoleIndicator.vue
+++ b/components/account/AccountRoleIndicator.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+interface Role {
+  name: string
+  color: string
+}
+
+defineProps<{
+  role: Role
+}>()
+</script>
+
+<template>
+  <div
+    flex="~ gap1" items-center
+    class="border border-base rounded-md px-1"
+    text-secondary-light
+  >
+    <slot name="prepend" />
+    <div :style="`color: ${role.color}; border-color: ${role.color}`">
+      {{ role.name }}
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Add roles into account header and account info

Linked to issue: https://github.com/elk-zone/elk/issues/2056

Added `AccountRoleIndicator` which is based on `AccountBotIndicator` so it has the same design. I use the color and name of the Role object to display it on the profile.

<img width="580" alt="Screenshot 2023-07-25 at 16 29 11" src="https://github.com/elk-zone/elk/assets/19307374/5d5fe008-204d-4893-96b1-f68d989cb0e4">

<img width="548" alt="Screenshot 2023-07-25 at 16 29 21" src="https://github.com/elk-zone/elk/assets/19307374/553afdd3-5f2a-4564-9b10-19852f521406">


