### PR TITLE
ci(docker.yml): support `linux/arm64` container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.metal.outputs.tags }}
           labels: ${{ steps.metal.outputs.labels }}


### PR DESCRIPTION
resolve #2682

Takahē has a quite similar GitHub Actions recipe and it supports `arm64` container (I can run Takahē on Raspberry Pi): https://github.com/jointakahe/takahe/blob/main/.github/workflows/docker-release.yml#L45.

This PR added `linux/arm64` to the platform parameter during the Docker build.

I tested the produced containers in my repository (https://github.com/shuuji3/elk/pkgs/container/elk/190033880?tag=main) both on Raspberry Pi 4 and Apple Silicon macOS and both seem to be working well.

Here's the result of running on Raspberry Pi 4:

## Environment
```shell
ubuntu@pi-0:~$ hostnamectl
 Static hostname: pi-0
       Icon name: computer
      Machine ID: 3b5684e503b04b088f70fa1fde008fee
         Boot ID: 6661a882e73c4ac59797c63fabbe919b
Operating System: Ubuntu 22.04.1 LTS              
          Kernel: Linux 5.15.0-1044-raspi
    Architecture: arm64
```

## `linux/amd64` container
```shell
ubuntu@pi-0:~$ docker run -p 5314:5314 --rm -it --name elk ghcr.io/shuuji3/elk:main@sha256:fe83c9add155bff2cdf7a0eb65ff2f368567c37c99d86739e12fe0201692e3b8
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

## `linux/arm4` container
```shell
ubuntu@pi-0:~$ docker run -p 5314:5314 --rm -it --name elk ghcr.io/shuuji3/elk:main@sha256:fca035179ac3d9ab037a5c4a52cf564165ba72baf22c077dec58371a6e40353e
Listening on http://[::]:5314
```

![Screenshot from 2024-03-17 18-06-16](https://github.com/elk-zone/elk/assets/1425259/2ff2e47f-327e-46ef-ba1c-ec7254403ad6)

(I couldn't test login since I don't know how to populate server lists yet. But it shouldn't an issue for this test)