### PR TITLE
fix: correct ratio of profile header avatar

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -115,8 +115,8 @@ const personalNoteMaxLength = 2000
     <div p4 mt--18 flex flex-col gap-4>
       <div relative>
         <div flex justify-between>
-          <button shrink-0 :class="{ 'rounded-full': !isSelf, 'squircle': isSelf }" w-30 h-30 p1 bg-base border-bg-base z-2 @click="previewAvatar">
-            <AccountAvatar :square="isSelf" :account="account" hover:opacity-90 transition-opacity />
+          <button shrink-0 :class="{ 'rounded-full': !isSelf, 'squircle': isSelf }" p1 bg-base border-bg-base z-2 @click="previewAvatar">
+            <AccountAvatar :square="isSelf" :account="account" hover:opacity-90 transition-opacity w-28 h-28 />
           </button>
           <div inset-ie-0 flex="~ wrap row-reverse" gap-2 items-center pt18 justify-start>
             <!-- Edit profile -->


### PR DESCRIPTION
fix #2287

To specify the correct image size, specifiers had to be applied to `AccountAvatar`, not the parent `<button>`.

Currently, Only `img { max-width: 100% }` (from the reset CSS) was applied to avatar `<img>` so it was not shown as expected if it's not the non-square image.