### PR TITLE
feat(pwa): register `web+ap` protocol handler

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -17,7 +17,7 @@ function handleAuth(to: RouteLocationNormalized) {
   if (to.path === '/') {
     // handle PWA protocol handler
     if (to.query['protocol-handler'] && to.query.target) {
-      const target = decodeURIComponent(to.query.target as string).replace(/^web\+ap:\/\//, 'https://')
+      const target = (to.query.target as string).replace(/^web\+ap:\/\//, 'https://')
       // eslint-disable-next-line no-console
       console.log(target)
       return navigateTo('/home')

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -15,6 +15,14 @@ export default defineNuxtRouteMiddleware((to) => {
 
 function handleAuth(to: RouteLocationNormalized) {
   if (to.path === '/') {
+    // handle PWA protocol handler
+    if (to.query['protocol-handler'] && to.query.target) {
+      const target = decodeURIComponent(to.query.target as string).replace(/^web\+ap:\/\//, 'https://')
+      // eslint-disable-next-line no-console
+      console.log(target)
+      return navigateTo('/home')
+    }
+
     // Installed PWA shortcut to notifications
     if (to.query['notifications-pwa-shortcut'] !== undefined) {
       if (currentUser.value)

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -124,6 +124,10 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
     edge_side_panel: {
       preferred_width: 480,
     },
+    protocol_handlers: [{
+      protocol: 'web+ap',
+      url: '/?protocol-handler=1&target=%s',
+    }],
   }
 
   if (env === 'release') {


### PR DESCRIPTION
Check Elk ux channel in Discord: 
https://discord.com/channels/1044887051155292200/1056215947519729664/1133553020270039151

https://akkoma.dev/AkkomaGang/akkoma/pulls/589

/cc @danielroe the PWA must be installed, only tested in Windows (Chrome and Edge):
- install the PWA: in my tests I must close the PWA and reopen it the first time
- open dev tools in the installed PWA and go to the Manifest: you can also open Elk Manifest in another browser
- locate Protocol Handlers entry, you will have an input and button to test the urls
- enter any url (should have a host + /: for example `example/`), the browser will ask you to open it in Elk Dev and also to send the url to Elk Dev
- the protocol handler will open Elk via `/?protocol-handler=1&target=%s` url, check the entry in the auth middleware (it is similar to the shortcuts)
- you have some screenshots in the ux discord channel
