### PR TITLE
fix(ui): clicking on custom emoji does not navigate to status detail

### DIFF
--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -14,7 +14,8 @@ function onclick(evt: MouseEvent | KeyboardEvent) {
   const path = evt.composedPath() as HTMLElement[]
   const el = path.find(el => ['A', 'BUTTON', 'IMG', 'VIDEO'].includes(el.tagName?.toUpperCase()))
   const text = window.getSelection()?.toString()
-  if (!el && !text)
+  const isCustomEmoji = el?.parentElement?.classList.contains('custom-emoji')
+  if ((!el && !text) || isCustomEmoji)
     go(evt)
 }
 


### PR DESCRIPTION
Clicking on emoji does not navigate to status detail page

Before:

https://github.com/elk-zone/elk/assets/10359255/c5255d95-3e69-479e-99b6-366764d8500b

After:

https://github.com/elk-zone/elk/assets/10359255/1066c285-e45a-48b9-bed2-98e248a07ac9

