### PR TITLE
fix(i18n): update Basque localisation

### DIFF
--- a/locales/eu-ES.json
+++ b/locales/eu-ES.json
@@ -7,6 +7,8 @@
     "route_loaded": "{0} orrialdea kargatu da"
   },
   "account": {
+    "authorize": "Baimendu jarraipena",
+    "authorized": "Eskaerari baiezkoa eman diozu",
     "avatar_description": "{0}(r)en abatarra",
     "blocked_by": "Erabiltzaile honek blokeatu zaitu.",
     "blocked_domains": "Blokeatutako domeinuak",
@@ -36,7 +38,10 @@
     "profile_description": "{0}(r)en profilaren goiburua",
     "profile_personal_note": "Nire oharra",
     "profile_unavailable": "Profila ez dago eskuragai",
+    "reject": "Ukatu jarraipena",
+    "rejected": "Eskaerari ezezkoa eman diozu",
     "request_follow": "Bidali jarraipen-eskaera",
+    "requested": "{0}(e)k jarraipen-eskaera bidali dizu",
     "unblock": "Utzi blokeatzeari",
     "unfollow": "Utzi jarraitzeari",
     "unmute": "Utzi mututzeari",
@@ -495,6 +500,8 @@
     },
     "notifications_settings": "Jakinarazpenak",
     "preferences": {
+      "embedded_media": "Kapsulatutako multimedia erreproduzigailua",
+      "embedded_media_description": "Kapsulatutako erreproduzigailu bat erakusten du partekatutako multimedia jarioen estekak zabaltzean, ez aurrebista txartel arrunta.",
       "enable_autoplay": "Gaitu erreproduzitze automatikoa",
       "enable_data_saving": "Gaitu datu aurrezlea",
       "enable_data_saving_description": "Aurreztu datuak eranskinen kargatze-automatikoa galarazten.",
@@ -572,6 +579,7 @@
     },
     "boosted_by": "Bultzatu dute:",
     "edited": "Azken edizioa: {0}",
+    "embedded_warning": "Litekeena da honakoa erreproduzitzean zure IPa gainontzekoentzak ikusgai egotea.",
     "favourited_by": "Gogoko egin dute:",
     "filter_hidden_phrase": "Iragazia:",
     "filter_show_anyway": "Erakutsi edonola ere",


### PR DESCRIPTION
Added:

- 10 "authorize": "Authorize to follow",
- 11 "authorized": "You have Authorized the request",
- 41 "reject": "Reject to follow",
- 42 "rejected": "You have rejected the request",
- 44 "requested": "{0} has requested to follow you",
- 503 "embedded_media": "Embedded Media Player",
- 504 "embedded_media_description": "Display an embedded player instead of the normal preview card when expanding shared media streaming links.",
- 582 "embedded_warning": "Playing this may reveal your IP address to others.",