### PR TITLE
fix(a11y): allow focusing color mode buttons on interface setting

### DIFF
--- a/components/settings/SettingsColorMode.vue
+++ b/components/settings/SettingsColorMode.vue
@@ -32,7 +32,6 @@ const modes = [
       v-for="{ icon, label, mode } in modes"
       :key="mode"
       btn-text flex-1 flex="~ gap-1 center" p4 border="~ base rounded" bg-base ws-nowrap
-      :tabindex="colorMode.preference === mode ? 0 : -1"
       :class="colorMode.preference === mode ? 'pointer-events-none' : 'filter-saturate-0'"
       @click="setColorMode(mode)"
     >


### PR DESCRIPTION
Currently, the only active color mode button is focusable so it's impossible to select other color modes by the keyboard.

![image](https://github.com/elk-zone/elk/assets/1425259/572ef772-0858-436c-ae67-6ff7aeda3f38)

This PR removes `tabindex="-1"`, which prevents any keyboard focus, from the buttons.

## How to test
1. Open Preview: https://deploy-preview-2771--elk-zone.netlify.app/settings/interface
2. Select color mode buttons with <kbd>Tab</kbd> key.
3. Compare to the previous behavior: https://elk.zone/settings/interface