### PR TITLE
fix: prevent showing notification errors for dev for known emoji reaction types

### DIFF
--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -4,6 +4,13 @@ import type { mastodon } from 'masto'
 const { notification } = defineProps<{
   notification: mastodon.v1.Notification
 }>()
+
+const { t } = useI18n()
+
+// well-known emoji reactions types Elk does not support yet
+const unsupportedEmojiReactionTypes = ['pleroma:emoji_reaction', 'reaction']
+if (unsupportedEmojiReactionTypes.includes(notification.type))
+  console.warn(`[DEV] ${t('notification.missing_type')} '${notification.type}' (notification.id: ${notification.id})`)
 </script>
 
 <template>
@@ -88,7 +95,8 @@ const { notification } = defineProps<{
     <template v-else-if="notification.type === 'mention' || notification.type === 'poll' || notification.type === 'status'">
       <StatusCard :status="notification.status!" />
     </template>
-    <template v-else>
+    <template v-else-if="!unsupportedEmojiReactionTypes.includes(notification.type)">
+      <!-- prevent showing errors for dev for known emoji reaction types -->
       <!-- type 'favourite' and 'reblog' should always rendered by NotificationGroupedLikes -->
       <div text-red font-bold>
         [DEV] {{ $t('notification.missing_type') }} '{{ notification.type }}'


### PR DESCRIPTION
mitigates #2701 #2043

The current error message seems to be for development and does not provide a good UX for normal users, especially those who receive reaction emojis frequently.

So instead of showing error messages, this change will only output warning messages to the console for the known two emoji reaction types: `pleroma:emoji_reaction`, `reaction`. (Other unknown notification types will keep showing the same error messages.)

Elk could support the Emoji reaction notification in some form in the future. (Note: currently, masto.js does not provide these non-Mastodon notification type information / related to https://github.com/neet/masto.js/issues/939)