### PR TITLE
fix(ui): make display name clickable in grouped follow notification

### DIFF
--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -22,11 +22,13 @@ const lang = computed(() => {
           :count="count"
         />
       </template>
-      <template v-else>
-        <AccountDisplayName
-          :account="items.items[0]?.account"
-          text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
-        />
+      <template v-else-if="count === 1">
+        <NuxtLink :to="getAccountRoute(items.items[0].account)">
+          <AccountDisplayName
+            :account="items.items[0].account"
+            text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
+          />
+        </NuxtLink>
         <span me-1 ws-nowrap>
           {{ $t('notification.followed_you') }}
         </span>


### PR DESCRIPTION
The name is highlighted and so I assume this is supposed to be clickable.

<img width="676" alt="Screenshot 2024-04-06 at 11 55 53 PM" src="https://github.com/elk-zone/elk/assets/10359255/506da329-1e93-45f7-a266-0d1a350a09f5">
