### PR TITLE
chore: set package-manager-strict to false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 shamefully-hoist=true
 shell-emulator=true
 ignore-workspace-root-check=true
+package-manager-strict=false


### PR DESCRIPTION
like in vite, set package-manager-strict to false so pnpm v9 can locally be used