### PR TITLE
fix: allow to translate "Lock" string on profile

### DIFF
--- a/components/account/AccountLockIndicator.vue
+++ b/components/account/AccountLockIndicator.vue
@@ -2,6 +2,8 @@
 defineProps<{
   showLabel?: boolean
 }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -15,7 +17,7 @@ defineProps<{
       <div i-ri:lock-line />
     </CommonTooltip>
     <div v-if="showLabel">
-      Lock
+      {{ t('account.lock') }}
     </div>
   </div>
 </template>

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,7 @@
     "follows_you": "Follows you",
     "go_to_profile": "Go to profile",
     "joined": "Joined",
+    "lock": "Lock",
     "moved_title": "has indicated that their new account is now:",
     "muted_users": "Muted users",
     "muting": "Muted",


### PR DESCRIPTION
Original request: https://discord.com/channels/1044887051155292200/1045711790593560678/1132028254795087983

This allows translation of the "Lock" label.

![Screenshot 2024-01-25 at 0 22 06](https://github.com/elk-zone/elk/assets/1425259/92d93ad1-8844-49ba-96a2-7a6ce6da804b)
