### PR TITLE
fix(ui): move account lock and bot icons next to name in timeline

### DIFF
--- a/components/status/StatusAccountDetails.vue
+++ b/components/status/StatusAccountDetails.vue
@@ -16,6 +16,10 @@ const userSettings = useUserSettings()
     text-link-rounded
   >
     <AccountDisplayName :account="account" :hide-emojis="getPreferences(userSettings, 'hideUsernameEmojis')" font-bold line-clamp-1 ws-pre-wrap break-all />
-    <AccountHandle :account="account" class="zen-none" />
+    <div flex="~ gap-1">
+      <AccountHandle :account="account" class="zen-none" />
+      <AccountBotIndicator v-if="account.bot" text-xs />
+      <AccountLockIndicator v-if="account.locked" text-xs />
+    </div>
   </NuxtLink>
 </template>

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -169,7 +169,6 @@ const forceShow = ref(false)
             </AccountHoverWrapper>
             <div flex-auto />
             <div v-show="!getPreferences(userSettings, 'zenMode')" text-sm text-secondary flex="~ row nowrap" hover:underline whitespace-nowrap>
-              <AccountLockIndicator v-if="status.account.locked" me-2 />
               <AccountBotIndicator v-if="status.account.bot" me-2 />
               <div flex="~ gap1" items-center>
                 <StatusVisibilityIndicator v-if="status.visibility !== 'public'" :status="status" />

--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -169,7 +169,6 @@ const forceShow = ref(false)
             </AccountHoverWrapper>
             <div flex-auto />
             <div v-show="!getPreferences(userSettings, 'zenMode')" text-sm text-secondary flex="~ row nowrap" hover:underline whitespace-nowrap>
-              <AccountBotIndicator v-if="status.account.bot" me-2 />
               <div flex="~ gap1" items-center>
                 <StatusVisibilityIndicator v-if="status.visibility !== 'public'" :status="status" />
                 <div flex>


### PR DESCRIPTION
fix #2492

As explained in the original issue, showing the account lock 🔒 icon on the status card is quite confusing:

![Screenshot from 2024-04-06 01-40-26](https://github.com/elk-zone/elk/assets/1425259/40ee8445-00bb-4afd-a675-0345a98a9d4e)

I think this decision in the official Mastodon UI is reasonable because the meaning of 🔒 icon on Mastodon differs from that on Twitter.

On Twitter, 🔒 icon for the account has two meanings at the same time: the account requires to follow requests, and the visibility of all the posts is limited to "Only follower". So showing 🔒 icon on the status makes sense.

On the other hand, on Mastodon, the visibility of posts and account following limitations are separated. And the locked account still can publish publicly visible posts so 🔒 icon only indicates that the following approval is required when someone is following.

Mastodon already has the icon for visibility on the post (such as 🌎 and 🔒) so it should be enough to show 🔒 icon only on the account page (or other account-specific component) where users need to know whether the account requires the following request or not.

Although Mastodon UI doesn't show the bot icon too, I think we can keep it because the bot icon can show both meanings: the account is automated and the post itself is programmatically published by the bot.

## After
![image](https://github.com/elk-zone/elk/assets/1425259/1c36604d-da62-49c5-9f57-d0f78b204991)

The status detail page still shows the lock indicator as the visibility indicator is clearly separated in different places without confusion.

![Screenshot from 2024-04-06 17-24-40](https://github.com/elk-zone/elk/assets/1425259/9c3dd98f-3b68-4a5c-bf05-4aefad63b5ba)

Another example with the lock icon:

![image](https://github.com/elk-zone/elk/assets/1425259/d8ef4c66-978a-4138-a69a-6e4eb4d804ca)
