### PR TITLE
fix: consistent hover highlight styling in mobile bottom navigation menus

### DIFF
--- a/components/nav/NavSideItem.vue
+++ b/components/nav/NavSideItem.vue
@@ -57,11 +57,21 @@ const noUserVisual = computed(() => isHydrated.value && props.userOnly && !curre
       <div
         class="item"
         flex items-center gap4
-        w-fit rounded-3
-        px2 mx3 sm:mxa
         xl="ml0 mr5 px5 w-auto"
-        transition-100
-        elk-group-hover="bg-active" group-focus-visible:ring="2 current"
+        :class="isSmallScreen
+          ? `
+            w-full
+            px5 sm:mxa
+            transition-colors duration-200 transform
+            hover-bg-gray-100 hover-dark:(bg-gray-700 text-white)
+          ` : `
+            w-fit rounded-3
+            px2 mx3 sm:mxa
+            transition-100
+            elk-group-hover-bg-active
+            group-focus-visible:ring-2
+            group-focus-visible:ring-current
+          `"
       >
         <slot name="icon">
           <div :class="icon" text-xl />

--- a/composables/screen.ts
+++ b/composables/screen.ts
@@ -2,5 +2,6 @@ import { breakpointsTailwind } from '@vueuse/core'
 
 export const breakpoints = useBreakpoints(breakpointsTailwind)
 
+export const isSmallScreen = breakpoints.smallerOrEqual('sm')
 export const isMediumOrLargeScreen = breakpoints.between('sm', 'xl')
 export const isExtraLargeScreen = breakpoints.smallerOrEqual('xl')


### PR DESCRIPTION
fix #2656 

Adopted the same hover highlight style as the bottom two items like the Zen mode menu.

## Screenshots

### Light mode

<img src="https://github.com/elk-zone/elk/assets/1425259/d35444d9-ea81-4cf9-9bf9-f59bd7108ddd" width="250">
<img src="https://github.com/elk-zone/elk/assets/1425259/5dc1ed19-5753-4399-9f31-139688546617" width="250">

### Dark mode

<img src="https://github.com/elk-zone/elk/assets/1425259/ce3ae1f7-b144-47c9-85ab-ed3e04f204cb" width="250">
<img src="https://github.com/elk-zone/elk/assets/1425259/d8dc05cf-a269-476d-931b-8075930880e3" width="250">

### Before

In dark mode, the highlight was really hard to see:

![Screenshot from 2024-03-08 00-25-37](https://github.com/elk-zone/elk/assets/1425259/5245f24c-c04b-4288-bf09-778c4e192e03)
