### PR TITLE
fix: fix emoji placement (#2626)

### DIFF
--- a/composables/tiptap/emoji.ts
+++ b/composables/tiptap/emoji.ts
@@ -1,10 +1,12 @@
-import type { ExtendedRegExpMatchArray } from '@tiptap/core'
+import type { ExtendedRegExpMatchArray, InputRuleFinder, nodeInputRule } from '@tiptap/core'
 import {
+  InputRule,
   Node,
+  callOrReturn,
   mergeAttributes,
-  nodeInputRule,
   nodePasteRule,
 } from '@tiptap/core'
+import type { NodeType } from '@tiptap/pm/model'
 import { emojiRegEx, getEmojiAttributes } from '~/config/emojis'
 
 function wrapHandler<T extends (...args: any[]) => any>(handler: T): T {
@@ -80,7 +82,34 @@ export const TiptapPluginEmoji = Node.create({
   },
 
   addInputRules() {
-    return createEmojiRule(nodeInputRule, this.type)
+    function emojiInputRule(config: {
+      find: InputRuleFinder
+      type: NodeType
+      getAttributes?:
+      | Record<string, any>
+      | ((match: ExtendedRegExpMatchArray) => Record<string, any>)
+      | false
+      | null
+    }) {
+      return new InputRule({
+        find: config.find,
+        handler: ({ state, range, match }) => {
+          const attributes = callOrReturn(config.getAttributes, undefined, match) || {}
+          const { tr } = state
+          const start = range.from
+          const end = range.to
+
+          tr.insert(start, config.type.create(attributes)).delete(
+            tr.mapping.map(start),
+            tr.mapping.map(end),
+          )
+
+          tr.scrollIntoView()
+        },
+      })
+    }
+
+    return createEmojiRule(emojiInputRule, this.type)
   },
 
   addPasteRules() {


### PR DESCRIPTION
Fixes #2626.

The issue was in tiptap's [`nodeInputRule` ](https://github.com/ueberdosis/tiptap/blob/e00700110af771c6f7f826a5d54802ebfed6aeb4/packages/core/src/inputRules/nodeInputRule.ts#L60), so I rewrote that function.

This is my first PR in this repo so please let me know if anything's not right.