### PR TITLE
fix: NavBottom fixed, not sticky

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -54,7 +54,7 @@ const isGrayscale = usePreferences('grayscaleMode')
         <div min-h="[calc(100vh-3.5rem)]" sm:min-h-screen>
           <slot />
         </div>
-        <div sticky left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
+        <div fixed left-0 right-0 bottom-0 z-10 bg-base pb="[env(safe-area-inset-bottom)]" transition="padding 20">
           <CommonOfflineChecker v-if="isHydrated" />
           <NavBottom v-if="isHydrated" sm:hidden />
         </div>


### PR DESCRIPTION
I could be missing something, but this fixes the bottom nav bar for me on mobile in Firefox, doesn't regress in Chrome, and doesn't affect the desktop layout.

resolve #1558