### PR TITLE
fix: paginator watch

### DIFF
--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -29,11 +29,11 @@ export function usePaginator<T, P, U = T>(
     prevItems.value = []
   }
 
-  watch(() => stream, async (stream) => {
-    if (!stream.value)
+  watch(stream, async (stream) => {
+    if (!stream)
       return
 
-    for await (const entry of stream.value) {
+    for await (const entry of stream) {
       if (entry.event === 'update') {
         const status = entry.payload
 


### PR DESCRIPTION
Regression from the Masto.js v6 update

There still seems to be issues with the updates. I think this was working before, but I can't seem to get updates now after subscribing.