### PR TITLE
fix: remember last accessed notification tab

### DIFF
--- a/components/nav/NavBottom.vue
+++ b/components/nav/NavBottom.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 // only one icon can be lit up at the same time
+import { STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE } from '~/constants'
+
 const moreMenuVisible = ref(false)
 
 const { notifications } = useNotifications()
+const lastAccessedNotificationRoute = useLocalStorage(STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE, '')
 </script>
 
 <template>
@@ -19,7 +22,7 @@ const { notifications } = useNotifications()
       <NuxtLink to="/search" :aria-label="$t('nav.search')" :active-class="moreMenuVisible ? '' : 'text-primary'" flex flex-row items-center place-content-center h-full flex-1 class="coarse-pointer:select-none" @click="$scrollToTop">
         <div i-ri:search-line />
       </NuxtLink>
-      <NuxtLink to="/notifications" :aria-label="$t('nav.notifications')" :active-class="moreMenuVisible ? '' : 'text-primary'" flex flex-row items-center place-content-center h-full flex-1 class="coarse-pointer:select-none" @click="$scrollToTop">
+      <NuxtLink :to="`/notifications/${lastAccessedNotificationRoute}`" :aria-label="$t('nav.notifications')" :active-class="moreMenuVisible ? '' : 'text-primary'" flex flex-row items-center place-content-center h-full flex-1 class="coarse-pointer:select-none" @click="$scrollToTop">
         <div flex relative>
           <div class="i-ri:notification-4-line" text-xl />
           <div v-if="notifications" class="top-[-0.3rem] right-[-0.3rem]" absolute font-bold rounded-full h-4 w-4 text-xs bg-primary text-inverted flex items-center justify-center>

--- a/components/nav/NavSide.vue
+++ b/components/nav/NavSide.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import { STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE } from '~/constants'
+
 const { command } = defineProps<{
   command?: boolean
 }>()
 const { notifications } = useNotifications()
 const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
+const lastAccessedNotificationRoute = useLocalStorage(STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE, '')
 </script>
 
 <template>
@@ -12,7 +15,7 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 
     <div class="spacer" shrink xl:hidden />
     <NavSideItem :text="$t('nav.home')" to="/home" icon="i-ri:home-5-line" user-only :command="command" />
-    <NavSideItem :text="$t('nav.notifications')" to="/notifications" icon="i-ri:notification-4-line" user-only :command="command">
+    <NavSideItem :text="$t('nav.notifications')" :to="`/notifications/${lastAccessedNotificationRoute}`" icon="i-ri:notification-4-line" user-only :command="command">
       <template #icon>
         <div flex relative>
           <div class="i-ri:notification-4-line" text-xl />

--- a/components/timeline/TimelineNotifications.vue
+++ b/components/timeline/TimelineNotifications.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import { STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE } from '~/constants'
 
 const { filter } = defineProps<{
   filter?: mastodon.v1.NotificationType
 }>()
+
+const route = useRoute()
+const lastAccessedNotificationRoute = useLocalStorage(STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE, '')
 
 const options = { limit: 30, types: filter ? [filter] : [] }
 
@@ -11,8 +15,13 @@ const options = { limit: 30, types: filter ? [filter] : [] }
 const paginator = useMastoClient().v1.notifications.list(options)
 const stream = useStreaming(client => client.user.notification.subscribe())
 
+lastAccessedNotificationRoute.value = route.path.replace(/\/notifications\/?/, '')
+
 const { clearNotifications } = useNotifications()
-onActivated(clearNotifications)
+onActivated(() => {
+  clearNotifications()
+  lastAccessedNotificationRoute.value = route.path.replace(/\/notifications\/?/, '')
+})
 </script>
 
 <template>

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -26,3 +26,5 @@ export const STORAGE_KEY_PWA_HIDE_INSTALL = 'elk-pwa-hide-install'
 export const HANDLED_MASTO_URLS = /^(https?:\/\/)?([\w\d-]+\.)+\w+\/(@[@\w\d-\.]+)(\/objects)?(\/\d+)?$/
 
 export const NOTIFICATION_FILTER_TYPES: mastodon.v1.NotificationType[] = ['status', 'reblog', 'follow', 'follow_request', 'favourite', 'poll', 'update', 'admin.sign_up', 'admin.report']
+
+export const STORAGE_KEY_LAST_ACCESSED_NOTIFICATION_ROUTE = 'elk-last-accessed-notification-route'


### PR DESCRIPTION
fix #1058

This allows Elk to remember the last accessed tab including filters like "Favorite" and "Reblog", not only the "Mentions" tab.

## How to test
1. Navigate to the "Notification" page.
2. Select the "Mentions" tab or any other filters.
3. Move to the other page.
4. Navigate to the "Notification" page again.
5. See if the previous tab is shown (not the default "All" tab).