### PR TITLE
fix: mention in content do not render hover card

### DIFF
--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { account } = defineProps<{
+const props = defineProps<{
   account: mastodon.v1.Account
 }>()
 
+const account = props.account
 const relationship = $(useRelationship(account))
 </script>
 


### PR DESCRIPTION
resolve #2362 
Ensure the `account` value not wrapped by `ref` to get the right route for hover card.

Also fix the account at profile bio do not render the hover card.