### PR TITLE
feat: enforce monochrome pwa icon to be used with android themed icons

### DIFF
--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -89,6 +89,12 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
         type: 'image/png',
       },
       {
+        src: 'pwa-192x192.png',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'monochrome',
+      },
+      {
         src: 'pwa-512x512.png',
         sizes: '512x512',
         type: 'image/png',


### PR DESCRIPTION
I am trying to resolve Android themed icon which is probably still in Beta

I've explicitly set `monochrome` purpose for the icon as it's shown in this issue https://stackoverflow.com/questions/74620798/material-you-icon-on-pwa

related topics: 
- https://w3c.github.io/manifest/#monochrome-icons-and-solid-fills
- https://issues.chromium.org/u/1/issues/40277264?pli=1