### PR TITLE
fix: #2439 - `endMessage` in CommonPaginator

### DIFF
--- a/components/common/CommonPaginator.vue
+++ b/components/common/CommonPaginator.vue
@@ -112,7 +112,7 @@ defineExpose({ createEntry, removeEntry, updateEntry })
     </slot>
     <slot v-else-if="state === 'done' && endMessage !== false" name="done" :items="items as U[]">
       <div p5 text-secondary italic text-center>
-        {{ t(typeof endMessage === 'string' ? endMessage : 'common.end_of_list') }}
+        {{ t(typeof endMessage === 'string' && items.length <= 0 ? endMessage : 'common.end_of_list') }}
       </div>
     </slot>
     <div v-else-if="state === 'error'" p5 text-secondary>


### PR DESCRIPTION
This is a PR for #2439 that adds a check for `items.length` in `CommonPaginator.vue` before setting the `endMessage` displayed in the UI.

1+ entries show `common.end_of_list` now:

![Screenshot from 2023-10-24 12-06-15](https://github.com/elk-zone/elk/assets/41571384/179335fc-7a07-4dd4-a7e2-81f6c1d60024)


<= 0 entries show the `endMessage` defined by the parent component, i.e. `common.no_bookmarks` in `TimelineBookmarks.vue`:

![Screenshot from 2023-10-24 12-06-23](https://github.com/elk-zone/elk/assets/41571384/17a6f87f-1b23-4669-a6c0-5a7cfee1eec3)
