### PR TITLE
ci(ci.yml): limit maximum execution time of ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: 🧪 Test project
         run: pnpm test:ci
+        timeout-minutes: 10
 
       - name: 📝 Lint
         run: pnpm lint


### PR DESCRIPTION
It looks like the CI testing is still sometimes running 6 hours: https://github.com/elk-zone/elk/actions/workflows/ci.yml?page=3#:~:text=4%20days%20ago-,6h%200m%2023s,-ci

Until the complete fix, this adds the testing timeout to 10 minutes to reduce the waste of computing resources. Usually, it will end within 1 min 30 seconds so 10 minutes should be a safe limit. 
