### PR TITLE
fix: correct local timeline stream

### DIFF
--- a/components/timeline/TimelinePublicLocal.vue
+++ b/components/timeline/TimelinePublicLocal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const paginator = useMastoClient().v1.timelines.public.list({ limit: 30, local: true })
-const stream = useStreaming(client => client.direct.subscribe())
+const stream = useStreaming(client => client.public.local.subscribe())
 </script>
 
 <template>


### PR DESCRIPTION
Now the `load new items` button is currently not visible due to being associated with the wrong stream.