### PR TITLE
fix(ui): remove a duplicated command

### DIFF
--- a/composables/command.ts
+++ b/composables/command.ts
@@ -245,23 +245,11 @@ export function useCommands(cmds: () => CommandProvider[]) {
 export function provideGlobalCommands() {
   const { locale, t } = useI18n()
   const { locales } = useI18n() as { locales: ComputedRef<LocaleObject[]> }
-  const router = useRouter()
   const users = useUsers()
   const masto = useMasto()
   const colorMode = useColorMode()
   const userSettings = useUserSettings()
   const { singleInstanceServer, oauth } = useSignIn()
-
-  useCommand({
-    scope: 'Navigation',
-
-    name: () => t('nav.settings'),
-    icon: 'i-ri:settings-3-line',
-
-    onActivate() {
-      router.push('/settings')
-    },
-  })
 
   useCommand({
     scope: 'Preferences',


### PR DESCRIPTION
`Settings` is duplicated in the command panel.

The other one has been defined in NavSideItem.vue
https://github.com/elk-zone/elk/blob/f6f50a582e94f56ecb8b376e5c9213b724b04a50/components/nav/NavSideItem.vue#L19

before:
<img width="760" alt="Screenshot 2024-03-29 at 12 45 34 PM" src="https://github.com/elk-zone/elk/assets/10359255/54294c40-f01b-448d-8171-578bc3e872a8">

after:
<img width="725" alt="Screenshot 2024-03-29 at 12 50 52 PM" src="https://github.com/elk-zone/elk/assets/10359255/d1a40925-c20f-46c6-ba7c-bab0bbe09bce">
