### PR TITLE
fix(ui): media preview card is misaligned

### DIFF
--- a/components/modal/ModalMediaPreview.vue
+++ b/components/modal/ModalMediaPreview.vue
@@ -37,7 +37,7 @@ onUnmounted(() => locked.value = false)
 </script>
 
 <template>
-  <div relative h-full w-full flex pt-12 w-100vh @click="onClick">
+  <div relative h-full w-full flex pt-12 @click="onClick">
     <button
       v-if="hasNext" pointer-events-auto btn-action-icon bg="black/20" :aria-label="$t('action.previous')"
       hover:bg="black/40" dark:bg="white/30" dark-hover:bg="white/20" absolute top="1/2" right-1 z5


### PR DESCRIPTION
Not sure why both `w-full`(width: 100%) and `w-100vh`(width: 100vh) are applied to media preview card. Sometimes, `w-100vh` are overriding `w-full` on my devices, making the picture misaligned.

Plus, I guess `w-100vh` is a typo? Is it supposed to be `w-100vw`?

<img width="1395" alt="Screenshot 2024-04-03 at 6 01 47 PM" src="https://github.com/elk-zone/elk/assets/10359255/ad7fa6b4-b94f-488f-b8cc-555a0d3bd70b">
