### PR TITLE
fix(ui): fix z-index of horizontal line between statuses

### DIFF
--- a/components/status/StatusCard.vue
+++ b/components/status/StatusCard.vue
@@ -72,7 +72,7 @@ const forceShow = ref(false)
 <template>
   <StatusLink :status="status" :hover="hover">
     <!-- Upper border -->
-    <div :h="showUpperBorder ? '1px' : '0'" w-auto bg-border mb-1 />
+    <div :h="showUpperBorder ? '1px' : '0'" w-auto bg-border mb-1 z--1 />
 
     <slot name="meta">
       <!-- Line connecting to previous status -->


### PR DESCRIPTION
When focusing on the status, the horizontal line between statuses was above the focus indicator.

The keyboard navigation (currently implementing) always shows the border so this is especially noticeable.

## Before
![Screenshot from 2024-04-07 23-44-48](https://github.com/elk-zone/elk/assets/1425259/2c9066fe-afa7-4315-8a97-96b786259b06)

## After
![Screenshot from 2024-04-08 00-01-10](https://github.com/elk-zone/elk/assets/1425259/98f0c1a4-a0c7-4c41-88a9-665a022185fc)
