### PR TITLE
fix: btn-solid text color for dark mode

### DIFF
--- a/styles/vars.css
+++ b/styles/vars.css
@@ -23,7 +23,6 @@
   --c-bg-btn-disabled: #a1a1a1;
   --c-text-btn-disabled: #fff;
   --c-text-btn-disabled-deeper: #a1a1a1;
-  --c-text-btn: #fff;
 
   --c-success: #67C23A;
   --c-warning: #E6A23C;

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
 
       // buttons
       'btn-base': 'cursor-pointer disabled:pointer-events-none disabled:bg-$c-bg-btn-disabled disabled:text-$c-text-btn-disabled',
-      'btn-solid': 'btn-base px-4 py-2 rounded text-$c-text-btn bg-$c-primary hover:bg-$c-primary-active',
+      'btn-solid': 'btn-base px-4 py-2 rounded text-inverted bg-$c-primary hover:bg-$c-primary-active',
       'btn-outline': 'btn-base px-4 py-2 rounded text-$c-primary border border-$c-primary hover:bg-$c-primary hover:text-inverted',
       'btn-text': 'btn-base px-4 py-2 text-$c-primary hover:text-$c-primary-active',
       'btn-action-icon': 'btn-base hover:bg-active rounded-full h9 w9 flex items-center justify-center disabled:bg-transparent disabled:text-$c-text-secondary',


### PR DESCRIPTION
#2449 switched to white for the solid button text color, that looks good on light mode but a bit off in dark mode.

See
<img width="529" alt="image" src="https://github.com/elk-zone/elk/assets/583075/81c5cd5b-626f-4c4c-8362-1ffa0aa396a3">

Against
<img width="529" alt="image" src="https://github.com/elk-zone/elk/assets/583075/58a72054-9e4e-490a-b9dc-cff037124a03">


#2449 also didn't change all similar buttons (like the Follow button that had custom logic and was already using `text-inverted` so it is white text for light mode and black text for dark mode). This PR switches to using `text-inverted` everywhere.