### PR TITLE
fix(ui): fix and adjust bottom navigation preview on setting page

### DIFF
--- a/components/settings/SettingsBottomNav.vue
+++ b/components/settings/SettingsBottomNav.vue
@@ -81,13 +81,13 @@ function save() {
         {{ $t('settings.interface.bottom_nav_instructions') }}
       </p>
       <!-- preview -->
-      <div aria-hidden="true" flex="~ gap4 wrap" items-center select-settings h-14 p0>
+      <div aria-hidden="true" flex="~ gap4 wrap" items-center select-settings h-14>
         <nav
           v-for="availableNavButton in selectedNavButtons" :key="availableNavButton.name"
           flex="~ 1" items-center justify-center text-xl
           scrollbar-hide overscroll-none
         >
-          <button btn-base :class="availableNavButton.icon" mx-4 tabindex="-1" />
+          <span :class="availableNavButton.icon" />
         </nav>
       </div>
 


### PR DESCRIPTION
fix #2805

Adjusted spacing for a narrow viewport.

Also, I removed `<button>`-related attributes since we don't need to click the button in the preview.

## Screenshot

### Before

![Screenshot from 2024-04-15 00-54-04](https://github.com/elk-zone/elk/assets/1425259/a0783716-49e6-4c98-bdf5-8cb7b1592d9b)

### After
![Screenshot from 2024-04-15 00-54-16](https://github.com/elk-zone/elk/assets/1425259/d9a04b19-972c-457d-8784-651b2aea1381)

