### PR TITLE
fix: list name is not up-to-date after modification

### DIFF
--- a/components/list/ListEntry.vue
+++ b/components/list/ListEntry.vue
@@ -32,9 +32,9 @@ async function prepareEdit() {
 async function cancelEdit() {
   isEditing.value = false
   actionError.value = undefined
-  reset()
 
   await nextTick()
+  reset()
   editBtn.value?.focus()
 }
 


### PR DESCRIPTION
Before: 

https://github.com/elk-zone/elk/assets/10359255/88fcb9b9-5b4b-4dcd-85c3-47e8a389633c

As you can see from this screenrecord, the name is always out-of-date.

After:

https://github.com/elk-zone/elk/assets/10359255/6116f959-6e2e-4c84-bb19-42d83788f282

CommonPaginator triggered updateEntry once a new list value is assigned.

https://github.com/elk-zone/elk/blob/706cffe209293478c84ed529fedbbd94b4d1dec0/components/common/CommonPaginator.vue#L60-L64

The cancelEdit will trigger a `reset` but at that time, `list.value` is still holding an old value. This pr just moves the `reset` after nextTick to ensure the value is up-to-date.

https://github.com/elk-zone/elk/blob/706cffe209293478c84ed529fedbbd94b4d1dec0/components/list/ListEntry.vue#L43-L46