### PR TITLE
fix: show correct reply target user account in reply post header

### DIFF
--- a/components/status/StatusReplyingTo.vue
+++ b/components/status/StatusReplyingTo.vue
@@ -10,7 +10,7 @@ const {
 }>()
 
 const isSelf = computed(() => status.inReplyToAccountId === status.account.id)
-const account = isSelf ? computed(() => status.account) : useAccountById(status.inReplyToAccountId)
+const account = isSelf.value ? computed(() => status.account) : useAccountById(status.inReplyToAccountId)
 </script>
 
 <template>


### PR DESCRIPTION
The reply status account is expected to be the target account but actually, it showed the reply author.

ref. https://discord.com/channels/1044887051155292200/1046769315405365288/1212694499160096858