### PR TITLE
feat: add several new shortcut keys for navigation

### DIFF
--- a/components/magickeys/MagickeysKeyboardShortcuts.vue
+++ b/components/magickeys/MagickeysKeyboardShortcuts.vue
@@ -41,12 +41,52 @@ const shortcutItemGroups = computed<ShortcutItemGroup[]>(() => [
       //   shortcut: { keys: ['k'], isSequence: false },
       // },
       {
+        description: t('magic_keys.groups.navigation.go_to_search'),
+        shortcut: { keys: ['/'], isSequence: false },
+      },
+      {
         description: t('magic_keys.groups.navigation.go_to_home'),
         shortcut: { keys: ['g', 'h'], isSequence: true },
       },
       {
         description: t('magic_keys.groups.navigation.go_to_notifications'),
         shortcut: { keys: ['g', 'n'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_conversations'),
+        shortcut: { keys: ['g', 'c'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_favourites'),
+        shortcut: { keys: ['g', 'f'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_bookmarks'),
+        shortcut: { keys: ['g', 'b'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_explore'),
+        shortcut: { keys: ['g', 'e'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_local'),
+        shortcut: { keys: ['g', 'l'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_federated'),
+        shortcut: { keys: ['g', 't'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_lists'),
+        shortcut: { keys: ['g', 'i'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_settings'),
+        shortcut: { keys: ['g', 's'], isSequence: true },
+      },
+      {
+        description: t('magic_keys.groups.navigation.go_to_profile'),
+        shortcut: { keys: ['g', 'p'], isSequence: true },
       },
     ],
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -226,7 +226,7 @@
         "boost": "Boost",
         "command_mode": "Command mode",
         "compose": "Compose",
-        "favourite": "Favourite",
+        "favourite": "Favorite",
         "search": "Search",
         "show_new_items": "Show new items",
         "title": "Actions"
@@ -235,8 +235,18 @@
         "title": "Media"
       },
       "navigation": {
+        "go_to_bookmarks": "Bookmarks",
+        "go_to_conversations": "Conversations",
+        "go_to_explore": "Explore",
+        "go_to_favourites": "Favorites",
+        "go_to_federated": "Federated",
         "go_to_home": "Home",
+        "go_to_lists": "Lists",
+        "go_to_local": "Local",
         "go_to_notifications": "Notifications",
+        "go_to_profile": "Profile",
+        "go_to_search": "Search",
+        "go_to_settings": "Settings",
         "next_status": "Next post",
         "previous_status": "Previous post",
         "shortcut_help": "Shortcut help",

--- a/plugins/magic-keys.client.ts
+++ b/plugins/magic-keys.client.ts
@@ -1,5 +1,6 @@
 import type { RouteLocationRaw } from 'vue-router'
 import { useMagicSequence } from '~/composables/magickeys'
+import { currentUser, getInstanceDomain } from '~/composables/users'
 
 export default defineNuxtPlugin(({ $scrollToTop }) => {
   const keys = useMagicKeys()
@@ -35,8 +36,20 @@ export default defineNuxtPlugin(({ $scrollToTop }) => {
   }
   whenever(logicAnd(isAuthenticated, notUsingInput, keys.c), defaultPublishDialog)
 
+  const instanceDomain = currentInstance.value ? getInstanceDomain(currentInstance.value) : 'm.webtoo.ls'
   whenever(logicAnd(notUsingInput, useMagicSequence(['g', 'h'])), () => navigateTo('/home'))
   whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'n'])), () => navigateTo('/notifications'))
+  // TODO: always overridden by 'c' (compose) shortcut
+  whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'c'])), () => navigateTo('/conversations'))
+  whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'f'])), () => navigateTo('/favourites'))
+  whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'b'])), () => navigateTo('/bookmarks'))
+  whenever(logicAnd(notUsingInput, useMagicSequence(['g', 'e'])), () => navigateTo(`/${instanceDomain}/explore`))
+  whenever(logicAnd(notUsingInput, useMagicSequence(['g', 'l'])), () => navigateTo(`/${instanceDomain}/public/local`))
+  whenever(logicAnd(notUsingInput, useMagicSequence(['g', 't'])), () => navigateTo(`/${instanceDomain}/public`))
+  whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'i'])), () => navigateTo('/lists'))
+  whenever(logicAnd(notUsingInput, useMagicSequence(['g', 's'])), () => navigateTo('/settings'))
+  whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'p'])), () => navigateTo(`/${instanceDomain}/@${currentUser.value?.account.username}`))
+  whenever(logicAnd(notUsingInput, keys['/']), () => navigateTo('/search'))
 
   const toggleFavouriteActiveStatus = () => {
     // TODO: find a better solution than clicking buttons...


### PR DESCRIPTION
This PR implements most of the navigation shortcuts in #1855.

**Before**
![image](https://github.com/elk-zone/elk/assets/1425259/392e49af-daa9-4b7a-aa15-8438a286ce30)

**After**
![Screenshot from 2024-02-25 03-43-29](https://github.com/elk-zone/elk/assets/1425259/0d2ec83d-d0a4-41c1-ade6-7fc6fd211ca9)

These had already been implemented:
- g+h - Home
- g+n - Notifications

New shortcuts by this PR:

- g+c - Conversations
- g+f - Favourites
- g+b - Bookmarks
- g+e - Explore
- g+l - Local Timeline
- g+t - (Federated) Timeline
- g+i - Lists
- g+p - Profile
- / - Search (this is listed in #1856).

Remaining:
- g+u - Go to User (focus on search with '@')