### PR TITLE
fix: hide duplicated status actions items on details page in zen mode

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -144,7 +144,7 @@ function showFavoritedAndBoostedBy() {
 
     <template #popper>
       <div flex="~ col">
-        <template v-if="getPreferences(userSettings, 'zenMode')">
+        <template v-if="getPreferences(userSettings, 'zenMode') && !details">
           <CommonDropdownItem
             :text="$t('action.reply')"
             icon="i-ri:chat-1-line"

--- a/components/status/StatusDetails.vue
+++ b/components/status/StatusDetails.vue
@@ -31,7 +31,7 @@ useHydratedHead({
 
 <template>
   <div :id="`status-${status.id}`" flex flex-col gap-2 pt2 pb1 ps-3 pe-4 relative :lang="status.language ?? undefined" aria-roledescription="status-details">
-    <StatusActionsMore :status="status" absolute inset-ie-2 top-2 @after-edit="$emit('refetchStatus')" />
+    <StatusActionsMore :status="status" :details="true" absolute inset-ie-2 top-2 @after-edit="$emit('refetchStatus')" />
     <NuxtLink :to="getAccountRoute(status.account)" rounded-full hover:bg-active transition-100 pe5 me-a>
       <AccountHoverWrapper :account="status.account">
         <AccountInfo :account="status.account" />


### PR DESCRIPTION
When enabled in the zen mode, the more actions menu shows the hidden action items such as "Reply" and "Boost". However, in the details page, the action footer is shown by default so we don't have to include these items in the more actions menu.

This PR hides these items only within the details page. The items in the home timeline remain the same.

## More actions in home timeline

No bottom actions so the more actions menu has items.
![Screenshot from 2024-04-01 11-27-08](https://github.com/elk-zone/elk/assets/1425259/b19abafc-cb33-4978-bce7-7a6fd8f8a329)

## More actions in details page

### Before
Both the bottom actions footer and the more actions menu has the same set of items, which are duplicated.

![Screenshot from 2024-04-01 11-26-34](https://github.com/elk-zone/elk/assets/1425259/497f797e-7012-422a-bdb4-169e85497f66)

### After

![Screenshot from 2024-04-01 11-26-25](https://github.com/elk-zone/elk/assets/1425259/67b2c595-cce4-4a85-a4ad-6ff34d411583)
