### PR TITLE
feat(i18n): add missing spanish mute duration dialog entries

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,3 +1,8 @@
 export default defineNuxtConfig({
   extends: '@nuxt-themes/docus',
+  vite: {
+    optimizeDeps: {
+      include: ['scule'],
+    },
+  },
 })

--- a/locales/es.json
+++ b/locales/es.json
@@ -149,7 +149,12 @@
     "mute_account": {
       "cancel": "Cancelar",
       "confirm": "Silenciar",
+      "days": "días|día|días",
       "description": "¿Estás seguro que quieres silenciar a {0}?",
+      "hours": "horas|hora|horas",
+      "minute": "minutos|minuto|minutos",
+      "notifications": "Silenciar notificaciones",
+      "specify_duration": "Especificar la duración del silenciado",
       "title": "Silenciar cuenta"
     },
     "show_reblogs": {


### PR DESCRIPTION
We've some hydration missmatch in docs: this PR includes `scule` in `vite.optimizedDeps.include`, accessing `/guide/contributing` page Vite optimizing `scule`.

/cc @mrcego @patak-dev 

![imagen](https://github.com/elk-zone/elk/assets/6311119/67f87fc0-d5cc-4d5c-8c00-6138ecbaf8ae)

![imagen](https://github.com/elk-zone/elk/assets/6311119/316fbb7e-83f1-4260-a093-e32ae9f2a5c4)
