### PR TITLE
fix(ui): fix publish dialog layout

### DIFF
--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -63,7 +63,7 @@ function handleFavouritedBoostedByClose() {
     </ModalDialog>
     <ModalDialog
       v-model="isPublishDialogOpen"
-      max-w-180 flex
+      max-w-180 flex flex-col
       @close="handlePublishClose"
     >
       <!-- This `w-0` style is used to avoid overflow problems in flex layouts，so don't remove it unless you know what you're doing -->


### PR DESCRIPTION
fix #2834

The layout is off due to the change during thread implementation. This dialog was not assumed to have multiple widgets either.

Note: This publish dialog can be opened by typing <kbd>c</kbd> key.

## Before

![Screenshot from 2024-04-22 18-22-19](https://github.com/elk-zone/elk/assets/1425259/e0c0e79f-8471-4984-96a8-bae692c21a9a)
![Screenshot from 2024-04-22 18-22-12](https://github.com/elk-zone/elk/assets/1425259/84a3805c-4283-48dc-adb1-d7ca53a0dec2)

## After
![Screenshot from 2024-04-22 18-21-42](https://github.com/elk-zone/elk/assets/1425259/6c897ee7-743c-4903-8869-a9c0611114f3)

![Screenshot from 2024-04-22 18-21-51](https://github.com/elk-zone/elk/assets/1425259/cdef5342-90b6-48d2-b827-44deb912d737)
