### PR TITLE
fix: move the ALT text button for video attahcments to the top

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -67,6 +67,7 @@ const type = $computed(() => {
 const video = ref<HTMLVideoElement | undefined>()
 const prefersReducedMotion = usePreferredReducedMotion()
 const isAudio = $computed(() => attachment.type === 'audio')
+const isVideo = $computed(() => attachment.type === 'video')
 
 const enableAutoplay = usePreferences('enableAutoplay')
 
@@ -246,7 +247,12 @@ watch(shouldLoadAttachment, () => {
         />
       </button>
     </template>
-    <div v-if="attachment.description && !getPreferences(userSettings, 'hideAltIndicatorOnPosts')" :class="isAudio ? '' : 'absolute left-2 bottom-2'">
+    <div
+      v-if="attachment.description && !getPreferences(userSettings, 'hideAltIndicatorOnPosts')" :class="isAudio ? [] : [
+        'absolute left-2',
+        isVideo ? 'top-2' : 'bottom-2',
+      ]"
+    >
       <VDropdown :distance="6" placement="bottom-start">
         <button
           font-bold text-sm


### PR DESCRIPTION
closes #2443

In order to avoid cover video controls, we should move `ALT` to the top for the video attachments.

From an aesthetic perspective, it doesn't seem ugly either.

![image](https://github.com/elk-zone/elk/assets/49969959/efdb3a3c-3b05-4690-8a6d-7815089853b9)
