### PR TITLE
fix: improve keyboard operability especially on search page and editor

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -283,6 +283,7 @@ onDeactivated(() => {
             flex max-w-full
             :class="shouldExpanded ? 'min-h-30 md:max-h-[calc(100vh-200px)] sm:max-h-[calc(100vh-400px)] max-h-35 of-y-auto overscroll-contain' : ''"
             @keydown="stopQuestionMarkPropagation"
+            @keydown.esc.prevent="editor?.commands.blur()"
           />
         </div>
 

--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -82,6 +82,7 @@ function activate() {
         placeholder-text-secondary
         @keydown.down.prevent="shift(1)"
         @keydown.up.prevent="shift(-1)"
+        @keydown.esc.prevent=" input?.blur()"
         @keypress.enter="activate"
       >
       <button v-if="query.length" btn-action-icon text-secondary @click="query = ''; input?.focus()">

--- a/components/search/SearchWidget.vue
+++ b/components/search/SearchWidget.vue
@@ -82,7 +82,7 @@ function activate() {
         placeholder-text-secondary
         @keydown.down.prevent="shift(1)"
         @keydown.up.prevent="shift(-1)"
-        @keydown.esc.prevent=" input?.blur()"
+        @keydown.esc.prevent="input?.blur()"
         @keypress.enter="activate"
       >
       <button v-if="query.length" btn-action-icon text-secondary @click="query = ''; input?.focus()">

--- a/pages/[[server]]/search.vue
+++ b/pages/[[server]]/search.vue
@@ -1,18 +1,25 @@
 <script setup lang="ts">
+const keys = useMagicKeys()
 const { t } = useI18n()
+
 useHydratedHead({
   title: () => t('nav.search'),
 })
 
 const search = ref<{ input?: HTMLInputElement }>()
+
 watchEffect(() => {
   if (search.value?.input)
     search.value?.input?.focus()
 })
-onActivated(() =>
-  search.value?.input?.focus(),
-)
+onActivated(() => search.value?.input?.focus())
 onDeactivated(() => search.value?.input?.blur())
+
+watch(keys['/'], (v) => {
+  // focus on input when '/' is up to avoid '/' being typed
+  if (!v)
+    search.value?.input?.focus()
+})
 </script>
 
 <template>


### PR DESCRIPTION
This PR contains two improvements for keyboard navigations:
- [fix: allow to escape from compose editor and search input by esc key](https://github.com/elk-zone/elk/commit/4c2e38adb1229e3fad8fac673fa070893b55f5e0)
- [fix: allow focus to search input within search page](https://github.com/elk-zone/elk/commit/08a8ab62c6adad3cab0d9bfae21f663d18991c8a)

The first one is to allow using the ESC key to unfocus the editor and search inputs. 

This is the default behavior for the native HTML input/textarea elements so users expect that the ESC key works as usual, but Elk uses the custom elements that prevent navigating with the ESC key and it needs to use the Tab key to go to outside input.

The second one is to fix the behavior of `/` key in the search page.

When typing `/` in other pages than the search page, Elk will navigate to the search page and then autofocus the search input element. But if we are already inside the search page, `/` won't let us focus on the input.