### PR TITLE
fix: fix `[object Object]` on the mentions tab

### DIFF
--- a/pages/notifications/[filter].vue
+++ b/pages/notifications/[filter].vue
@@ -15,7 +15,7 @@ const filter = computed<mastodon.v1.NotificationType | undefined>(() => {
 })
 
 useHydratedHead({
-  title: () => `${t(`tab.notifications_${filter ?? 'all'}`)} | ${t('nav.notifications')}`,
+  title: () => `${t(`tab.notifications_${filter.value ?? 'all'}`)} | ${t('nav.notifications')}`,
 })
 </script>
 


### PR DESCRIPTION
There was one missing unwrapping for the computedRef 🙂 

## Before
![Screenshot from 2024-02-24 23-00-19](https://github.com/elk-zone/elk/assets/1425259/9e39c1ea-fb97-4776-a314-4047eb9fba63)

## After
![Screenshot from 2024-02-24 23-00-39](https://github.com/elk-zone/elk/assets/1425259/c5b21309-af09-4368-81f3-549a2fcc3358)
