### PR TITLE
chore: update masto to v6.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "iso-639-1": "^3.0.0",
     "js-yaml": "^4.1.0",
     "lru-cache": "^10.0.0",
-    "masto": "^6.5.2",
+    "masto": "^6.7.0",
     "node-emoji": "^2.1.3",
     "nuxt-security": "^0.13.1",
     "page-lifecycle": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^10.0.0
         version: 10.2.0
       masto:
-        specifier: ^6.5.2
-        version: 6.5.2
+        specifier: ^6.7.0
+        version: 6.7.0
       node-emoji:
         specifier: ^2.1.3
         version: 2.1.3
@@ -10414,8 +10414,8 @@ packages:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
     dev: true
 
-  /masto@6.5.2:
-    resolution: {integrity: sha512-JfnG7MSQmhszWnLsvdBuxXc2tcVUyCvlTxnSH/5S+In4dU1tvc1wGhFR87kO+YW8gfDsDw9CHh+AD/z+DbTTfQ==}
+  /masto@6.7.0:
+    resolution: {integrity: sha512-R1UyuCdiyBuA9xuIEVIYa2187oIoHhpL1T0glIY+RICAo7JYOAEPdi4aAmROyPcWOYwMlaVDmRRb1zmNbvTnVg==}
     dependencies:
       change-case: 4.1.2
       events-to-async: 2.0.1


### PR DESCRIPTION
resolves #2705

simply updating from v6.5.2 to v6.7.0. I think no change affects Elk feature.

ref. masto.js release note: Releases · neet/masto.js - https://github.com/neet/masto.js/releases