### PR TITLE
fix: fix `vue/no-ref-as-operand` and `vue/return-in-computed-property` ESLint errors

### DIFF
--- a/components/command/CommandPanel.vue
+++ b/components/command/CommandPanel.vue
@@ -22,7 +22,7 @@ onMounted(() => {
 
 const commandMode = computed(() => input.value.startsWith('>'))
 
-const query = computed(() => commandMode ? '' : input.value.trim())
+const query = computed(() => commandMode.value ? '' : input.value.trim())
 
 const { accounts, hashtags, loading } = useSearch(query)
 
@@ -61,7 +61,7 @@ const searchResult = computed<QueryResult>(() => {
   }
 })
 
-const result = computed<QueryResult>(() => commandMode
+const result = computed<QueryResult>(() => commandMode.value
   ? registry.query(scopes.value.map(s => s.id).join('.'), input.value.slice(1).trim())
   : searchResult.value,
 )

--- a/components/list/ListEntry.vue
+++ b/components/list/ListEntry.vue
@@ -92,7 +92,7 @@ async function removeList() {
 async function clearError() {
   actionError.value = undefined
   await nextTick()
-  if (isEditing)
+  if (isEditing.value)
     input.value?.focus()
   else
     deleteBtn.value?.focus()

--- a/components/modal/ModalConfirm.vue
+++ b/components/modal/ModalConfirm.vue
@@ -17,7 +17,7 @@ const isMute = computed(() => props.extraOptionType === 'mute')
 function handleChoice(choice: ConfirmDialogChoice['choice']) {
   const dialogChoice = {
     choice,
-    ...isMute && {
+    ...isMute.value && {
       extraOptions: {
         mute: {
           duration: hasDuration.value ? duration.value : 0,

--- a/components/user/UserSignIn.vue
+++ b/components/user/UserSignIn.vue
@@ -72,7 +72,7 @@ function onEnter(e: KeyboardEvent) {
 }
 
 function escapeAutocomplete(evt: KeyboardEvent) {
-  if (!autocompleteShow)
+  if (!autocompleteShow.value)
     return
   autocompleteShow.value = false
   evt.stopPropagation()

--- a/composables/masto/search.ts
+++ b/composables/masto/search.ts
@@ -59,7 +59,7 @@ export function useSearch(query: MaybeRefOrGetter<string>, options: UseSearchOpt
   }
 
   watch(() => resolveUnref(query), () => {
-    loading.value = !!(q && isHydrated.value)
+    loading.value = !!(q.value && isHydrated.value)
   })
 
   debouncedWatch(() => resolveUnref(query), async () => {
@@ -87,7 +87,7 @@ export function useSearch(query: MaybeRefOrGetter<string>, options: UseSearchOpt
   }, { debounce: 300 })
 
   const next = async () => {
-    if (!q || !isHydrated.value || !paginator)
+    if (!q.value || !isHydrated.value || !paginator)
       return
 
     loading.value = true

--- a/composables/push-notifications/usePushManager.ts
+++ b/composables/push-notifications/usePushManager.ts
@@ -64,7 +64,7 @@ export function usePushManager() {
     policy?: mastodon.v1.WebPushSubscriptionPolicy,
     force?: boolean,
   ): Promise<SubscriptionResult> => {
-    if (!isSupported)
+    if (!isSupported.value)
       return 'not-supported'
 
     if (!currentUser.value)
@@ -112,7 +112,7 @@ export function usePushManager() {
   }
 
   const unsubscribe = async () => {
-    if (!isSupported || !isSubscribed || !currentUser.value)
+    if (!isSupported.value || !isSubscribed.value || !currentUser.value)
       return false
 
     await removePushNotifications(currentUser.value)

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -21,7 +21,7 @@ const { data: status, pending, refresh: refreshStatus } = useAsyncData(
 )
 const { client } = useMasto()
 const { data: context, pending: pendingContext, refresh: refreshContext } = useAsyncData(
-  `context:${id}`,
+  `context:${id.value}`,
   async () => client.value.v1.statuses.$select(id.value).context.fetch(),
   { watch: [isHydrated], immediate: isHydrated.value, lazy: true, default: () => shallowRef() },
 )

--- a/pages/notifications.vue
+++ b/pages/notifications.vue
@@ -32,6 +32,8 @@ const filter = computed<mastodon.v1.NotificationType | undefined>(() => {
   const actualFilter = Array.isArray(rawFilter) ? rawFilter[0] : rawFilter
   if (isNotificationFilter(actualFilter))
     return actualFilter
+
+  return undefined
 })
 
 const filterIconMap: Record<mastodon.v1.NotificationType, string> = {

--- a/pages/notifications/[filter].vue
+++ b/pages/notifications/[filter].vue
@@ -12,6 +12,8 @@ const filter = computed<mastodon.v1.NotificationType | undefined>(() => {
   const actualFilter = Array.isArray(rawFilter) ? rawFilter[0] : rawFilter
   if (isNotification(actualFilter))
     return actualFilter
+
+  return undefined
 })
 
 useHydratedHead({


### PR DESCRIPTION
see #2678 for how to temporarily enable some vue-related ESLint rules