### PR TITLE
fix(ui): fix regression where editor is expanded before composing

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -295,7 +295,7 @@ function stopQuestionMarkPropagation(e: KeyboardEvent) {
               </ol>
             </CommonErrorMessage>
 
-            <div relative flex-1 flex flex-col min-h-30>
+            <div relative flex-1 flex flex-col :class="shouldExpanded ? 'min-h-30' : ''">
               <EditorContent
                 :editor="editor" flex max-w-full
                 :class="{


### PR DESCRIPTION
fix #2781

Due to the regression, the editor has been expanded without condition. This change prevents the expansion by default and keeps the lower height until clicking.

## Screenshots
### Before fix
#### Before click
![image](https://github.com/elk-zone/elk/assets/1425259/5a764194-4e94-451c-8708-846e29f60ab3)

### After click
![image](https://github.com/elk-zone/elk/assets/1425259/7c5f497a-61bf-4a6a-8e8c-8d2d753eadad)


### After fix (Home)
#### Before click
![Screenshot from 2024-04-09 00-12-54](https://github.com/elk-zone/elk/assets/1425259/7f6750c0-7a51-4ab2-854b-a65a3e1bafde)

#### After click
![Screenshot from 2024-04-09 00-12-40](https://github.com/elk-zone/elk/assets/1425259/edcf2029-e0cf-4d2a-b0a8-80b024025e92)

### After fix (Thread reply)
#### Before click
![Screenshot from 2024-04-09 00-12-09](https://github.com/elk-zone/elk/assets/1425259/ecd459b3-9ae5-4298-b0a6-3cec878b308f)

#### After click

![Screenshot from 2024-04-09 00-12-13](https://github.com/elk-zone/elk/assets/1425259/2acbb006-fe6b-44f0-a726-6e2ca6f5dcc7)