### PR TITLE
feat(ui): add manage list at the end of the lists

### DIFF
--- a/components/list/Lists.vue
+++ b/components/list/Lists.vue
@@ -30,7 +30,7 @@ async function edit(listId: string) {
 </script>
 
 <template>
-  <CommonPaginator :end-message="false" :paginator="paginator">
+  <CommonPaginator end-message :paginator="paginator">
     <template #default="{ item }">
       <div p4 hover:bg-active block w="100%" flex justify-between items-center gap-4>
         <p>{{ item.title }}</p>
@@ -48,6 +48,14 @@ async function edit(listId: string) {
           </button>
         </CommonTooltip>
       </div>
+    </template>
+    <template #done>
+      <NuxtLink
+        p4 hover:bg-active block w="100%" flex justify-between items-center gap-4
+        to="/lists"
+      >
+        <p>{{ $t('list.manage') }}</p>
+      </NuxtLink>
     </template>
   </CommonPaginator>
 </template>

--- a/components/list/Lists.vue
+++ b/components/list/Lists.vue
@@ -30,7 +30,7 @@ async function edit(listId: string) {
 </script>
 
 <template>
-  <CommonPaginator end-message :paginator="paginator">
+  <CommonPaginator :paginator="paginator">
     <template #default="{ item }">
       <div p4 hover:bg-active block w="100%" flex justify-between items-center gap-4>
         <p>{{ item.title }}</p>

--- a/locales/en.json
+++ b/locales/en.json
@@ -221,6 +221,7 @@
     "error": "There was an error while creating the list",
     "error_prefix": "Error: ",
     "list_title_placeholder": "List title",
+    "manage": "Manage lists",
     "modify_account": "Modify lists with account",
     "remove_account": "Remove account from list",
     "save": "Save changes"


### PR DESCRIPTION
Fix #2819 

The implementation is to replace the end message with a styled button, which navigates to `[[server]]/lists`