### PR TITLE
fix: improve default font family

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -2,6 +2,7 @@ html {
   font-size: var(--font-size, 15px);
   width: 100%;
   width: 100vw;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 @font-face {


### PR DESCRIPTION
Currently, elk's font-family is based on the `@unocss/reset/tailwind.css` file. The font-family in tailwind css is Mac-centric and does not take into account the Windows environment (specifically the CJK Windows environment).

The biggest problem with the font-family in tailwind css is the presence of system-ui, which breaks readability in the CJK windowing environment. In addition to breaking readability on Windows(https://infinnie.github.io/blog/2017/systemui.html), system-ui does not take advantage of the ability to change fonts based on lang attributes.

![스크린샷 2023-08-08 211437](https://github.com/elk-zone/elk/assets/56965274/1383586e-a77c-405b-982b-1a711caf8a67)
Current ELK client. Because of system-ui, it renders Malgun Gothic(This is Korean font. This is not japanese font) instead of Japanese fonts, and the Japanese readability of Malgun Gothicc is horrible.

![스크린샷 2023-08-08 211550](https://github.com/elk-zone/elk/assets/56965274/8a331f1e-81d1-45c4-a8c3-be92a1fb9dd1)
After removing system-ui, the correct Japanese font is loaded.

This PR fixes this issue.