### PR TITLE
feat: add fav and boosted icon

### DIFF
--- a/components/notification/NotificationGroupedLikes.vue
+++ b/components/notification/NotificationGroupedLikes.vue
@@ -8,6 +8,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 
 const reblogs = $computed(() => group.likes.filter(i => i.reblog))
 const likes = $computed(() => group.likes.filter(i => i.favourite && !i.reblog))
+const likedAndReblogged = $computed(() => group.likes.filter(i => i.favourite && i.reblog))
 </script>
 
 <template>
@@ -16,6 +17,15 @@ const likes = $computed(() => group.likes.filter(i => i.favourite && !i.reblog))
       <div flex flex-col gap-2>
         <div v-if="reblogs.length" flex="~ gap-1">
           <div i-ri:repeat-fill text-xl me-1 color-green />
+          <div
+            v-if="likedAndReblogged.length"
+            :class="useStarFavoriteIcon ? 'i-ri:star-fill color-yellow' : 'i-ri:heart-fill color-red'"
+            me-1
+            absolute
+            top-2
+            left-6
+          />
+          <!-- Maybe only add heart/star on avatars who've liked this post? -->
           <template v-for="i, idx of reblogs" :key="idx">
             <AccountHoverWrapper :account="i.account">
               <NuxtLink :to="getAccountRoute(i.account)">
@@ -24,7 +34,7 @@ const likes = $computed(() => group.likes.filter(i => i.favourite && !i.reblog))
             </AccountHoverWrapper>
           </template>
           <div ml1>
-            {{ $t('notification.reblogged_post') }}
+            {{ likedAndReblogged.length ? $t('notification.reblogged_and_favourited_post') : $t('notification.reblogged_post') }}
           </div>
         </div>
         <div v-if="likes.length" flex="~ gap-1">

--- a/locales/en.json
+++ b/locales/en.json
@@ -298,6 +298,7 @@
     "followed_you": "followed you",
     "followed_you_count": "{0} people followed you|{0} person followed you|{0} people followed you",
     "missing_type": "MISSING notification.type:",
+    "reblogged_and_favourited_post": "boosted and favorited your post",
     "reblogged_post": "boosted your post",
     "reported": "{0} reported {1}",
     "request_to_follow": "requested to follow you",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -298,6 +298,7 @@
     "followed_you": "vous suit",
     "followed_you_count": "{0} personnes vous suivent|{0} personne vous suit|{0} personnes vous suivent",
     "missing_type": "MISSING notification.type:",
+    "reblogged_and_favourited_post": "a relayé et aimé votre message",
     "reblogged_post": "a relayé votre message",
     "reported": "{0} a signalé {1}",
     "request_to_follow": "vous demande de le suivre",


### PR DESCRIPTION
## Add favorited and boosted

Issue: https://github.com/elk-zone/elk/issues/2218

I've added the like and favorited icon. 

<img width="294" alt="Screenshot 2023-08-16 at 10 18 34" src="https://github.com/elk-zone/elk/assets/19307374/1e6e44dc-844f-4407-9307-31b1c41bb6df">

I've just noticed that if multiple people boost a post there's a list of icon so it's not really readable who liked or not. So I've also made this version :

<img width="318" alt="Screenshot 2023-08-16 at 10 26 58" src="https://github.com/elk-zone/elk/assets/19307374/e21f1ef3-b230-4c5c-aa1e-d4770579974e">

Tell me which one is the best but I kinda like the 2nd one.