### PR TITLE
fix: notifications in update timeline

### DIFF
--- a/components/common/CommonPaginator.vue
+++ b/components/common/CommonPaginator.vue
@@ -8,6 +8,7 @@ import type { UnwrapRef } from 'vue'
 const {
   paginator,
   stream,
+  eventType,
   keyProp = 'id',
   virtualScroller = false,
   preprocess,
@@ -17,6 +18,7 @@ const {
   keyProp?: keyof T
   virtualScroller?: boolean
   stream?: mastodon.streaming.Subscription
+  eventType?: 'update' | 'notification'
   preprocess?: (items: (U | T)[]) => U[]
   endMessage?: boolean | string
 }>()
@@ -44,7 +46,7 @@ defineSlots<{
 const { t } = useI18n()
 const nuxtApp = useNuxtApp()
 
-const { items, prevItems, update, state, endAnchor, error } = usePaginator(paginator, toRef(() => stream), preprocess)
+const { items, prevItems, update, state, endAnchor, error } = usePaginator(paginator, toRef(() => stream), eventType, preprocess)
 
 nuxtApp.hook('elk-logo:click', () => {
   update()

--- a/components/notification/NotificationPaginator.vue
+++ b/components/notification/NotificationPaginator.vue
@@ -171,6 +171,7 @@ const { formatNumber } = useHumanReadableNumber()
     :paginator="paginator"
     :preprocess="preprocess"
     :stream="stream"
+    eventType="notification"
     :virtualScroller="virtualScroller"
   >
     <template #updater="{ number, update }">

--- a/composables/paginator.ts
+++ b/composables/paginator.ts
@@ -5,6 +5,7 @@ import type { PaginatorState } from '~/types'
 export function usePaginator<T, P, U = T>(
   _paginator: mastodon.Paginator<T[], P>,
   stream: Ref<mastodon.streaming.Subscription | undefined>,
+  eventType: 'update' | 'notification' = 'update',
   preprocess: (items: (T | U)[]) => U[] = items => items as unknown as U[],
   buffer = 10,
 ) {
@@ -34,7 +35,7 @@ export function usePaginator<T, P, U = T>(
       return
 
     for await (const entry of stream) {
-      if (entry.event === 'update' || entry.event === 'notification') {
+      if (entry.event === eventType) {
         const status = entry.payload
 
         if ('uri' in status)


### PR DESCRIPTION
Fixes #2724

#2714 tried to fix an issue introduced at #2530 and #2566.

I removed `eventType` in #2566 from paginator assuming that now the events were normalized as `'update'` given that we are subscribing to specific streams. The event for the notification stream is still `'notification'`. This PR adds back `eventType`.