### PR TITLE
feat(a11y): enhance post-related a11y features

### DIFF
--- a/components/publish/PublishEditorTools.vue
+++ b/components/publish/PublishEditorTools.vue
@@ -11,6 +11,7 @@ const { editor } = defineProps<{
     <VDropdown v-if="editor" placement="top">
       <button
         btn-action-icon
+        :aria-label="$t('tooltip.open_editor_tools')"
       >
         <div i-ri:font-size-2 />
       </button>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -369,7 +369,7 @@ onDeactivated(() => {
             @select="insertEmoji"
             @select-custom="insertCustomEmoji"
           >
-            <button btn-action-icon :title="$t('tooltip.add_emojis')">
+            <button btn-action-icon :title="$t('tooltip.emojis')" :aria-label="$t('tooltip.add_emojis')">
               <div i-ri:emotion-line />
             </button>
           </PublishEmojiPicker>

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -369,7 +369,7 @@ onDeactivated(() => {
             @select="insertEmoji"
             @select-custom="insertCustomEmoji"
           >
-            <button btn-action-icon :title="$t('tooltip.emoji')">
+            <button btn-action-icon :title="$t('tooltip.add_emojis')">
               <div i-ri:emotion-line />
             </button>
           </PublishEmojiPicker>

--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -57,6 +57,7 @@ useCommand({
     :class="active ? color : 'text-secondary'"
     :aria-label="content"
     :disabled="disabled"
+    :aria-disabled="disabled"
   >
     <CommonTooltip placement="bottom" :content="content">
       <div

--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -55,7 +55,7 @@ useCommand({
     :hover=" !disabled ? hover : undefined"
     focus:outline-none
     :focus-visible="hover"
-    :class="active ? color : (disabled ? 'op25 pointer-events-none cursor-not-allowed' : 'text-secondary')"
+    :class="active ? color : (disabled ? 'op25 cursor-not-allowed' : 'text-secondary')"
     :aria-label="content"
     :disabled="disabled"
     :aria-disabled="disabled"

--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -54,7 +54,7 @@ useCommand({
     :hover=" !disabled ? hover : undefined"
     focus:outline-none
     :focus-visible="hover"
-    :class="active ? color : (disabled ? 'op25 cursor-not-allowed' : 'text-secondary')"
+    :class="active ? color : (disabled ? 'op25 pointer-events-none cursor-not-allowed' : 'text-secondary')"
     :aria-label="content"
     :disabled="disabled"
     :aria-disabled="disabled"

--- a/components/status/StatusActionButton.vue
+++ b/components/status/StatusActionButton.vue
@@ -54,7 +54,7 @@ useCommand({
     :hover=" !disabled ? hover : undefined"
     focus:outline-none
     :focus-visible="hover"
-    :class="active ? color : 'text-secondary'"
+    :class="active ? color : (disabled ? 'op25 cursor-not-allowed' : 'text-secondary')"
     :aria-label="content"
     :disabled="disabled"
     :aria-disabled="disabled"

--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -48,9 +48,11 @@ useHydratedHead({
           <span ms1 font-bold cursor-pointer>{{ $t('state.edited') }}</span>
         </StatusEditIndicator>
       </div>
-      <div>&middot;</div>
+      <div aria-hidden="true">
+        &middot;
+      </div>
       <StatusVisibilityIndicator :status="status" />
-      <div v-if="status.application?.name">
+      <div v-if="status.application?.name" aria-hidden="true">
         &middot;
       </div>
       <div v-if="status.application?.website && status.application.name">

--- a/components/status/StatusSpoiler.vue
+++ b/components/status/StatusSpoiler.vue
@@ -30,7 +30,7 @@ function getToggleText() {
       <slot name="spoiler" />
     </div>
     <div flex="~ gap-1 center" w-full :mb="isDM && !showContent ? '4' : ''" mt="-4.5">
-      <button btn-text px-2 py-1 :bg="isDM ? 'transparent' : 'base'" flex="~ center gap-2" :class="showContent ? '' : 'filter-saturate-0 hover:filter-saturate-100'" @click="toggleContent()">
+      <button btn-text px-2 py-1 :bg="isDM ? 'transparent' : 'base'" flex="~ center gap-2" :class="showContent ? '' : 'filter-saturate-0 hover:filter-saturate-100'" :aria-expanded="showContent" @click="toggleContent()">
         <div v-if="showContent" i-ri:eye-line />
         <div v-else i-ri:eye-close-line />
         {{ showContent ? $t('status.spoiler_show_less') : $t(getToggleText()) }}

--- a/components/status/StatusVisibilityIndicator.vue
+++ b/components/status/StatusVisibilityIndicator.vue
@@ -10,6 +10,6 @@ const visibility = $computed(() => statusVisibilities.find(v => v.value === stat
 
 <template>
   <CommonTooltip :content="$t(`visibility.${visibility.value}`)" placement="bottom">
-    <div :class="visibility.icon" />
+    <div :class="visibility.icon" :aria-label="$t(`visibility.${visibility.value}`)" />
   </CommonTooltip>
 </template>


### PR DESCRIPTION
1, announce open editor tools button & emoji button
**Before**:
<img width="741" alt="Screenshot 2023-08-11 at 3 37 25 PM" src="https://github.com/elk-zone/elk/assets/10359255/e1c5b133-9e0c-46ad-986c-fbe895077d2f">
<img width="714" alt="Screenshot 2023-08-11 at 3 57 48 PM" src="https://github.com/elk-zone/elk/assets/10359255/48916759-8ded-4e53-8529-c31aab4b91eb">


**After**:
<img width="653" alt="Screenshot 2023-08-11 at 3 38 56 PM" src="https://github.com/elk-zone/elk/assets/10359255/538ab672-0496-48ac-8c85-d33cd4ebf8f8">
<img width="744" alt="Screenshot 2023-08-11 at 3 41 45 PM" src="https://github.com/elk-zone/elk/assets/10359255/a4b70eab-2d23-4a3c-b2db-d3df40320374">

2. show "not allowed" cursor for disabled boost button
**After**
<img width="496" alt="Screenshot 2023-08-11 at 4 00 13 PM" src="https://github.com/elk-zone/elk/assets/10359255/6d2b5f4c-c024-4203-920c-d2dd3f8994b1">

3. don't announce the midpoints between icons
**Before**
<img width="711" alt="Screenshot 2023-08-11 at 4 02 25 PM" src="https://github.com/elk-zone/elk/assets/10359255/e99d3a40-35f7-4297-90d0-9e7b83e70c03">

4. announce "expanded" & "collapsed" state for "show more" and "show less" buttons
<img width="705" alt="Screenshot 2023-08-11 at 3 43 50 PM" src="https://github.com/elk-zone/elk/assets/10359255/96b1380c-c615-41de-b032-d9beb0b31b91">

5. announce the visibility of the toot when focus is moved to the visibility icon