### PR TITLE
feat: add keyboard shortcut helper link or button

### DIFF
--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -92,5 +92,10 @@ function toggleDark() {
         GitHub
       </NuxtLink>
     </div>
+    <div>
+      <button hover:underline @click="toggleKeyboardShortcuts">
+        {{ $t('magic_keys.dialog_header') }}
+      </button>
+    </div>
   </footer>
 </template>

--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -16,6 +16,9 @@ function toggleDark() {
 <template>
   <footer p4 text-sm text-secondary-light flex="~ col">
     <div flex="~ gap2" items-center mb4>
+      <CommonTooltip :content="$t('magic_keys.dialog_header')">
+        <button flex i-ri:keyboard-box-line dark-i-ri:keyboard-box-line text-lg :aria-label="$t('magic_keys.dialog_header')" @click="toggleKeyboardShortcuts" />
+      </CommonTooltip>
       <CommonTooltip :content="$t('nav.toggle_theme')">
         <button flex i-ri:sun-line dark-i-ri:moon-line text-lg :aria-label="$t('nav.toggle_theme')" @click="toggleDark()" />
       </CommonTooltip>

--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -16,9 +16,6 @@ function toggleDark() {
 <template>
   <footer p4 text-sm text-secondary-light flex="~ col">
     <div flex="~ gap2" items-center mb4>
-      <CommonTooltip :content="$t('magic_keys.dialog_header')">
-        <button flex i-ri:keyboard-box-line dark-i-ri:keyboard-box-line text-lg :aria-label="$t('magic_keys.dialog_header')" @click="toggleKeyboardShortcuts" />
-      </CommonTooltip>
       <CommonTooltip :content="$t('nav.toggle_theme')">
         <button flex i-ri:sun-line dark-i-ri:moon-line text-lg :aria-label="$t('nav.toggle_theme')" @click="toggleDark()" />
       </CommonTooltip>
@@ -30,6 +27,9 @@ function toggleDark() {
           :aria-label="$t('nav.zen_mode')"
           @click="togglePreferences('zenMode')"
         />
+      </CommonTooltip>
+      <CommonTooltip :content="$t('magic_keys.dialog_header')">
+        <button flex i-ri:keyboard-box-line dark-i-ri:keyboard-box-line text-lg :aria-label="$t('magic_keys.dialog_header')" @click="toggleKeyboardShortcuts" />
       </CommonTooltip>
       <CommonTooltip :content="$t('settings.about.sponsor_action')">
         <NuxtLink


### PR DESCRIPTION
This adds an explicit link/button to show the keyboard shortcut helper panel. I tried to implement both but that's just to evaluate which one is better (will revert one of the commits later).

I saw some people commented somewhere (sorry, couldn't find the original comment) that they didn't notice the keyboard shortcut is supported by Elk. This link/button can help to find the feature.

<img width="320" alt="Screenshot 2023-08-26 at 2 15 03" src="https://github.com/elk-zone/elk/assets/1425259/dcc71ed8-adab-4f1c-928a-05a54dca0fb9">

<img width="332" alt="Screenshot 2023-08-26 at 2 14 54" src="https://github.com/elk-zone/elk/assets/1425259/848c338a-7d60-47af-af3c-4948a56db135">
