### PR TITLE
fix(unocss): resolve match warning for uno

### DIFF
--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -81,7 +81,7 @@ function reply() {
         :text="!getPreferences(userSettings, 'hideFavoriteCount') && status.favouritesCount ? status.favouritesCount : ''"
         :color="useStarFavoriteIcon ? 'text-yellow' : 'text-rose'"
         :hover="useStarFavoriteIcon ? 'text-yellow' : 'text-rose'"
-        :elk-group-hover="useStarFavoriteIcon ? 'bg-yellow/10' : 'bg-rose/10'"
+        v-bind="{ elkGroupHover: useStarFavoriteIcon ? 'bg-yellow/10' : 'bg-rose/10' }"
         :icon="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'"
         :active-icon="useStarFavoriteIcon ? 'i-ri:star-fill' : 'i-ri:heart-3-fill'"
         :active="!!status.favourited"
@@ -103,7 +103,7 @@ function reply() {
         :content="$t('action.bookmark')"
         :color="useStarFavoriteIcon ? 'text-rose' : 'text-yellow'"
         :hover="useStarFavoriteIcon ? 'text-rose' : 'text-yellow'"
-        :elk-group-hover="useStarFavoriteIcon ? 'bg-rose/10' : 'bg-yellow/10' "
+        v-bind="{ elkGroupHover: useStarFavoriteIcon ? 'bg-rose/10' : 'bg-yellow/10' }"
         icon="i-ri:bookmark-line"
         active-icon="i-ri:bookmark-fill"
         :active="!!status.bookmarked"
@@ -112,5 +112,9 @@ function reply() {
         @click="toggleBookmark()"
       />
     </div>
+
+    <!-- ⚠️ Placeholder for UnoCSS parse. ⚠️ -->
+    <!-- <template elk-group-hover="bg-yellow/10"></template>
+    <template elk-group-hover="bg-rose/10"></template> -->
   </div>
 </template>

--- a/components/status/StatusActions.vue
+++ b/components/status/StatusActions.vue
@@ -114,7 +114,6 @@ function reply() {
     </div>
 
     <!-- ⚠️ Placeholder for UnoCSS parse. ⚠️ -->
-    <!-- <template elk-group-hover="bg-yellow/10"></template>
-    <template elk-group-hover="bg-rose/10"></template> -->
+    <!-- <template elk-group-hover="bg-yellow/10" elk-group-hover="bg-rose/10"></template> -->
   </div>
 </template>


### PR DESCRIPTION
Because of Uno extract the untransformed code to parse, made some warnings.
<img width="711" alt="image" src="https://github.com/elk-zone/elk/assets/42139754/53099252-fa7b-4783-997c-9a284515a5f8">

As a workaround, we can prepare the unitilities of generated in comment node.