### PR TITLE
fix: like/bookmark button is disappeared

### DIFF
--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -68,7 +68,7 @@ useCommand({
           'group-focus-visible:ring': '2 current',
         }"
       >
-        <div :class="active && activeIcon ? activeIcon : (disabled ? inactiveIcon : icon)" />
+        <div :class="active && activeIcon ? activeIcon : (disabled && inactiveIcon ? inactiveIcon : icon)" />
       </div>
     </CommonTooltip>
 


### PR DESCRIPTION
The button is disappeared when the post is unfavorited/unbookmarked. I think I accidentally introduced this bug in the pr #2326. Sorry for that.


https://github.com/elk-zone/elk/assets/10359255/f482d555-662e-4b1a-9b52-50e4afa1d6a5

