### PR TITLE
chore(ui): use full width in settings toggle items

### DIFF
--- a/components/settings/SettingsToggleItem.vue
+++ b/components/settings/SettingsToggleItem.vue
@@ -16,7 +16,7 @@ const { disabled = false } = defineProps<{
     :class="disabled ? 'opacity-50 cursor-not-allowed' : ''"
   >
     <div
-      w-full flex w-fit px5 py3 md:gap2 gap4 items-center
+      w-full flex px5 py3 md:gap2 gap4 items-center
       transition-250
       :class="disabled ? '' : 'group-hover:bg-active'"
       group-focus-visible:ring="2 current"


### PR DESCRIPTION
Check dev server, w-full is before w-fit, sometimes the styles are reversed and the toogle items don't fill the full width:

![imagen](https://github.com/elk-zone/elk/assets/6311119/f6287803-0777-416f-a791-e8df71f83da0)
