### PR TITLE
feat(ui): add missing `goto magic keys` spanish translation entries

### DIFF
--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -84,6 +84,16 @@
     "add_account": "Añadir cuenta a la lista",
     "remove_account": "Quitar cuenta de la lista"
   },
+  "magic_keys": {
+    "groups": {
+      "navigation": {
+        "go_to_conversations": "Mensajes directos",
+        "go_to_federated": "Historia federada",
+        "go_to_local": "Historia local",
+        "go_to_settings": "Preferencias"
+      }
+    }
+  },
   "menu": {
     "block_domain": "Ocultar dominio {0}",
     "delete_and_redraft": "Eliminar y volver a borrador",

--- a/locales/es.json
+++ b/locales/es.json
@@ -235,8 +235,18 @@
         "title": "Multimedia"
       },
       "navigation": {
+        "go_to_bookmarks": "Marcadores",
+        "go_to_conversations": "Conversaciones",
+        "go_to_explore": "Explorar",
+        "go_to_favourites": "Favoritas",
+        "go_to_federated": "Federados",
         "go_to_home": "Inicio",
+        "go_to_lists": "Listas",
+        "go_to_local": "Local",
         "go_to_notifications": "Notificaciones",
+        "go_to_profile": "Perfil",
+        "go_to_search": "Buscar",
+        "go_to_settings": "Ajustes",
         "next_status": "Siguiente estado",
         "previous_status": "Anterior estado",
         "shortcut_help": "Atajo de ayuda",


### PR DESCRIPTION
/cc @patak-dev @mrcego (es-419 also included with nav entries)

related #2618