### PR TITLE
fix: add missing notification event type

### DIFF
--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -34,10 +34,10 @@ export function usePaginator<T, P, U = T>(
       return
 
     for await (const entry of stream) {
-      if (entry.event === 'update') {
+      if (entry.event === 'update' || entry.event === 'notification') {
         const status = entry.payload
 
-        if ('uri' in entry)
+        if ('uri' in status)
           cacheStatus(status, undefined, true)
 
         const index = prevItems.value.findIndex((i: any) => i.id === status.id)


### PR DESCRIPTION
fix #2599 
This PR follows #2530. The `notification` event should be handled as an `update` event, and `uri` should be an attribute of `entry.payload`.

Steps to test :
1. Open notification page first
2. Receive new notifications and will see the button for new notifications