### PR TITLE
fix: spoiler button style in notifications

### DIFF
--- a/components/status/StatusSpoiler.vue
+++ b/components/status/StatusSpoiler.vue
@@ -30,7 +30,7 @@ function getToggleText() {
       <slot name="spoiler" />
     </div>
     <div flex="~ gap-1 center" w-full :mb="isDM && !showContent ? '4' : ''" mt="-4.5">
-      <button btn-text px-2 py-1 :bg="isDM ? 'transparent' : 'base'" flex="~ center gap-2" :class="showContent ? '' : 'filter-saturate-0 hover:filter-saturate-100'" :aria-expanded="showContent" @click="toggleContent()">
+      <button btn-text px-2 py-1 rounded-lg :bg="isDM ? 'transparent' : 'base'" flex="~ center gap-2" :class="showContent ? '' : 'filter-saturate-0 hover:filter-saturate-100'" :aria-expanded="showContent" @click="toggleContent()">
         <div v-if="showContent" i-ri:eye-line />
         <div v-else i-ri:eye-close-line />
         {{ showContent ? $t('status.spoiler_show_less') : $t(getToggleText()) }}


### PR DESCRIPTION
At `Home` page, it has no contrast with pages background since they're both `base`. But at notification page, there's difference between them.

This pull request set the button as `rounded-lg` to make the button have a better appearance. But I'm not sure if the button's background should be always transparent, since it will be transparent when the post is a DM.

## Without hover

### Dark
![Screenshot_20231230_000340](https://github.com/elk-zone/elk/assets/14120445/ed901e72-2c26-409a-967e-23502fcaa28e)

### Light
![Screenshot_20231230_000359](https://github.com/elk-zone/elk/assets/14120445/3ccee67d-ae8e-4de6-b1d1-5c795e4e7a5a)

## Hover, Before

### Dark
![Screenshot_20231230_000324](https://github.com/elk-zone/elk/assets/14120445/9fa8298f-9361-4fd5-837b-8d3533eb68cd)

### Light
![Screenshot_20231230_000405](https://github.com/elk-zone/elk/assets/14120445/14a4765a-8ba1-4ca3-a995-737f18e33361)

## Hover, After

### Dark
![Screenshot_20231230_000257](https://github.com/elk-zone/elk/assets/14120445/6a3fd637-6615-4703-bb4c-f99560c0f0d6)

### Light
![Screenshot_20231230_000424](https://github.com/elk-zone/elk/assets/14120445/29f43379-6f2c-4afc-85dd-b6c8d1965cee)