### PR TITLE
feat: support more than 4 media attachments with 3 columns grid

### DIFF
--- a/components/status/StatusMedia.vue
+++ b/components/status/StatusMedia.vue
@@ -6,10 +6,20 @@ const { status, isPreview = false } = defineProps<{
   fullSize?: boolean
   isPreview?: boolean
 }>()
+
+const gridColumnNumber = computed(() => {
+  const num = status.mediaAttachments.length
+  if (num <= 1)
+    return 1
+  else if (num <= 4)
+    return 2
+  else
+    return 3
+})
 </script>
 
 <template>
-  <div class="status-media-container" :class="`status-media-container-${status.mediaAttachments.length}`">
+  <div class="status-media-container" :class="`status-media-container-${gridColumnNumber}`">
     <template v-for="attachment of status.mediaAttachments" :key="attachment.id">
       <StatusAttachment
         :attachment="attachment"
@@ -36,14 +46,10 @@ const { status, isPreview = false } = defineProps<{
 }
 .status-media-container-2 {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, 1fr);
 }
 .status-media-container-3 {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-}
-.status-media-container-4 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
 }
 </style>

--- a/components/status/StatusMedia.vue
+++ b/components/status/StatusMedia.vue
@@ -19,7 +19,7 @@ const gridColumnNumber = computed(() => {
 </script>
 
 <template>
-  <div class="status-media-container" :class="`status-media-container-${gridColumnNumber}`">
+  <div class="status-media-container">
     <template v-for="attachment of status.mediaAttachments" :key="attachment.id">
       <StatusAttachment
         :attachment="attachment"
@@ -35,21 +35,12 @@ const gridColumnNumber = computed(() => {
 
 <style lang="postcss">
 .status-media-container {
+  --grid-cols: v-bind(gridColumnNumber);
+  display: grid;
+  grid-template-columns: repeat(var(--grid-cols, 1), 1fr);
   --at-apply: gap-2;
   position: relative;
   width: 100%;
   overflow: hidden;
-}
-.status-media-container-1 {
-  display: grid;
-  grid-template-columns: 1fr;
-}
-.status-media-container-2 {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-}
-.status-media-container-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
 }
 </style>


### PR DESCRIPTION
fix #2502
fix #2796

This PR fixes the broken grid layout for more than 4 attachments. In that case, the number of the grid columns switches from 2 to 3 to reduce the height of the post and show more overview of the gallery.

## Screenshot

Example posts in https://github.com/elk-zone/elk/issues/2796: https://pixelfed.social/p/Lacalle/684124192137313050

![Screenshot from 2024-04-12 21-55-37](https://github.com/elk-zone/elk/assets/1425259/127a4149-787c-487b-ba26-38c574559907)
