### PR TITLE
fix: rename tab label from "Mention" to "Mentions"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -632,7 +632,7 @@
     "notifications_favourite": "Favourite",
     "notifications_follow": "Follow",
     "notifications_follow_request": "Follow request",
-    "notifications_mention": "Mention",
+    "notifications_mention": "Mentions",
     "notifications_more_tooltip": "Filter notifications by type",
     "notifications_poll": "Poll",
     "notifications_reblog": "Boost",


### PR DESCRIPTION
simply change the mention tab label to the plural form.

ref. Original report: https://discord.com/channels/1044887051155292200/1045711790593560678/1199399384463442041

### Before
![Screenshot 2024-01-24 at 20 16 19](https://github.com/elk-zone/elk/assets/1425259/f4c4595c-0c42-4d9e-8d89-3054089f0cbf)

### After
![Screenshot 2024-01-24 at 20 16 12](https://github.com/elk-zone/elk/assets/1425259/7cfc75e9-2111-49dd-8c32-a48e3351fb21)

### Mastodon UI
![image](https://github.com/elk-zone/elk/assets/1425259/a0198b41-61b3-4f2d-ad92-c1d8270d9eba)
