### PR TITLE
fix(ui): show custom emoji in spoiler text

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -44,7 +44,9 @@ const allowEmbeddedMedia = computed(() => status.card?.html && embeddedMediaPref
     <StatusBody v-if="(!isFiltered && isSensitiveNonSpoiler) || hideAllMedia" :status="status" :newer="newer" :with-action="!isDetails" :class="isDetails ? 'text-xl' : ''" />
     <StatusSpoiler :enabled="hasSpoilerOrSensitiveMedia || isFiltered" :filter="isFiltered" :sensitive-non-spoiler="isSensitiveNonSpoiler || hideAllMedia" :is-d-m="isDM">
       <template v-if="spoilerTextPresent" #spoiler>
-        <p>{{ status.spoilerText }}</p>
+        <p>
+          <ContentRich :content="status.spoilerText" :emojis="status.emojis" :markdown="false" />
+        </p>
       </template>
       <template v-else-if="filterPhrase" #spoiler>
         <p>{{ `${$t('status.filter_hidden_phrase')}: ${filterPhrase}` }}</p>


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="618" alt="Screenshot 2024-04-20 at 11 48 12 AM" src="https://github.com/elk-zone/elk/assets/10359255/8364aa33-dac1-4ccf-bbea-b0ed8c5f3fef">|<img width="613" alt="Screenshot 2024-04-20 at 12 05 23 PM" src="https://github.com/elk-zone/elk/assets/10359255/cbf9eab4-bb7b-4f57-ad1e-6c9c936ab6b9">|

Before: [Link to the post](main.elk.zone/universeodon.com/@iamada@tech.lgbt/112304940629697112).
After: [Deploy Preview](https://deploy-preview-2836--elk-zone.netlify.app/universeodon.com/@iamada@tech.lgbt/112304940629697112)