### PR TITLE
feat: add pinterest icon in profile metadata

### DIFF
--- a/composables/masto/icons.ts
+++ b/composables/masto/icons.ts
@@ -28,6 +28,7 @@ export const accountFieldIcons: Record<string, string> = Object.fromEntries(Obje
   PayPal: 'i-ri:paypal-line',
   PGP: 'i-ri:key-2-line',
   Photos: 'i-ri:camera-2-line',
+  Pinterest: 'i-ri:pinterest-line',
   PlayStation: 'i-ri:playstation-line',
   Portfolio: 'i-ri:link',
   Pronouns: 'i-ri:contacts-line',


### PR DESCRIPTION
Pinterest icon `i-ri:pinterest-line` 

![image](https://github.com/elk-zone/elk/assets/108399634/bd27c7b5-4add-4296-a1d7-e34199ff9dc3)

https://github.com/elk-zone/elk/assets/108399634/e6356884-2fed-463c-ade3-6aa6e51c56d6

