### PR TITLE
chore: include `.gitattributes` for eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Every time I install dependencies or run tests locally some files touched with CRLF:

![imagen](https://github.com/elk-zone/elk/assets/6311119/da90224e-c315-40a0-87ab-f0813dca04bd)
