### PR TITLE
fix(ui): account mentions not being fetched when visible

### DIFF
--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -21,7 +21,7 @@ const account = ref<mastodon.v1.Account | null | undefined>(props.account)
 useIntersectionObserver(
   hoverCard,
   ([{ intersectionRatio }]) => {
-    targetIsVisible.value = intersectionRatio <= 0.75
+    targetIsVisible.value = intersectionRatio > 0.1
   },
 )
 watch(

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -32,7 +32,7 @@ watch(
       return
     }
 
-    if (!newVisible)
+    if (!newVisible || process.test)
       return
 
     if (newHandle) {


### PR DESCRIPTION
The `intersectionRatio` usage is wrong in `AccountHoverWrapper`  and so any mention in the screen will show the dialog.

This PR also prevents fetching the account when testing.