### PR TITLE
Add basic user-agent to all mastodon-bound requests

### DIFF
--- a/server/api/[server]/oauth/[origin].ts
+++ b/server/api/[server]/oauth/[origin].ts
@@ -1,5 +1,7 @@
 import { stringifyQuery } from 'ufo'
 
+import { APP_NAME } from '~/constants'
+
 export default defineEventHandler(async (event) => {
   let { server, origin } = getRouterParams(event)
   server = server.toLocaleLowerCase().trim()
@@ -24,6 +26,9 @@ export default defineEventHandler(async (event) => {
   try {
     const result: any = await $fetch(`https://${server}/oauth/token`, {
       method: 'POST',
+      headers: {
+        'user-agent': APP_NAME,
+      },
       body: {
         client_id: app.client_id,
         client_secret: app.client_secret,

--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -41,6 +41,9 @@ export function getRedirectURI(origin: string, server: string) {
 async function fetchAppInfo(origin: string, server: string) {
   const app: AppInfo = await $fetch(`https://${server}/api/v1/apps`, {
     method: 'POST',
+    headers: {
+      'user-agent': APP_NAME,
+    },
     body: {
       client_name: APP_NAME + (env !== 'release' ? ` (${env})` : ''),
       website: 'https://elk.zone',


### PR DESCRIPTION
Default UA "undici" is not very nice, and I blocked it on my instance to
block a certain botwave.
