### PR TITLE
fix(ui): wrong polls are removed

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -87,7 +87,9 @@ function editPollOptionDraft(event: Event, index: number) {
 }
 
 function deletePollOption(index: number) {
-  draft.value.params.poll!.options = draft.value.params.poll!.options.slice().splice(index, 1)
+  const newPollOptions = draft.value.params.poll!.options.slice()
+  newPollOptions.splice(index, 1)
+  draft.value.params.poll!.options = newPollOptions
   trimPollOptions()
 }
 


### PR DESCRIPTION
The removed options are assigned to `options` by mistake.

before:

https://github.com/elk-zone/elk/assets/10359255/840e2c85-b345-494a-a796-bd83754ddcbd

after:
 
https://github.com/elk-zone/elk/assets/10359255/b13ecbdd-d19e-479d-b408-8b4daa15b6d3

