### PR TITLE
feat(ui): overlap multiple account icons in notification

### DIFF
--- a/components/notification/NotificationGroupedLikes.vue
+++ b/components/notification/NotificationGroupedLikes.vue
@@ -30,7 +30,7 @@ const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
         <div v-if="likes.length" flex="~ gap-1">
           <div :class="useStarFavoriteIcon ? 'i-ri:star-line color-yellow' : 'i-ri:heart-line color-red'" text-xl me-2 />
           <template v-for="i, idx of likes" :key="idx">
-            <AccountHoverWrapper :account="i.account" relative me--4 border="2 bg-base" rounded-full>
+            <AccountHoverWrapper :account="i.account" relative me--4 border="2 bg-base" rounded-full hover:z-1 focus-within:z-1>
               <NuxtLink :to="getAccountRoute(i.account)">
                 <AccountAvatar text-primary font-bold :account="i.account" class="h-1.5em w-1.5em" />
               </NuxtLink>

--- a/components/notification/NotificationGroupedLikes.vue
+++ b/components/notification/NotificationGroupedLikes.vue
@@ -30,13 +30,13 @@ const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
         <div v-if="likes.length" flex="~ gap-1">
           <div :class="useStarFavoriteIcon ? 'i-ri:star-line color-yellow' : 'i-ri:heart-line color-red'" text-xl me-2 />
           <template v-for="i, idx of likes" :key="idx">
-            <AccountHoverWrapper :account="i.account">
+            <AccountHoverWrapper :account="i.account" relative me--4 border="2 bg-base" rounded-full>
               <NuxtLink :to="getAccountRoute(i.account)">
                 <AccountAvatar text-primary font-bold :account="i.account" class="h-1.5em w-1.5em" />
               </NuxtLink>
             </AccountHoverWrapper>
           </template>
-          <div ms1>
+          <div ms-4>
             {{ $t('notification.favourited_post') }}
           </div>
         </div>

--- a/components/notification/NotificationGroupedLikes.vue
+++ b/components/notification/NotificationGroupedLikes.vue
@@ -27,7 +27,7 @@ const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
             {{ $t('notification.reblogged_post') }}
           </div>
         </div>
-        <div v-if="likes.length" flex="~ gap-1">
+        <div v-if="likes.length" flex="~ gap-1 wrap">
           <div :class="useStarFavoriteIcon ? 'i-ri:star-line color-yellow' : 'i-ri:heart-line color-red'" text-xl me-2 />
           <template v-for="i, idx of likes" :key="idx">
             <AccountHoverWrapper :account="i.account" relative me--4 border="2 bg-base" rounded-full hover:z-1 focus-within:z-1>


### PR DESCRIPTION
fix #2855

## Before

![Screenshot from 2024-05-12 00-47-03](https://github.com/elk-zone/elk/assets/1425259/039d0715-49cd-4e40-9902-c7830926e624)
![Screenshot from 2024-05-12 00-46-58](https://github.com/elk-zone/elk/assets/1425259/25eb7fe8-45a9-4ac9-9cc8-e3efd97c9c78)


## After

Multiple avatar icons are now overlapped to reduce the area:

![Screenshot from 2024-05-11 17-05-35](https://github.com/elk-zone/elk/assets/1425259/d3bd2108-0919-46d4-8f39-188cba867282)
(dummy accounts are used in screenshots)

And the below icon will get to the front when it is hovered or focused:

![Screenshot from 2024-05-11 17-05-24](https://github.com/elk-zone/elk/assets/1425259/b73f6487-39a5-4893-ac6f-2243b4ec8d48)

Also, when there are many more accounts, it will be wrapped to the next row.

![Screenshot from 2024-05-12 00-38-52](https://github.com/elk-zone/elk/assets/1425259/71e92590-31f1-45e1-85be-edb13545d2fa)
