### PR TITLE
fix: prevent empty search keyword to send invalid request

### DIFF
--- a/composables/masto/search.ts
+++ b/composables/masto/search.ts
@@ -63,7 +63,7 @@ export function useSearch(query: MaybeRefOrGetter<string>, options: UseSearchOpt
   })
 
   debouncedWatch(() => resolveUnref(query), async () => {
-    if (!q || !isHydrated.value)
+    if (!q.value || !isHydrated.value)
       return
 
     loading.value = true


### PR DESCRIPTION
fix #2675

This was caused by another missing `.value` 😅 