### PR TITLE
fix: change status focus style

### DIFF
--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -37,7 +37,7 @@ function go(evt: MouseEvent | KeyboardEvent) {
     p="b-2 is-3 ie-4"
     :class="{ 'hover:bg-active': hover }"
     tabindex="0"
-    focus:outline-none focus-visible:ring="2 primary"
+    focus:outline-none focus-visible:ring="2 primary inset"
     aria-roledescription="status-card"
     :lang="status.language ?? undefined"
     @click="onclick"


### PR DESCRIPTION
Correct status focus style if use virtual scrolling
- Before
![image](https://github.com/elk-zone/elk/assets/11923242/2e0b4cea-0d7f-4430-94a6-299402ef774a)

- After
![image](https://github.com/elk-zone/elk/assets/11923242/37147780-be46-4a03-a6a1-04b9eec043de)
