### PR TITLE
feat: hide original post area in the edit widget

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -213,13 +213,9 @@ onDeactivated(() => {
 <template>
   <div v-if="isHydrated && currentUser" flex="~ col gap-4" py3 px2 sm:px4 aria-roledescription="publish-widget">
     <template v-if="draft.editingStatus">
-      <div flex="~ col gap-1">
-        <div id="state-editing" text-secondary self-center>
-          {{ $t('state.editing') }}
-        </div>
-        <StatusCard :status="draft.editingStatus" :actions="false" :hover="false" is-preview px-0 />
+      <div id="state-editing" text-secondary self-center>
+        {{ $t('state.editing') }}
       </div>
-      <div border="b dashed gray/40" />
     </template>
 
     <div flex gap-3 flex-1>


### PR DESCRIPTION
resolve #2276

You can also the alternative implementation (original flipping layout) for comparison: #2284