### PR TITLE
fix: meta og:url should use the origin of the request instead of elk.zone

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -5,9 +5,11 @@ provideGlobalCommands()
 const route = useRoute()
 
 if (process.server && !route.path.startsWith('/settings')) {
+  const url = useRequestURL()
+
   useHead({
     meta: [
-      { property: 'og:url', content: `https://elk.zone${route.path}` },
+      { property: 'og:url', content: `${url.origin}${route.path}` },
     ],
   })
 }


### PR DESCRIPTION
Always having elk.zone in the og:url doesn't make sense. The urls don't even work if another instance is configured
I've deployed the fix to my elk instance and it works:

```
$ curl -sSf https://elk.fosspri.de/@joshix/111711285196317734 | grep 'og:url'
<meta property="og:url" content="https://elk.fosspri.de/@joshix/111711285196317734">
```

for it to work I had to add the following to my nginx config:
```
proxy_set_header Host              $http_host;
proxy_set_header X-Real-IP         $remote_addr;
proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
proxy_set_header X-Forwarded-Proto $scheme;
```