### PR TITLE
feat: allow to scroll-to-top by clicking header title in account, list, and tag pages

### DIFF
--- a/pages/[[server]]/@[account]/index.vue
+++ b/pages/[[server]]/@[account]/index.vue
@@ -24,10 +24,11 @@ onReactivated(() => {
   <MainContent back>
     <template #title>
       <ContentRich
-        timeline-title-style
+        timeline-title-style cursor-pointer
         :content="account ? getDisplayName(account) : t('nav.profile')"
         :show-emojis="!getPreferences(userSettings, 'hideUsernameEmojis')"
         :markdown="false"
+        @click="$scrollToTop"
       />
     </template>
 

--- a/pages/[[server]]/list/[list]/index.vue
+++ b/pages/[[server]]/list/[list]/index.vue
@@ -50,7 +50,12 @@ onReactivated(() => {
 <template>
   <MainContent back>
     <template #title>
-      <span text-lg font-bold>{{ listInfo ? listInfo.title : t('nav.list') }}</span>
+      <span
+        text-lg font-bold timeline-title-style cursor-pointer
+        @click="$scrollToTop"
+      >
+        {{ listInfo ? listInfo.title : t('nav.list') }}
+      </span>
     </template>
     <template #header>
       <CommonRouteTabs replace :options="tabs" />

--- a/pages/[[server]]/tags/[tag].vue
+++ b/pages/[[server]]/tags/[tag].vue
@@ -28,7 +28,10 @@ onReactivated(() => {
 <template>
   <MainContent back>
     <template #title>
-      <bdi text-lg font-bold>#{{ tagName }}</bdi>
+      <bdi
+        text-lg font-bold timeline-title-style cursor-pointer
+        @click="$scrollToTop"
+      >#{{ tagName }}</bdi>
     </template>
 
     <template #actions>


### PR DESCRIPTION
In Elk, we can click the title to scroll to the top pages. This is useful after reading many posts. But some pages don't have this feature and the title text style was inconsistent.

This RP ensures that three pages (user account, list, tag) have this feature. All of them usually have many posts so the scroll-to-top feature should be useful too.

## User account page
### Before
![Screenshot from 2024-02-28 23-13-52](https://github.com/elk-zone/elk/assets/1425259/cfd514da-a6be-4ece-9ee5-e70a57654f5d)

### After
![Screenshot from 2024-02-28 23-13-28](https://github.com/elk-zone/elk/assets/1425259/0ff9bd9a-2dfc-4c6b-a586-c6c32a0e6b1d)

## List page

### Before
![Screenshot from 2024-02-28 23-14-58](https://github.com/elk-zone/elk/assets/1425259/80f01146-cc39-474d-8455-ed75c4ac3dc6)
### After
![Screenshot from 2024-02-28 23-14-46](https://github.com/elk-zone/elk/assets/1425259/e6a7dd60-e437-46a6-bf3a-8bcd2dcf0eeb)


## Hashtag page

### Before
![Screenshot from 2024-02-28 23-14-19](https://github.com/elk-zone/elk/assets/1425259/8a1e700b-0a7c-490b-a086-102cf78d6d49)
### After

![Screenshot from 2024-02-28 23-14-30](https://github.com/elk-zone/elk/assets/1425259/def1c131-e4de-4257-af0e-0df748e78ed9)
