### PR TITLE
fix(ui): prevent from navigating to search page when opening command panel

### DIFF
--- a/plugins/magic-keys.client.ts
+++ b/plugins/magic-keys.client.ts
@@ -49,7 +49,7 @@ export default defineNuxtPlugin(({ $scrollToTop }) => {
   whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'i'])), () => navigateTo('/lists'))
   whenever(logicAnd(notUsingInput, useMagicSequence(['g', 's'])), () => navigateTo('/settings'))
   whenever(logicAnd(isAuthenticated, notUsingInput, useMagicSequence(['g', 'p'])), () => navigateTo(`/${instanceDomain}/@${currentUser.value?.account.username}`))
-  whenever(logicAnd(notUsingInput, keys['/']), () => navigateTo('/search'))
+  whenever(logicAnd(notUsingInput, computed(() => keys.current.size === 1), keys['/']), () => navigateTo('/search'))
 
   const toggleFavouriteActiveStatus = () => {
     // TODO: find a better solution than clicking buttons...


### PR DESCRIPTION
Currently, opening command panel with shortcuts `cmd+/` will navigate to search page as well.

This pr adds `computed(() => keys.current.size === 1)` to ensure other key combinations will not accidentally trigger this shortcut.

before:

https://github.com/elk-zone/elk/assets/10359255/ab6fae31-0308-4fe4-8726-89d5dbc1855a

after:

https://github.com/elk-zone/elk/assets/10359255/e5c68193-ed53-48b5-882f-705fd3f99c18