### PR TITLE
refactor: solve the problem that the title is not centered

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -40,7 +40,7 @@ const containerClass = computed(() => {
           >
             <div i-ri:arrow-left-line class="rtl-flip" />
           </NuxtLink>
-          <div :truncate="!noOverflowHidden ? '' : false" flex w-full data-tauri-drag-region class="native-mac:justify-center native-mac:text-center native-mac:sm:justify-start">
+          <div :truncate="!noOverflowHidden ? '' : false" flex w-full data-tauri-drag-region class="native-mac:justify-start native-mac:text-center">
             <slot name="title" />
           </div>
           <div sm:hidden h-7 w-1px />


### PR DESCRIPTION

before:
<img width="391" alt="image" src="https://github.com/elk-zone/elk/assets/47295879/2802c5be-1939-4d58-8996-6070bff766e4">


after:
<img width="372" alt="image" src="https://github.com/elk-zone/elk/assets/47295879/b3fd2274-d1d2-454d-ab78-fad36869e559">

refer to:
<img width="454" alt="image" src="https://github.com/elk-zone/elk/assets/47295879/8309ec8e-7415-49a1-82a5-75ed4e36d1a5">

