### PR TITLE
feat(i18n): add `open image preview dialog` spanish translation

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -73,6 +73,7 @@
     "favourited": "Marcado como favorita",
     "more": "Más",
     "next": "Siguiente",
+    "open_image_preview_dialog": "Abrir diálogo de vista previa de la imagen",
     "prev": "Anterior",
     "publish": "Publicar",
     "publish_thread": "Publicar hilo",


### PR DESCRIPTION
I guess that entry is wrong, there is nothing to preview, it should be something like "Open image in carousel dialog" or similar.

Clicking on any image will open the carousel where we can zoom or navigate between images in the toot.

/cc @patak-dev @mrcego 