### PR TITLE
fix: show loading spinner while fetching account relationship

### DIFF
--- a/components/account/AccountFollowButton.vue
+++ b/components/account/AccountFollowButton.vue
@@ -13,6 +13,11 @@ const { t } = useI18n()
 const isSelf = useSelfAccount(() => account)
 const enable = computed(() => !isSelf.value && currentUser.value)
 const relationship = computed(() => props.relationship || useRelationship(account).value)
+const isLoading = ref(false)
+
+watchEffect(() => {
+  isLoading.value = relationship.value === undefined
+})
 
 const { client } = useMasto()
 
@@ -62,6 +67,10 @@ const buttonStyle = computed(() => {
   if (relationship.value ? relationship.value.following : context === 'following')
     return `text-base ${relationship.value?.followedBy ? 'border-strong' : 'border-base'}`
 
+  // If loading, use a plain style
+  if (isLoading.value)
+    return 'text-base border-base'
+
   // If not following, use a button style
   return 'text-inverted bg-primary border-primary'
 })
@@ -77,28 +86,33 @@ const buttonStyle = computed(() => {
     :hover="!relationship?.blocking && !relationship?.muting && relationship?.following ? 'border-red text-red' : 'bg-base border-primary text-primary'"
     @click="relationship?.blocking ? unblock() : relationship?.muting ? unmute() : toggleFollowAccount(relationship!, account)"
   >
-    <template v-if="relationship?.blocking">
-      <span elk-group-hover="hidden">{{ $t('account.blocking') }}</span>
-      <span hidden elk-group-hover="inline">{{ $t('account.unblock') }}</span>
-    </template>
-    <template v-if="relationship?.muting">
-      <span elk-group-hover="hidden">{{ $t('account.muting') }}</span>
-      <span hidden elk-group-hover="inline">{{ $t('account.unmute') }}</span>
-    </template>
-    <template v-else-if="relationship ? relationship.following : context === 'following'">
-      <span elk-group-hover="hidden">{{ relationship?.followedBy ? $t('account.mutuals') : $t('account.following') }}</span>
-      <span hidden elk-group-hover="inline">{{ $t('account.unfollow') }}</span>
-    </template>
-    <template v-else-if="relationship?.requested">
-      <span elk-group-hover="hidden">{{ $t('account.follow_requested') }}</span>
-      <span hidden elk-group-hover="inline">{{ $t('account.withdraw_follow_request') }}</span>
-    </template>
-    <template v-else-if="relationship ? relationship.followedBy : context === 'followedBy'">
-      <span elk-group-hover="hidden">{{ $t('account.follows_you') }}</span>
-      <span hidden elk-group-hover="inline">{{ account.locked ? $t('account.request_follow') : $t('account.follow_back') }}</span>
+    <template v-if="isLoading">
+      <span i-svg-spinners-180-ring-with-bg />
     </template>
     <template v-else>
-      <span>{{ account.locked ? $t('account.request_follow') : $t('account.follow') }}</span>
+      <template v-if="relationship?.blocking">
+        <span elk-group-hover="hidden">{{ $t('account.blocking') }}</span>
+        <span hidden elk-group-hover="inline">{{ $t('account.unblock') }}</span>
+      </template>
+      <template v-if="relationship?.muting">
+        <span elk-group-hover="hidden">{{ $t('account.muting') }}</span>
+        <span hidden elk-group-hover="inline">{{ $t('account.unmute') }}</span>
+      </template>
+      <template v-else-if="relationship ? relationship.following : context === 'following'">
+        <span elk-group-hover="hidden">{{ relationship?.followedBy ? $t('account.mutuals') : $t('account.following') }}</span>
+        <span hidden elk-group-hover="inline">{{ $t('account.unfollow') }}</span>
+      </template>
+      <template v-else-if="relationship?.requested">
+        <span elk-group-hover="hidden">{{ $t('account.follow_requested') }}</span>
+        <span hidden elk-group-hover="inline">{{ $t('account.withdraw_follow_request') }}</span>
+      </template>
+      <template v-else-if="relationship ? relationship.followedBy : context === 'followedBy'">
+        <span elk-group-hover="hidden">{{ $t('account.follows_you') }}</span>
+        <span hidden elk-group-hover="inline">{{ account.locked ? $t('account.request_follow') : $t('account.follow_back') }}</span>
+      </template>
+      <template v-else>
+        <span>{{ account.locked ? $t('account.request_follow') : $t('account.follow') }}</span>
+      </template>
     </template>
   </button>
 </template>


### PR DESCRIPTION
fix #2647

This PR makes the loading spinner shown while loading a follow relationship with an account so that we can avoid showing a different button label from the actual relationship. The difference is noticeable, especially when the loading time is long.

## Screen recording
### Before
https://github.com/elk-zone/elk/assets/1425259/3c8a90ec-eb23-403f-9612-a4dd55e93713
### After
https://github.com/elk-zone/elk/assets/1425259/a0f2f38c-8f6a-4fe1-9e5f-a64129a73f56

