### PR TITLE
feat(ui): style blockquote

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -112,6 +112,9 @@ em-emoji-picker {
   ul > li {
     --at-apply: pl-2;
   }
+  blockquote {
+    --at-apply: border-primary border-l-4 border-solid pl-3 my-3 text-secondary;
+  }
   .code-block {
     --at-apply: bg-code text-0.875em p3 mt-2 rounded overflow-auto
       leading-1.6em;


### PR DESCRIPTION
blockquote is common in Misskey and some mastodon instances with markdown plugins

Probably fix #1502 

[demo post](https://dvd.chat/notes/9rie8zfeiusszl45)

<img width="605" alt="Screenshot 2024-04-01 at 11 13 00 PM" src="https://github.com/elk-zone/elk/assets/10359255/7c5c5b8e-3486-44b5-bd97-5991eea5bc05">
<img width="583" alt="Screenshot 2024-04-01 at 11 12 51 PM" src="https://github.com/elk-zone/elk/assets/10359255/795c5cd1-2e4e-4773-99bf-e60128306094">
<img width="633" alt="Screenshot 2024-04-01 at 11 37 21 PM" src="https://github.com/elk-zone/elk/assets/10359255/24152f88-795a-4cbd-983b-6491d8018764">
