### PR TITLE
feat: add "How to contribute?" link next to language status

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -459,6 +459,7 @@
     },
     "language": {
       "display_language": "Display Language",
+      "how_to_contribute": "How to contribute?",
       "label": "Language",
       "post_language": "Posting Language",
       "status": "Translation status: {0}/{1} ({2}%)",

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -26,8 +26,18 @@ const status = computed(() => {
         <h2 py2 font-bold text-xl flex="~ gap-1" items-center>
           {{ $t('settings.language.display_language') }}
         </h2>
-        <div>{{ status }}</div>
+        <div>
+          {{ status }}
+        </div>
         <SettingsLanguage select-settings />
+        <NuxtLink
+          href="https://docs.elk.zone/guide/contributing"
+          target="_blank"
+          hover:underline text-primary inline-flex items-center gap-1
+        >
+          <span inline-block i-ri:information-line />
+          {{ $t('settings.language.how_to_contribute') }}
+        </NuxtLink>
       </div>
       <div mt4>
         <h2 font-bold text-xl flex="~ gap-1" items-center>


### PR DESCRIPTION
Currently, the language translation status only shows the percentage number of the translation status and it's a bit unclear which text is not translated and where to find the Elk documentation.

This will also help potential new translators find the entry point for contribution. 

## Screenshot

Japanese example:

![Screenshot from 2024-04-01 12-36-11](https://github.com/elk-zone/elk/assets/1425259/44715012-3181-42c7-815a-da754616da0a)
