### PR TITLE
feat: put sign-in icon to default "Sign in" button

### DIFF
--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -34,7 +34,13 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
         <strong>{{ currentServer }}</strong>
       </i18n-t>
     </button>
-    <button v-else btn-solid text-sm px-2 py-1 text-center xl:hidden @click="openSigninDialog()">
+    <button
+      v-else
+      flex="~ row"
+      gap-x-1 items-center justify-center btn-solid text-sm px-2 py-1 xl:hidden
+      @click="openSigninDialog()"
+    >
+      <span aria-hidden="true" block i-ri:login-circle-line class="rtl-flip" />
       {{ $t('action.sign_in') }}
     </button>
   </template>


### PR DESCRIPTION
Currently, the sign-in button has the icon for both the single server instance and the actual button on the sign-in dialog.

![Screenshot from 2024-04-01 17-35-40](https://github.com/elk-zone/elk/assets/1425259/089545e5-8b57-47a5-924b-3e11c8c90b34)

![Screenshot from 2024-04-01 17-36-04](https://github.com/elk-zone/elk/assets/1425259/e7e0c02a-79e8-41ed-bf7c-d295788b7631)

So I feel like it's natural that the default sign-in button also has the sign-in icon on the button rather than the simple text-only button.
 
## Before
![image](https://github.com/elk-zone/elk/assets/1425259/9a7aa2fc-8539-4208-895b-5fbc3eb6de6d)

## After
![Screenshot from 2024-04-01 17-35-32](https://github.com/elk-zone/elk/assets/1425259/0e8d9ef6-03d4-4fe2-bd33-57b1b22ca975)
