### PR TITLE
feat(a11y): add checkbox role to toggle items

### DIFF
--- a/components/settings/SettingsToggleItem.vue
+++ b/components/settings/SettingsToggleItem.vue
@@ -11,6 +11,7 @@ const { disabled = false } = defineProps<{
   <button
     exact-active-class="text-primary"
     block w-full group focus:outline-none text-start
+    role="checkbox" :aria-checked="checked"
     :disabled="disabled"
     :class="disabled ? 'opacity-50 cursor-not-allowed' : ''"
   >


### PR DESCRIPTION
Currently, the screen reader does not announce whether the current toggle is on or not.

The bottom text is the screen reader speech output.
Before:
![photo_2023-08-09 23 28 57](https://github.com/elk-zone/elk/assets/10359255/1a8d4d6d-daa8-4fd9-995c-28ad84949a2d)

After: 
![photo_2023-08-09 23 32 23](https://github.com/elk-zone/elk/assets/10359255/9e3d887c-098f-4cdb-bf91-a9af419e18dd)
![photo_2023-08-09 23 32 25](https://github.com/elk-zone/elk/assets/10359255/8a932f39-d81c-4ba9-a198-9d51cecf7cba)
