### PR TITLE
fix: pre tag overwritten by default style

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -85,6 +85,9 @@ em-emoji-picker {
   p:last-child {
     --at-apply: mb-1;
   }
+  pre {
+    --at-apply: whitespace-pre-wrap;
+  }
   code {
     --at-apply: bg-code text-code px1 py0.5 rounded text-0.875em leading-0.8em;
   }


### PR DESCRIPTION
fix #2590 
Ensure the `pre` tag style is not overwritten by the user agent stylesheet. The default value was set to `pre`.