### PR TITLE
feat: use configured writing/post language of user from mastodon

### DIFF
--- a/composables/masto/publish.ts
+++ b/composables/masto/publish.ts
@@ -15,7 +15,7 @@ export function usePublish(options: {
   const { client } = $(useMasto())
   const settings = useUserSettings()
 
-  const preferredLanguage = $computed(() => (settings.value?.language || 'en').split('-')[0])
+  const preferredLanguage = $computed(() => (currentUser.value?.account.source.language || settings.value?.language || 'en').split('-')[0])
 
   let isSending = $ref(false)
   const isExpanded = $ref(false)

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -426,6 +426,7 @@
     "language": {
       "display_language": "Anzeigesprache",
       "label": "Sprache",
+      "post_language": "Beitragssprache",
       "status": "Übersetzungsstatus: {0}/{1} ({2}%)",
       "translations": {
         "add": "Hinzufügen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -427,6 +427,7 @@
     "language": {
       "display_language": "Display Language",
       "label": "Language",
+      "post_language": "Posting Language",
       "status": "Translation status: {0}/{1} ({2}%)",
       "translations": {
         "add": "Add",

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -22,13 +22,27 @@ const status = computed(() => {
       </div>
     </template>
     <div p6>
-      <label space-y-2>
-        <span block font-medium>{{ $t('settings.language.display_language') }}</span>
-        <span block>
-          {{ status }}
-        </span>
+      <div space-y-2>
+        <h2 py2 font-bold text-xl flex="~ gap-1" items-center>
+          {{ $t('settings.language.display_language') }}
+        </h2>
+        <div>{{ status }}</div>
         <SettingsLanguage select-settings />
-      </label>
+      </div>
+      <div mt4>
+        <h2 font-bold text-xl flex="~ gap-1" items-center>
+          {{ $t('settings.language.post_language') }}
+        </h2>
+        <SettingsItem
+          v-if="currentUser"
+          command large
+          icon="i-ri:quill-pen-line"
+          :text="$t('settings.language.post_language')"
+          :description="$t('settings.account_settings.description')"
+          :to="`https://${currentUser!.server}/settings/preferences/other`"
+          external target="_blank"
+        />
+      </div>
       <h2 py4 mt2 font-bold text-xl flex="~ gap-1" items-center>
         {{ $t('settings.language.translations.heading') }}
       </h2>


### PR DESCRIPTION
closes #2079 
ref: #876
ref: #1196

This PR adds the following things:
- use the users writing/posting language from mastodon profile when available
- add a link to the mastodon settings page (where the writing/posting language can be configured) to Elk language settings page

