### PR TITLE
chore(types): include `$pwa` module augmentation types for Nuxt and Vue

### DIFF
--- a/modules/pwa/types.ts
+++ b/modules/pwa/types.ts
@@ -1,6 +1,31 @@
 import type { VitePWAOptions } from 'vite-plugin-pwa'
+import { type Ref, type UnwrapNestedRefs } from 'vue'
 
 export interface VitePWANuxtOptions extends Partial<VitePWAOptions> {}
+
+export interface PwaInjection {
+  isInstalled: boolean
+  showInstallPrompt: Ref<boolean>
+  cancelInstall: () => void
+  install: () => Promise<void>
+  swActivated: Ref<boolean>
+  registrationError: Ref<boolean>
+  needRefresh: Ref<boolean>
+  updateServiceWorker: (reloadPage?: boolean | undefined) => Promise<void>
+  close: () => Promise<void>
+}
+
+declare module '#app/nuxt' {
+  interface NuxtApp {
+    $pwa: UnwrapNestedRefs<PwaInjection>
+  }
+}
+
+declare module '@vue/runtime-core' {
+  export interface ComponentCustomProperties {
+    $pwa: UnwrapNestedRefs<PwaInjection>
+  }
+}
 
 declare module '@nuxt/schema' {
   interface NuxtConfig {

--- a/modules/pwa/types.ts
+++ b/modules/pwa/types.ts
@@ -15,7 +15,8 @@ export interface PwaInjection {
   close: () => Promise<void>
 }
 
-declare module '#app/nuxt' {
+// TODO: we'll need to review this to '#app/nuxt'
+declare module '#app' {
   interface NuxtApp {
     $pwa: UnwrapNestedRefs<PwaInjection>
   }


### PR DESCRIPTION
VSCode (also working when using IntelliJ and should work also with WebStorm):

![imagen](https://github.com/elk-zone/elk/assets/6311119/e35df660-4958-4d11-8a9c-468e22529522)

![imagen](https://github.com/elk-zone/elk/assets/6311119/35419966-a029-444d-a8f8-d46229a11f6c)
