### PR TITLE
feat(ui): fetch account data on demand

### DIFF
--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -10,8 +10,8 @@ const relationship = computed(() => account ? useRelationship(account).value : u
 
 <template>
   <div>
-    <StatusCardSkeleton v-if="!account" />
-    <div v-else v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+    <StatusCardSkeleton v-if="!relationship" />
+    <div v-else-if="account" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
       <div flex="~ gap2" items-center>
         <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
           <AccountInfo :account="account" />

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -2,26 +2,23 @@
 import type { mastodon } from 'masto'
 
 const { account } = defineProps<{
-  account?: mastodon.v1.Account | null
+  account: mastodon.v1.Account
 }>()
 
 const relationship = computed(() => account ? useRelationship(account).value : undefined)
 </script>
 
 <template>
-  <div>
-    <StatusCardSkeleton v-if="!account" />
-    <div v-else flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
-      <div flex="~ gap2" items-center>
-        <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
-          <AccountInfo :account="account" />
-        </NuxtLink>
-        <AccountFollowButton v-show="relationship" text-sm :account="account" :relationship="relationship" />
-      </div>
-      <div v-if="account.note" max-h-100 overflow-y-auto>
-        <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
-      </div>
-      <AccountPostsFollowers text-sm :account="account" :is-hover-card="true" />
+  <div v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+    <div flex="~ gap2" items-center>
+      <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
+        <AccountInfo :account="account" />
+      </NuxtLink>
+      <AccountFollowButton text-sm :account="account" :relationship="relationship" />
     </div>
+    <div v-if="account.note" max-h-100 overflow-y-auto>
+      <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
+    </div>
+    <AccountPostsFollowers text-sm :account="account" :is-hover-card="true" />
   </div>
 </template>

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -5,7 +5,7 @@ const { account } = defineProps<{
   account: mastodon.v1.Account
 }>()
 
-const relationship = computed(() => account ? useRelationship(account).value : undefined)
+const relationship = useRelationship(account)
 </script>
 
 <template>

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -2,23 +2,26 @@
 import type { mastodon } from 'masto'
 
 const { account } = defineProps<{
-  account: mastodon.v1.Account
+  account?: mastodon.v1.Account
 }>()
 
-const relationship = useRelationship(account)
+const relationship = computed(() => account ? useRelationship(account) : undefined)
 </script>
 
 <template>
-  <div v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
-    <div flex="~ gap2" items-center>
-      <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
-        <AccountInfo :account="account" />
-      </NuxtLink>
-      <AccountFollowButton text-sm :account="account" :relationship="relationship" />
+  <div>
+    <StatusCardSkeleton v-if="!account" />
+    <div v-else v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+      <div flex="~ gap2" items-center>
+        <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
+          <AccountInfo :account="account" />
+        </NuxtLink>
+        <AccountFollowButton text-sm :account="account" :relationship="relationship" />
+      </div>
+      <div v-if="account.note" max-h-100 overflow-y-auto>
+        <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
+      </div>
+      <AccountPostsFollowers text-sm :account="account" :is-hover-card="true" />
     </div>
-    <div v-if="account.note" max-h-100 overflow-y-auto>
-      <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />
-    </div>
-    <AccountPostsFollowers text-sm :account="account" :is-hover-card="true" />
   </div>
 </template>

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -2,10 +2,10 @@
 import type { mastodon } from 'masto'
 
 const { account } = defineProps<{
-  account?: mastodon.v1.Account
+  account?: mastodon.v1.Account | null
 }>()
 
-const relationship = computed(() => account ? useRelationship(account) : undefined)
+const relationship = computed(() => account ? useRelationship(account).value : undefined)
 </script>
 
 <template>

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -10,13 +10,13 @@ const relationship = computed(() => account ? useRelationship(account).value : u
 
 <template>
   <div>
-    <StatusCardSkeleton v-if="!relationship" />
-    <div v-else-if="account" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
+    <StatusCardSkeleton v-if="!account" />
+    <div v-else flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
       <div flex="~ gap2" items-center>
         <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
           <AccountInfo :account="account" />
         </NuxtLink>
-        <AccountFollowButton text-sm :account="account" :relationship="relationship" />
+        <AccountFollowButton v-show="relationship" text-sm :account="account" :relationship="relationship" />
       </div>
       <div v-if="account.note" max-h-100 overflow-y-auto>
         <ContentRich text-4 text-secondary :content="account.note" :emojis="account.emojis" />

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -54,7 +54,7 @@ const userSettings = useUserSettings()
     <VMenu
       v-if="!disabled && !getPreferences(userSettings, 'hideAccountHoverCard')"
       placement="bottom-start"
-      :delay="{ show: 5, hide: 100 }"
+      :delay="{ show: 500, hide: 100 }"
       v-bind="$attrs"
       :close-on-content-click="false"
     >

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -52,7 +52,7 @@ const userSettings = useUserSettings()
 <template>
   <span ref="accountHover">
     <VMenu
-      v-if="!disabled && !getPreferences(userSettings, 'hideAccountHoverCard')"
+      v-if="!disabled && account && !getPreferences(userSettings, 'hideAccountHoverCard')"
       placement="bottom-start"
       :delay="{ show: 500, hide: 100 }"
       v-bind="$attrs"
@@ -60,7 +60,7 @@ const userSettings = useUserSettings()
     >
       <slot />
       <template #popper>
-        <AccountHoverCard :account="account" />
+        <AccountHoverCard v-if="account" :account="account" />
       </template>
     </VMenu>
     <slot v-else />

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -14,11 +14,12 @@ const props = defineProps<{
   disabled?: boolean
 }>()
 
-const targetIsHover = ref(false)
+const accountHover = ref()
+const hovered = useElementHover(accountHover)
 const account = ref<mastodon.v1.Account | null | undefined>(props.account)
 
 watch(
-  () => [props.account, props.handle, targetIsHover.value] satisfies WatcherType,
+  () => [props.account, props.handle, hovered.value] satisfies WatcherType,
   ([newAccount, newHandle, newVisible], oldProps) => {
     if (!newVisible || process.test)
       return
@@ -49,11 +50,11 @@ const userSettings = useUserSettings()
 </script>
 
 <template>
-  <span @mouseenter="targetIsHover = true" @mouseleave="targetIsHover = false">
+  <span ref="accountHover">
     <VMenu
       v-if="!disabled && !getPreferences(userSettings, 'hideAccountHoverCard')"
       placement="bottom-start"
-      :delay="{ show: 0, hide: 100 }"
+      :delay="{ show: 5, hide: 100 }"
       v-bind="$attrs"
       :close-on-content-click="false"
     >

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -2,14 +2,14 @@
 import type { mastodon } from 'masto'
 import { fetchAccountByHandle } from '~/composables/cache'
 
-type WatcherType = [acc?: mastodon.v1.Account, h?: string, v?: boolean]
+type WatcherType = [acc?: mastodon.v1.Account | null, h?: string, v?: boolean]
 
 defineOptions({
   inheritAttrs: false,
 })
 
 const props = defineProps<{
-  account?: mastodon.v1.Account
+  account?: mastodon.v1.Account | null
   handle?: string
   disabled?: boolean
 }>()

--- a/components/account/AccountHoverWrapper.vue
+++ b/components/account/AccountHoverWrapper.vue
@@ -14,26 +14,19 @@ const props = defineProps<{
   disabled?: boolean
 }>()
 
-const hoverCard = ref()
-const targetIsVisible = ref(false)
+const targetIsHover = ref(false)
 const account = ref<mastodon.v1.Account | null | undefined>(props.account)
 
-useIntersectionObserver(
-  hoverCard,
-  ([{ intersectionRatio }]) => {
-    targetIsVisible.value = intersectionRatio > 0.1
-  },
-)
 watch(
-  () => [props.account, props.handle, targetIsVisible.value] satisfies WatcherType,
+  () => [props.account, props.handle, targetIsHover.value] satisfies WatcherType,
   ([newAccount, newHandle, newVisible], oldProps) => {
+    if (!newVisible || process.test)
+      return
+
     if (newAccount) {
       account.value = newAccount
       return
     }
-
-    if (!newVisible || process.test)
-      return
 
     if (newHandle) {
       const [_oldAccount, oldHandle, _oldVisible] = oldProps ?? [undefined, undefined, false]
@@ -56,11 +49,17 @@ const userSettings = useUserSettings()
 </script>
 
 <template>
-  <span ref="hoverCard">
-    <VMenu v-if="!disabled && account && !getPreferences(userSettings, 'hideAccountHoverCard')" placement="bottom-start" :delay="{ show: 500, hide: 100 }" v-bind="$attrs" :close-on-content-click="false">
+  <span @mouseenter="targetIsHover = true" @mouseleave="targetIsHover = false">
+    <VMenu
+      v-if="!disabled && !getPreferences(userSettings, 'hideAccountHoverCard')"
+      placement="bottom-start"
+      :delay="{ show: 0, hide: 100 }"
+      v-bind="$attrs"
+      :close-on-content-click="false"
+    >
       <slot />
       <template #popper>
-        <AccountHoverCard v-if="account" :account="account" />
+        <AccountHoverCard :account="account" />
       </template>
     </VMenu>
     <slot v-else />


### PR DESCRIPTION
This PR includes:
- fetch account data when hovering on the account link (on demand)
- ~~add status card skeleton when resolving the account data~~

This will also prevent fetching account data of all accounts in the viewport while scrolling.

We can change the skeleton or switch to use an spinner loader.

Check this video https://streamable.com/4kk87e : added few seconds timeout to see the skeleton on first fetch (afterwards it is immediate)

/cc @patak-dev @shuuji3 