### PR TITLE
feat: show save failed error messages on the profile config page

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -51,6 +51,7 @@
     "boost_count": "{0}",
     "boosted": "Boosted",
     "clear_publish_failed": "Clear publish errors",
+    "clear_save_failed": "Clear save errors",
     "clear_upload_failed": "Clear file upload errors",
     "close": "Close",
     "compose": "Compose",
@@ -557,6 +558,7 @@
     "loading": "Loading...",
     "publish_failed": "Publish failed",
     "publishing": "Publishing",
+    "save_failed": "Save failed",
     "upload_failed": "Upload failed",
     "uploading": "Uploading..."
   },

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -51,6 +51,7 @@
     "boost_count": "{0}",
     "boosted": "ブースト済み",
     "clear_publish_failed": "投稿エラーをクリア",
+    "clear_save_failed": "保存エラーをクリア",
     "clear_upload_failed": "ファイルアップロードエラーをクリア",
     "close": "閉じる",
     "compose": "投稿",
@@ -499,6 +500,7 @@
     "loading": "読込中...",
     "publish_failed": "投稿に失敗しました",
     "publishing": "投稿中",
+    "save_failed": "保存に失敗しました",
     "upload_failed": "アップロードに失敗しました",
     "uploading": "更新中..."
   },

--- a/pages/settings/profile/appearance.vue
+++ b/pages/settings/profile/appearance.vue
@@ -57,6 +57,7 @@ const { form, reset, submitter, isDirty, isError } = useForm({
 })
 
 const isCanSubmit = computed(() => !isError.value && isDirty.value)
+const failedMessages = $ref<string[]>([])
 
 const { submit, submitting } = submitter(async ({ dirtyFields }) => {
   if (!isCanSubmit.value)
@@ -67,8 +68,8 @@ const { submit, submitting } = submitter(async ({ dirtyFields }) => {
     .catch((error: Error) => ({ error }))
 
   if ('error' in res) {
-    // TODO: Show error message
-    console.error('Error(updateCredentials):', res.error)
+    console.error(res.error)
+    failedMessages.push(res.error.message)
     return
   }
 
@@ -200,6 +201,7 @@ onReactivated(refreshInfo)
           </button>
 
           <button
+            v-if="failedMessages.length === 0"
             type="submit"
             btn-solid rounded-full text-sm
             flex gap-x-2 items-center
@@ -211,7 +213,42 @@ onReactivated(refreshInfo)
             <span v-else aria-hidden="true" block i-ri:save-line />
             {{ $t('action.save') }}
           </button>
+
+          <button
+            v-else
+            type="submit"
+            btn-danger rounded-full text-sm
+            flex gap-x-2 items-center
+          >
+            <span
+              aria-hidden="true" block i-carbon:face-dizzy-filled
+            />
+            <span>{{ $t('state.save_failed') }}</span>
+          </button>
         </div>
+
+        <CommonErrorMessage v-if="failedMessages.length > 0" described-by="save-failed">
+          <header id="save-failed" flex justify-between>
+            <div flex items-center gap-x-2 font-bold>
+              <div aria-hidden="true" i-ri:error-warning-fill />
+              <p>{{ $t('state.save_failed') }}</p>
+            </div>
+            <CommonTooltip placement="bottom" :content="$t('action.clear_save_failed')">
+              <button
+                flex rounded-4 p1 hover:bg-active cursor-pointer transition-100 :aria-label="$t('action.clear_save_failed')"
+                @click="failedMessages = []"
+              >
+                <span aria-hidden="true" w="1.75em" h="1.75em" i-ri:close-line />
+              </button>
+            </CommonTooltip>
+          </header>
+          <ol ps-2 sm:ps-1>
+            <li v-for="(error, i) in failedMessages" :key="i" flex="~ col sm:row" gap-y-1 sm:gap-x-2>
+              <strong>{{ i + 1 }}.</strong>
+              <span>{{ error }}</span>
+            </li>
+          </ol>
+        </CommonErrorMessage>
       </div>
     </form>
   </MainContent>


### PR DESCRIPTION
resolves #2263

This PR implements the error messages when saving the profile almost the same way as the publishing errors. This task has remained as TODO.

## How to test

1. Go to /settings/profile/appearance
2. Upload the large icon image (>2MB)
3. Click "Save" button

You can use this large image for testing:
![BlackMarble_2016_928m_s_america_s_labeled copy](https://github.com/elk-zone/elk/assets/1425259/d64cc993-c68f-4c19-bacd-f17cc8868201)
Source: https://svs.gsfc.nasa.gov/vis/a030000/a030800/a030877/frames/5760x3240_16x9_01p/

## Screenshots

**Error message example**
<img width="1137" alt="Screenshot 2023-07-27 at 22 36 14" src="https://github.com/elk-zone/elk/assets/1425259/d3601c9e-31ce-4323-86fd-ff3d90e3dc2e">

Note: There seems a repetition in the error message but the original error message has this string and I couldn't find any other string. I guess masto.js or the server returns this string.

**Close button tooltip label**
<img width="318" alt="Screenshot 2023-07-27 at 22 36 56" src="https://github.com/elk-zone/elk/assets/1425259/ebe3b36b-2008-49cf-86e6-980d02f59062">

**Current publishing errors UI (for reference)**
<img width="689" alt="Screenshot 2023-07-27 at 22 10 50" src="https://github.com/elk-zone/elk/assets/1425259/01429e09-00f5-4322-ab49-0f586a08a9b5">
