### PR TITLE
fix: fix tooltip overlaps with editor tool popup on Mobile

### DIFF
--- a/components/publish/PublishEditorTools.vue
+++ b/components/publish/PublishEditorTools.vue
@@ -8,7 +8,7 @@ const { editor } = defineProps<{
 
 <template>
   <CommonTooltip placement="top" :content="$t('tooltip.open_editor_tools')">
-    <VDropdown v-if="editor" placement="top">
+    <VDropdown v-if="editor" placement="bottom">
       <button
         btn-action-icon
         :aria-label="$t('tooltip.open_editor_tools')"


### PR DESCRIPTION
On mobile devices, the tooltip overlaps with the editor tool popup. Clicking on tooltip will dismiss both of them. This pr moves the editor tool popup to bottom. This looks the same as the emoji popup.

Before:

https://github.com/elk-zone/elk/assets/10359255/a8e6d9cc-fa2d-4680-9813-d02744fe27cd

After:
![after](https://github.com/elk-zone/elk/assets/10359255/70b0d587-e2ba-4d06-a6ad-49904eabdecc)
