### PR TITLE
fix(ui): hashtags not working when composing

### DIFF
--- a/composables/tiptap.ts
+++ b/composables/tiptap.ts
@@ -63,6 +63,9 @@ export function useTiptap(options: UseTiptapOptions) {
       Mention
         .extend({ name: 'hashtag' })
         .configure({
+          renderHTML({ options, node }) {
+            return ['span', { 'data-type': 'hashtag', 'data-id': node.attrs.id }, `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`]
+          },
           suggestion: TiptapHashtagSuggestion,
         }),
       Mention


### PR DESCRIPTION
Updating tiptap seems to break the hashtag "plugin" (added data-type and data-id to the span), similar problem wth mentions plugin in #2655