### PR TITLE
fix(ui): mentions not working when composing

### DIFF
--- a/composables/tiptap.ts
+++ b/composables/tiptap.ts
@@ -55,6 +55,9 @@ export function useTiptap(options: UseTiptapOptions) {
         },
       }),
       Mention.configure({
+        renderHTML({ options, node }) {
+          return ['span', { 'data-type': 'mention', 'data-id': node.attrs.id }, `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`]
+        },
         suggestion: TiptapMentionSuggestion,
       }),
       Mention


### PR DESCRIPTION
Updating tiptap seems to break the mention "plugin" (added data-type and data-id to the span)