### PR TITLE
chore(tests): fix vitest can't terminate worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: 📦 Install dependencies

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -210,7 +210,7 @@ vi.mock('vue-router', async () => {
     }),
   }
 })
-/*
+
 vi.mock('@vueuse/shared', async () => {
   const vueuseShared = await import('@vueuse/shared')
   // mock pausableWatch and watchPausable: vitest process hangs from time to time
@@ -234,7 +234,7 @@ vi.mock('@vueuse/shared', async () => {
     },
   }
 })
-*/
+
 mockComponent('ContentMentionGroup', {
   setup(props, { slots }) {
     return () => h('mention-group', null, { default: () => slots?.default?.() })

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -210,6 +210,7 @@ vi.mock('vue-router', async () => {
     }),
   }
 })
+/*
 vi.mock('@vueuse/shared', async () => {
   const vueuseShared = await import('@vueuse/shared')
   // mock pausableWatch and watchPausable: vitest process hangs from time to time
@@ -233,7 +234,7 @@ vi.mock('@vueuse/shared', async () => {
     },
   }
 })
-
+*/
 mockComponent('ContentMentionGroup', {
   setup(props, { slots }) {
     return () => h('mention-group', null, { default: () => slots?.default?.() })

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -210,6 +210,29 @@ vi.mock('vue-router', async () => {
     }),
   }
 })
+vi.mock('@vueuse/shared', async () => {
+  const vueuseShared = await import('@vueuse/shared')
+  // mock pausableWatch and watchPausable: vitest process hangs from time to time
+  return {
+    ...vueuseShared,
+    pausableWatch: () => {
+      return {
+        stop: () => {},
+        pause: () => {},
+        resume: () => {},
+        isActive: readonly(ref(true)),
+      }
+    },
+    watchPausable: () => {
+      return {
+        stop: () => {},
+        pause: () => {},
+        resume: () => {},
+        isActive: readonly(ref(true)),
+      }
+    },
+  }
+})
 
 mockComponent('ContentMentionGroup', {
   setup(props, { slots }) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,13 @@ export default defineVitestConfig({
     setupFiles: [
       '/tests/setup.ts',
     ],
+    environmentOptions: {
+      nuxt: {
+        mock: {
+          indexedDb: true,
+          intersectionObserver: true,
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
From time to time in my local using Node 18.16.0 LTS vitest cannot finish the worker, when using Node 20.10.0 LTS tests seems to be fine: CI using Node 18.19.1.

The error on my local is about flushing local storage on user.ts module and the write method via the pausableWatcher in `@vueuse/shared` and so I just mock it, adding also indexedDB and intersectionObserver mocks from nuxt test utils.

EDIT: executed CI 3 times and seems to be fine