### PR TITLE
fix: profile header avatar being pushed lower on smaller devices

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -115,7 +115,7 @@ const personalNoteMaxLength = 2000
     <div p4 mt--18 flex flex-col gap-4>
       <div relative>
         <div flex justify-between>
-          <button shrink-0 :class="{ 'rounded-full': !isSelf, 'squircle': isSelf }" p1 bg-base border-bg-base z-2 @click="previewAvatar">
+          <button shrink-0 h-full :class="{ 'rounded-full': !isSelf, 'squircle': isSelf }" p1 bg-base border-bg-base z-2 @click="previewAvatar">
             <AccountAvatar :square="isSelf" :account="account" hover:opacity-90 transition-opacity w-28 h-28 />
           </button>
           <div inset-ie-0 flex="~ wrap row-reverse" gap-2 items-center pt18 justify-start>


### PR DESCRIPTION
this fixes an issue where on smaller devices the avatar was moved down, not aligning with the profile header anymore

an example of the issue can be seen here: 
<img width="365" alt="image" src="https://github.com/elk-zone/elk/assets/18548570/996ca511-1915-4c23-886d-795829e66600">
Fixed it looks like this:
<img width="365" alt="image" src="https://github.com/elk-zone/elk/assets/18548570/be275c35-16c4-4ed1-a8c5-1094eb950467">


to test the fix, you can take a look at any profile with header image and profile picture on a smaller screen ( when the profile buttons wrap around), the account I used is http://localhost:5314/bumscode.com/@tagesschau@ard.social on screen width 320px