### PR TITLE
fix: allow to edit alt description of attached image again

### DIFF
--- a/components/publish/PublishAttachment.vue
+++ b/components/publish/PublishAttachment.vue
@@ -19,7 +19,8 @@ const emit = defineEmits<{
 const maxDescriptionLength = 1500
 
 const isEditDialogOpen = ref(false)
-const description = computed(() => props.attachment.description ?? '')
+const description = ref(props.attachment.description ?? '')
+
 function toggleApply() {
   isEditDialogOpen.value = false
   emit('setDescription', description.value)


### PR DESCRIPTION
fix #2629

I wrote the cause of the issue in #2629.