### PR TITLE
chore: upgrade `@vueuse/core` from `10.8.0` to `10.9.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@upstash/redis": "^1.27.1",
     "@vercel/kv": "^1.0.1",
     "@vue-macros/nuxt": "^1.6.0",
-    "@vueuse/core": "^10.8.0",
+    "@vueuse/core": "^10.9.0",
     "@vueuse/gesture": "^2.0.0",
     "@vueuse/integrations": "^10.8.0",
     "@vueuse/math": "^10.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,10 +101,10 @@ importers:
         version: 1.0.1
       '@vue-macros/nuxt':
         specifier: ^1.6.0
-        version: 1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.8.0)(nuxt@3.10.3)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue-tsc@1.8.27)(vue@3.4.19)(webpack@5.89.0)
+        version: 1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.9.0)(nuxt@3.10.3)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue-tsc@1.8.27)(vue@3.4.19)(webpack@5.89.0)
       '@vueuse/core':
-        specifier: ^10.8.0
-        version: 10.8.0(vue@3.4.19)
+        specifier: ^10.9.0
+        version: 10.9.0(vue@3.4.19)
       '@vueuse/gesture':
         specifier: ^2.0.0
         version: 2.0.0(vue@3.4.19)
@@ -1765,7 +1765,7 @@ packages:
     resolution: {integrity: sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3045,7 +3045,7 @@ packages:
     dependencies:
       '@nuxt/kit': 3.10.3(rollup@3.29.4)
       '@nuxtjs/mdc': 0.5.0(rollup@3.29.4)
-      '@vueuse/core': 10.8.0(vue@3.4.19)
+      '@vueuse/core': 10.9.0(vue@3.4.19)
       '@vueuse/head': 2.0.0(vue@3.4.19)
       '@vueuse/nuxt': 10.8.0(nuxt@3.10.3)(rollup@3.29.4)(vue@3.4.19)
       consola: 3.2.3
@@ -4735,15 +4735,8 @@ packages:
   /@types/eslint-scope@3.7.6:
     resolution: {integrity: sha512-zfM4ipmxVKWdxtDaJ3MP3pBurDXOCoyjvlpE3u6Qzrmw4BPbfm4/ambIeTk/r/J0iq/+2/xp0Fmt+gFvXJY2PQ==}
     dependencies:
-      '@types/eslint': 8.44.5
+      '@types/eslint': 8.56.5
       '@types/estree': 1.0.3
-    dev: false
-
-  /@types/eslint@8.44.5:
-    resolution: {integrity: sha512-Ol2eio8LtD/tGM4Ga7Jb83NuFwEv3NqvssSlifXL9xuFpSyQZw0ecmm2Kux6iU0KxQmp95hlPmGCzGJ0TCFeRA==}
-    dependencies:
-      '@types/estree': 1.0.3
-      '@types/json-schema': 7.0.14
     dev: false
 
   /@types/eslint@8.56.5:
@@ -4751,7 +4744,6 @@ packages:
     dependencies:
       '@types/estree': 1.0.3
       '@types/json-schema': 7.0.14
-    dev: true
 
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
@@ -5737,7 +5729,7 @@ packages:
       vue: 3.4.19(typescript@5.3.3)
     dev: false
 
-  /@vue-macros/define-models@1.0.13(@vueuse/core@10.8.0)(rollup@4.6.0)(vue@3.4.19):
+  /@vue-macros/define-models@1.0.13(@vueuse/core@10.9.0)(rollup@4.6.0)(vue@3.4.19):
     resolution: {integrity: sha512-1GphMtJsR5+Dqcarm3f8pKYMHSigEiqGqijPp4njQT6O+H+i5Ja6kcqtqre5N1/fNRRgxe4l2KGKyk44IstmMA==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
@@ -5747,7 +5739,7 @@ packages:
         optional: true
     dependencies:
       '@vue-macros/common': 1.7.0(rollup@4.6.0)(vue@3.4.19)
-      '@vueuse/core': 10.8.0(vue@3.4.19)
+      '@vueuse/core': 10.9.0(vue@3.4.19)
       ast-walker-scope: 0.5.0(rollup@4.6.0)
       unplugin: 1.7.1
     transitivePeerDependencies:
@@ -5914,7 +5906,7 @@ packages:
       - vue
     dev: false
 
-  /@vue-macros/nuxt@1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.8.0)(nuxt@3.10.3)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue-tsc@1.8.27)(vue@3.4.19)(webpack@5.89.0):
+  /@vue-macros/nuxt@1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.9.0)(nuxt@3.10.3)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue-tsc@1.8.27)(vue@3.4.19)(webpack@5.89.0):
     resolution: {integrity: sha512-tRi1p+k09pkZLq8y8UuNLtQH7x/F8EOyj1kcUunQqQFonzakdQfBkSQpOq7CG6hOiA7bS8FgGjBtCf/h4tRZZQ==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
@@ -5926,7 +5918,7 @@ packages:
       '@vue-macros/short-vmodel': 1.2.15(rollup@4.6.0)(vue@3.4.19)
       '@vue-macros/volar': 0.13.3(@vue-macros/reactivity-transform@0.3.23)(rollup@4.6.0)(typescript@5.3.3)(vue-tsc@1.8.27)(vue@3.4.19)
       nuxt: 3.10.3(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(idb-keyval@6.2.1)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue-tsc@1.8.27)
-      unplugin-vue-macros: 2.4.4(@vueuse/core@10.8.0)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue@3.4.19)(webpack@5.89.0)
+      unplugin-vue-macros: 2.4.4(@vueuse/core@10.9.0)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue@3.4.19)(webpack@5.89.0)
     transitivePeerDependencies:
       - '@vue-macros/reactivity-transform'
       - '@vueuse/core'
@@ -6203,6 +6195,17 @@ packages:
       - '@vue/composition-api'
       - vue
 
+  /@vueuse/core@10.9.0(vue@3.4.19):
+    resolution: {integrity: sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.9.0
+      '@vueuse/shared': 10.9.0(vue@3.4.19)
+      vue-demi: 0.14.7(vue@3.4.19)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   /@vueuse/core@9.13.0(vue@3.4.19):
     resolution: {integrity: sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==}
     dependencies:
@@ -6307,6 +6310,9 @@ packages:
   /@vueuse/metadata@10.8.0:
     resolution: {integrity: sha512-Nim/Vle5OgXcXhAvGOgkJQXB1Yb+Kq/fMbLuv3YYDYbiQrwr39ljuD4k9fPeq4yUyokYRo2RaNQmbbIMWB/9+w==}
 
+  /@vueuse/metadata@10.9.0:
+    resolution: {integrity: sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==}
+
   /@vueuse/metadata@9.13.0:
     resolution: {integrity: sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==}
     dev: true
@@ -6316,7 +6322,7 @@ packages:
     peerDependencies:
       vue: ^3.4.19
     dependencies:
-      '@vueuse/core': 10.8.0(vue@3.4.19)
+      '@vueuse/core': 10.9.0(vue@3.4.19)
       '@vueuse/shared': 10.8.0(vue@3.4.19)
       csstype: 3.1.3
       framesync: 6.1.2
@@ -6369,6 +6375,14 @@ packages:
 
   /@vueuse/shared@10.8.0(vue@3.4.19):
     resolution: {integrity: sha512-dUdy6zwHhULGxmr9YUg8e+EnB39gcM4Fe2oKBSrh3cOsV30JcMPtsyuspgFCUo5xxFNaeMf/W2yyKfST7Bg8oQ==}
+    dependencies:
+      vue-demi: 0.14.7(vue@3.4.19)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  /@vueuse/shared@10.9.0(vue@3.4.19):
+    resolution: {integrity: sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==}
     dependencies:
       vue-demi: 0.14.7(vue@3.4.19)
     transitivePeerDependencies:
@@ -14402,7 +14416,7 @@ packages:
       - vue
     dev: false
 
-  /unplugin-vue-macros@2.4.4(@vueuse/core@10.8.0)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue@3.4.19)(webpack@5.89.0):
+  /unplugin-vue-macros@2.4.4(@vueuse/core@10.9.0)(rollup@4.6.0)(typescript@5.3.3)(vite@5.1.4)(vue@3.4.19)(webpack@5.89.0):
     resolution: {integrity: sha512-f7L8GnSOhtLNXU5PSyA8svIIjP68ij+TdM9Jhq409M31szSsW9ug6hZ5oTBwNcvapFV1I3ZvK4LKqXeY5FcIhA==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
@@ -14412,7 +14426,7 @@ packages:
       '@vue-macros/chain-call': 0.1.3(rollup@4.6.0)(vue@3.4.19)
       '@vue-macros/common': 1.7.0(rollup@4.6.0)(vue@3.4.19)
       '@vue-macros/define-emit': 0.1.13(vue@3.4.19)
-      '@vue-macros/define-models': 1.0.13(@vueuse/core@10.8.0)(rollup@4.6.0)(vue@3.4.19)
+      '@vue-macros/define-models': 1.0.13(@vueuse/core@10.9.0)(rollup@4.6.0)(vue@3.4.19)
       '@vue-macros/define-prop': 0.2.4(vue@3.4.19)
       '@vue-macros/define-props': 1.0.17(@vue-macros/reactivity-transform@0.3.19)(rollup@4.6.0)(vue@3.4.19)
       '@vue-macros/define-props-refs': 1.1.7(rollup@4.6.0)(vue@3.4.19)


### PR DESCRIPTION
probably fix #2628

There was an GitHub Issue for `useActiveElement` in the `@vueuse/core` repository, which was fixed by the latest version `10.9.0`: https://github.com/vueuse/vueuse/issues/3799.

We are using almost the same logic for our keyboard shortcuts here: https://github.com/elk-zone/elk/blob/edcc8741bfe63302ae1ba58886ccd7279115e345/plugins/magic-keys.client.ts#L10-L18

Also, confirmed this issue was fixed: https://github.com/elk-zone/elk/pull/2612#issuecomment-1962390478
