### PR TITLE
feat: generate alt-text with ai

### DIFF
--- a/composables/settings/definition.ts
+++ b/composables/settings/definition.ts
@@ -32,6 +32,7 @@ export interface PreferencesSettings {
   experimentalGitHubCards: boolean
   experimentalUserPicker: boolean
   experimentalEmbeddedMedia: boolean
+  experimentalAltTextGeneration: boolean
 }
 
 export interface UserSettings {
@@ -88,6 +89,7 @@ export const DEFAULT__PREFERENCES_SETTINGS: PreferencesSettings = {
   experimentalGitHubCards: true,
   experimentalUserPicker: true,
   experimentalEmbeddedMedia: false,
+  experimentalAltTextGeneration: false,
 }
 
 export function getDefaultUserSettings(locales: string[]): UserSettings {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vueuse/math": "^10.8.0",
     "@vueuse/motion": "2.1.0",
     "@vueuse/nuxt": "^10.8.0",
+    "@xenova/transformers": "^2.17.1",
     "blurhash": "^2.0.5",
     "browser-fs-access": "^0.35.0",
     "chroma-js": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,49 +35,49 @@ importers:
         version: 2.1.22
       '@nuxt/devtools':
         specifier: ^1.0.8
-        version: 1.1.5(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@4.14.0)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)
+        version: 1.1.5(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
       '@nuxt/test-utils':
         specifier: ^3.12.0
-        version: 3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@4.14.0)(vite@5.2.8)(vitest@1.4.0)(vue-router@4.3.0)(vue@3.4.21)
+        version: 3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))
       '@nuxtjs/color-mode':
         specifier: ^3.3.2
-        version: 3.3.2(rollup@4.14.0)
+        version: 3.3.2(rollup@2.79.1)
       '@nuxtjs/i18n':
         specifier: ^8.3.0
-        version: 8.3.0(rollup@4.14.0)(vue@3.4.21)
+        version: 8.3.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@pinia/nuxt':
         specifier: ^0.5.1
-        version: 0.5.1(rollup@4.14.0)(typescript@5.4.4)(vue@3.4.21)
+        version: 0.5.1(rollup@2.79.1)(typescript@5.4.4)(vue@3.4.21(typescript@5.4.4))
       '@tiptap/core':
         specifier: 2.2.4
         version: 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/extension-bold':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
       '@tiptap/extension-character-count':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/extension-code-block':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/extension-history':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/extension-italic':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
       '@tiptap/extension-mention':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)(@tiptap/suggestion@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)(@tiptap/suggestion@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4))
       '@tiptap/extension-paragraph':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
       '@tiptap/extension-placeholder':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/extension-text':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
       '@tiptap/pm':
         specifier: ^2.2.4
         version: 2.2.4
@@ -86,13 +86,13 @@ importers:
         version: 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/suggestion':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/vue-3':
         specifier: 2.2.4
-        version: 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)(vue@3.4.21)
+        version: 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)(vue@3.4.21(typescript@5.4.4))
       '@unocss/nuxt':
         specifier: ^0.58.9
-        version: 0.58.9(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8)(webpack@5.89.0)
+        version: 0.58.9(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(webpack@5.89.0(esbuild@0.20.2))
       '@upstash/redis':
         specifier: ^1.27.1
         version: 1.27.1
@@ -101,25 +101,28 @@ importers:
         version: 1.0.1
       '@vue-macros/nuxt':
         specifier: ^1.6.0
-        version: 1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.9.0)(nuxt@3.11.2)(rollup@4.14.0)(typescript@5.4.4)(vite@5.2.8)(vue-tsc@2.0.10)(vue@3.4.21)(webpack@5.89.0)
+        version: 1.6.0(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(esbuild@0.20.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))(webpack@5.89.0(esbuild@0.20.2))
       '@vueuse/core':
         specifier: ^10.9.0
-        version: 10.9.0(vue@3.4.21)
+        version: 10.9.0(vue@3.4.21(typescript@5.4.4))
       '@vueuse/gesture':
         specifier: ^2.0.0
-        version: 2.0.0(vue@3.4.21)
+        version: 2.0.0(vue@3.4.21(typescript@5.4.4))
       '@vueuse/integrations':
         specifier: ^10.8.0
-        version: 10.9.0(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21)
+        version: 10.9.0(change-case@4.1.2)(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21(typescript@5.4.4))
       '@vueuse/math':
         specifier: ^10.8.0
-        version: 10.8.0(vue@3.4.21)
+        version: 10.8.0(vue@3.4.21(typescript@5.4.4))
       '@vueuse/motion':
         specifier: 2.1.0
-        version: 2.1.0(rollup@4.14.0)(vue@3.4.21)
+        version: 2.1.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vueuse/nuxt':
         specifier: ^10.8.0
-        version: 10.8.0(nuxt@3.11.2)(rollup@4.14.0)(vue@3.4.21)
+        version: 10.8.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@xenova/transformers':
+        specifier: ^2.17.1
+        version: 2.17.1
       blurhash:
         specifier: ^2.0.5
         version: 2.0.5
@@ -137,7 +140,7 @@ importers:
         version: 2.0.5
       floating-vue:
         specifier: ^5.2.2
-        version: 5.2.2(vue@3.4.21)
+        version: 5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4))
       focus-trap:
         specifier: ^7.5.1
         version: 7.5.4
@@ -176,19 +179,19 @@ importers:
         version: 2.1.3
       nuxt-security:
         specifier: ^0.13.1
-        version: 0.13.1(patch_hash=bd6cmp7ukwwiwrxafbbotwkihe)(rollup@4.14.0)
+        version: 0.13.1(patch_hash=bd6cmp7ukwwiwrxafbbotwkihe)(rollup@2.79.1)
       page-lifecycle:
         specifier: ^0.1.2
         version: 0.1.2
       pinia:
         specifier: ^2.1.7
-        version: 2.1.7(typescript@5.4.4)(vue@3.4.21)
+        version: 2.1.7(typescript@5.4.4)(vue@3.4.21(typescript@5.4.4))
       postcss-nested:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.4.38)
       prosemirror-highlight:
         specifier: ^0.5.0
-        version: 0.5.0(prosemirror-model@1.19.4)(prosemirror-state@1.4.3)(prosemirror-view@1.32.7)(shiki@1.1.7)
+        version: 0.5.0(@types/hast@3.0.4)(prosemirror-model@1.19.4)(prosemirror-state@1.4.3)(prosemirror-transform@1.8.0)(prosemirror-view@1.32.7)(shiki@1.1.7)
       rollup-plugin-node-polyfills:
         specifier: ^0.2.1
         version: 0.2.1
@@ -200,10 +203,10 @@ importers:
         version: 3.24.0
       slimeform:
         specifier: ^0.9.1
-        version: 0.9.1(vue@3.4.21)
+        version: 0.9.1(vue@3.4.21(typescript@5.4.4))
       stale-dep:
         specifier: ^0.7.0
-        version: 0.7.0
+        version: 0.7.0(@nuxt/kit@3.11.2(rollup@2.79.1))(@nuxt/schema@3.11.2(rollup@2.79.1))
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
@@ -233,16 +236,16 @@ importers:
         version: 1.5.3
       unimport:
         specifier: ^3.7.1
-        version: 3.7.1(rollup@4.14.0)
+        version: 3.7.1(rollup@2.79.1)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.2(vite@5.2.8)(workbox-build@7.0.0)(workbox-window@7.0.0)
+        version: 0.19.2(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(workbox-build@7.0.0)(workbox-window@7.0.0)
       vue-advanced-cropper:
         specifier: ^2.8.8
-        version: 2.8.8(vue@3.4.21)
+        version: 2.8.8(vue@3.4.21(typescript@5.4.4))
       vue-virtual-scroller:
         specifier: 2.0.0-beta.8
-        version: 2.0.0-beta.8(vue@3.4.21)
+        version: 2.0.0-beta.8(vue@3.4.21(typescript@5.4.4))
       workbox-build:
         specifier: ^7.0.0
         version: 7.0.0
@@ -255,7 +258,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.9.0
-        version: 2.9.0(@vue/compiler-sfc@3.4.21)(eslint-plugin-format@0.1.0)(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0)
+        version: 2.9.0(@unocss/eslint-plugin@0.58.9(eslint@8.57.0)(typescript@5.4.4))(@vue/compiler-sfc@3.4.21)(eslint-plugin-format@0.1.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))
       '@antfu/ni':
         specifier: ^0.21.12
         version: 0.21.12
@@ -285,7 +288,7 @@ importers:
         version: 8.5.10
       '@unlazy/nuxt':
         specifier: ^0.11.2
-        version: 0.11.2(rollup@4.14.0)
+        version: 0.11.2(rollup@2.79.1)
       '@unocss/eslint-config':
         specifier: ^0.58.9
         version: 0.58.9(eslint@8.57.0)(typescript@5.4.4)
@@ -315,7 +318,7 @@ importers:
         version: 15.2.2
       nuxt:
         specifier: ^3.11.2
-        version: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -336,7 +339,7 @@ importers:
         version: 5.4.4
       vitest:
         specifier: 1.4.0
-        version: 1.4.0(happy-dom@10.5.2)
+        version: 1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0)
       vue-tsc:
         specifier: ^2.0.10
         version: 2.0.10(typescript@5.4.4)
@@ -349,10 +352,10 @@ importers:
     devDependencies:
       '@nuxt-themes/docus':
         specifier: ^1.15.0
-        version: 1.15.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(nuxt@3.11.2)(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)
+        version: 1.15.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
       nuxt:
         specifier: ^3.11.2
-        version: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
 
 packages:
 
@@ -1536,6 +1539,10 @@ packages:
   '@fnando/sparkline@0.3.10':
     resolution: {integrity: sha512-Rwz2swatdSU5F4sCOvYG8EOWdjtLgq5d8nmnqlZ3PXdWJI9Zq9BRUvJ/9ygjajJG8qOyNpMFX3GEVFjZIuB1Jg==}
 
+  '@huggingface/jinja@0.2.2':
+    resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
+    engines: {node: '>=18'}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -2043,6 +2050,36 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
   '@remirror/core-constants@2.0.2':
     resolution: {integrity: sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ==}
 
@@ -2536,6 +2573,9 @@ packages:
 
   '@types/jsonfile@6.1.1':
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
+
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
   '@types/mdast@3.0.11':
     resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}
@@ -3076,12 +3116,6 @@ packages:
     peerDependencies:
       vue: ^3.4.21
 
-  '@vue-macros/reactivity-transform@0.3.23':
-    resolution: {integrity: sha512-SubIg1GsNpQdIDJusrcA2FWBgwSY+4jmL0j6SJ6PU85r3rlS+uDhn6AUkqxeZRAdmJnrbGHXDyWUdygOZmWrSg==}
-    engines: {node: '>=16.14.0'}
-    peerDependencies:
-      vue: ^3.4.21
-
   '@vue-macros/setup-block@0.2.15':
     resolution: {integrity: sha512-rhbJrxXFJ+GRqrR5NnqU8pMELLbAz80xc/+USGu4KzsuVyiklyQpy7jVEKRXDrm9rqlL09ia/sLrn375eCQDtA==}
     engines: {node: '>=16.14.0'}
@@ -3345,6 +3379,9 @@ packages:
   '@webassemblyjs/wast-printer@1.11.6':
     resolution: {integrity: sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==}
 
+  '@xenova/transformers@2.17.1':
+    resolution: {integrity: sha512-zo702tQAFZXhzeD2GCYUNUqeqkoueOdiSbQWa4s0q7ZE4z8WBIwIsMMPGobpgdqjQ2u0Qulo08wuqVEUrBXjkQ==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -3559,6 +3596,21 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bare-events@2.2.2:
+    resolution: {integrity: sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==}
+
+  bare-fs@2.3.0:
+    resolution: {integrity: sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==}
+
+  bare-os@2.3.0:
+    resolution: {integrity: sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==}
+
+  bare-path@2.1.3:
+    resolution: {integrity: sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==}
+
+  bare-stream@1.0.0:
+    resolution: {integrity: sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3575,6 +3627,9 @@ packages:
 
   birpc@0.2.17:
     resolution: {integrity: sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   blurhash@2.0.5:
     resolution: {integrity: sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==}
@@ -3606,6 +3661,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -3731,6 +3789,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4057,9 +4118,17 @@ packages:
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4224,6 +4293,9 @@ packages:
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
   engine.io-client@6.5.3:
     resolution: {integrity: sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==}
@@ -4566,6 +4638,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
 
@@ -4647,6 +4723,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  flatbuffers@1.12.0:
+    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
+
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
@@ -4682,6 +4761,9 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
@@ -4785,6 +4867,9 @@ packages:
   git-url-parse@14.0.0:
     resolution: {integrity: sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   github-reserved-names@2.0.4:
     resolution: {integrity: sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg==}
 
@@ -4854,6 +4939,9 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -5531,6 +5619,9 @@ packages:
     resolution: {integrity: sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==}
     engines: {node: '>=18'}
 
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -5784,6 +5875,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5802,6 +5897,9 @@ packages:
   minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass-collect@1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -5850,6 +5948,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -5910,6 +6011,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     hasBin: true
 
+  napi-build-utils@1.0.2:
+    resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+
   natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
 
@@ -5935,6 +6039,13 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-abi@3.62.0:
+    resolution: {integrity: sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==}
+    engines: {node: '>=10'}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
   node-addon-api@7.0.0:
     resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
@@ -6128,6 +6239,19 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  onnx-proto@4.0.4:
+    resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
+
+  onnxruntime-common@1.14.0:
+    resolution: {integrity: sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==}
+
+  onnxruntime-node@1.14.0:
+    resolution: {integrity: sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.14.0:
+    resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
 
   open@10.0.3:
     resolution: {integrity: sha512-dtbI5oW7987hwC9qjJTyABldTaa19SuyJse1QboWv3b0qCcrrLNVDqBx1XgELAjh9QTVQaP/C5b1nhQebd1H2A==}
@@ -6324,6 +6448,9 @@ packages:
 
   pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -6523,6 +6650,11 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.2:
+    resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -6674,8 +6806,15 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@6.11.4:
+    resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
+    hasBin: true
+
   protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
+
+  pump@3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -6703,6 +6842,10 @@ packages:
 
   rc9@2.1.1:
     resolution: {integrity: sha512-lNeOl38Ws0eNxpO3+wD1I9rkHGQyj1NU1jlzv4go2CtEnEQEUfqnIvZG7W+bC/aXdJ27n5x/yUjb6RoT9tko+Q==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -6985,6 +7128,10 @@ packages:
   sharp-ico@0.1.5:
     resolution: {integrity: sha512-a3jODQl82NPp1d5OYb0wY+oFaPk7AvyxipIowCHk7pBsZCWgbe0yAkU2OOXdoH0ENyANhyOQbs9xkAiRHcF02Q==}
 
+  sharp@0.32.6:
+    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
+    engines: {node: '>=14.15.0'}
+
   sharp@0.33.3:
     resolution: {integrity: sha512-vHUeXJU1UvlO/BNwTpT0x/r53WkLUVxrmb5JTgW92fdFCFk0ispLMAeu/jPO2vjkXM1fYUi3K7/qcLF47pwM1A==}
     engines: {libvips: '>=8.15.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -7019,6 +7166,12 @@ packages:
   sigstore@2.2.2:
     resolution: {integrity: sha512-2A3WvXkQurhuMgORgT60r6pOWiCOO5LlEqY2ADxGBDGVYLSo5HN0uLtb68YpVpuL/Vi8mLTe7+0Dx2Fq8lLqEg==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-git-hooks@2.11.1:
     resolution: {integrity: sha512-tgqwPUMDcNDhuf1Xf6KTUsyeqGdgKMhzaH4PAZZuzguOgTl5uuyeYe/8mWgAr6IBxB5V06uqEf6Dy37gIWDtDg==}
@@ -7181,6 +7334,9 @@ packages:
   streamx@2.15.0:
     resolution: {integrity: sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==}
 
+  streamx@2.16.1:
+    resolution: {integrity: sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -7250,6 +7406,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -7331,6 +7491,16 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.1:
+    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+
+  tar-fs@3.0.6:
+    resolution: {integrity: sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.1.6:
     resolution: {integrity: sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==}
 
@@ -7340,12 +7510,10 @@ packages:
 
   tauri-plugin-log-api@https://codeload.github.com/tauri-apps/tauri-plugin-log/tar.gz/db7255ca2e07fc4d3e6cc5d93f9ccfceacb28901:
     resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-log/tar.gz/db7255ca2e07fc4d3e6cc5d93f9ccfceacb28901}
-    name: tauri-plugin-log-api
     version: 0.0.0
 
   tauri-plugin-store-api@https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/02243686d0507d2aeeb2924cd889dd0bcb47ecef:
     resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/02243686d0507d2aeeb2924cd889dd0bcb47ecef}
-    name: tauri-plugin-store-api
     version: 0.0.0
 
   temp-dir@2.0.0:
@@ -7496,6 +7664,9 @@ packages:
   tuf-js@2.2.0:
     resolution: {integrity: sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -8276,7 +8447,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.9.0(@vue/compiler-sfc@3.4.21)(eslint-plugin-format@0.1.0)(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0)':
+  '@antfu/eslint-config@2.9.0(@unocss/eslint-plugin@0.58.9(eslint@8.57.0)(typescript@5.4.4))(@vue/compiler-sfc@3.4.21)(eslint-plugin-format@0.1.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))':
     dependencies:
       '@antfu/eslint-define-config': 1.23.0-2
       '@antfu/install-pkg': 0.3.1
@@ -8285,25 +8456,24 @@ snapshots:
       '@eslint-types/typescript-eslint': 7.0.2
       '@eslint-types/unicorn': 51.0.1
       '@stylistic/eslint-plugin': 1.7.0(eslint@8.57.0)(typescript@5.4.4)
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0)(eslint@8.57.0)(typescript@5.4.4)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.4)
       eslint: 8.57.0
       eslint-config-flat-gitignore: 0.1.3
       eslint-merge-processors: 0.1.0(eslint@8.57.0)
       eslint-plugin-antfu: 2.1.2(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-format: 0.1.0(eslint@8.57.0)
       eslint-plugin-import-x: 0.4.3(eslint@8.57.0)(typescript@5.4.4)
       eslint-plugin-jsdoc: 48.2.1(eslint@8.57.0)
       eslint-plugin-jsonc: 2.13.0(eslint@8.57.0)
       eslint-plugin-markdown: 4.0.1(eslint@8.57.0)
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-perfectionist: 2.6.0(eslint@8.57.0)(typescript@5.4.4)(vue-eslint-parser@9.4.2)
+      eslint-plugin-perfectionist: 2.6.0(eslint@8.57.0)(typescript@5.4.4)(vue-eslint-parser@9.4.2(eslint@8.57.0))
       eslint-plugin-toml: 0.9.2(eslint@8.57.0)
       eslint-plugin-unicorn: 51.0.1(eslint@8.57.0)
-      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@7.2.0)(eslint@8.57.0)
-      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.2.0)(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0)
+      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)
+      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))
       eslint-plugin-vue: 9.23.0(eslint@8.57.0)
       eslint-plugin-yml: 1.12.2(eslint@8.57.0)
       eslint-processor-vue-blocks: 0.1.1(@vue/compiler-sfc@3.4.21)(eslint@8.57.0)
@@ -8316,6 +8486,9 @@ snapshots:
       vue-eslint-parser: 9.4.2(eslint@8.57.0)
       yaml-eslint-parser: 1.2.2
       yargs: 17.7.2
+    optionalDependencies:
+      '@unocss/eslint-plugin': 0.58.9(eslint@8.57.0)(typescript@5.4.4)
+      eslint-plugin-format: 0.1.0(eslint@8.57.0)
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - supports-color
@@ -9121,7 +9294,7 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@csstools/cascade-layer-name-parser@1.0.3(@csstools/css-parser-algorithms@2.3.0)(@csstools/css-tokenizer@2.1.1)':
+  '@csstools/cascade-layer-name-parser@1.0.3(@csstools/css-parser-algorithms@2.3.0(@csstools/css-tokenizer@2.1.1))(@csstools/css-tokenizer@2.1.1)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.3.0(@csstools/css-tokenizer@2.1.1)
       '@csstools/css-tokenizer': 2.1.1
@@ -9394,6 +9567,8 @@ snapshots:
 
   '@fnando/sparkline@0.3.10': {}
 
+  '@huggingface/jinja@0.2.2': {}
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
@@ -9427,7 +9602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@iconify/vue@4.1.1(vue@3.4.21)':
+  '@iconify/vue@4.1.1(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@iconify/types': 2.0.0
       vue: 3.4.21(typescript@5.4.4)
@@ -9507,7 +9682,7 @@ snapshots:
   '@img/sharp-win32-x64@0.33.3':
     optional: true
 
-  '@intlify/bundle-utils@7.5.0(vue-i18n@9.9.1)':
+  '@intlify/bundle-utils@7.5.0(vue-i18n@9.9.1(vue@3.4.21(typescript@5.4.4)))':
     dependencies:
       '@intlify/message-compiler': 9.9.1
       '@intlify/shared': 9.9.1
@@ -9518,8 +9693,9 @@ snapshots:
       magic-string: 0.30.9
       mlly: 1.6.1
       source-map-js: 1.2.0
-      vue-i18n: 9.9.1(vue@3.4.21)
       yaml-eslint-parser: 1.2.2
+    optionalDependencies:
+      vue-i18n: 9.9.1(vue@3.4.21(typescript@5.4.4))
 
   '@intlify/core-base@9.9.1':
     dependencies:
@@ -9543,11 +9719,11 @@ snapshots:
 
   '@intlify/shared@9.9.1': {}
 
-  '@intlify/unplugin-vue-i18n@3.0.1(rollup@4.14.0)(vue-i18n@9.9.1)':
+  '@intlify/unplugin-vue-i18n@3.0.1(rollup@2.79.1)(vue-i18n@9.9.1(vue@3.4.21(typescript@5.4.4)))':
     dependencies:
-      '@intlify/bundle-utils': 7.5.0(vue-i18n@9.9.1)
+      '@intlify/bundle-utils': 7.5.0(vue-i18n@9.9.1(vue@3.4.21(typescript@5.4.4)))
       '@intlify/shared': 9.9.1
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/compiler-sfc': 3.4.21
       debug: 4.3.4
       fast-glob: 3.3.2
@@ -9557,7 +9733,8 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.2.0
       unplugin: 1.10.1
-      vue-i18n: 9.9.1(vue@3.4.21)
+    optionalDependencies:
+      vue-i18n: 9.9.1(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -9616,12 +9793,12 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@mapbox/node-pre-gyp@1.0.10':
+  '@mapbox/node-pre-gyp@1.0.10(encoding@0.1.13)':
     dependencies:
       detect-libc: 2.0.3
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.6.12
+      node-fetch: 2.6.12(encoding@0.1.13)
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
@@ -9631,11 +9808,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.14.0)':
+  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@2.79.1)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       json5: 2.2.3
-      rollup: 4.14.0
+      rollup: 2.79.1
 
   '@netlify/functions@2.6.0':
     dependencies:
@@ -9708,15 +9885,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nuxt-themes/docus@1.15.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(nuxt@3.11.2)(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)':
+  '@nuxt-themes/docus@1.15.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt-themes/elements': 0.9.5(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)
-      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)
-      '@nuxt-themes/typography': 0.11.0(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)
-      '@nuxt/content': 2.12.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@3.29.4)(vue@3.4.21)
-      '@nuxthq/studio': 1.0.11(rollup@3.29.4)
-      '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21)
-      '@vueuse/nuxt': 10.8.0(nuxt@3.11.2)(rollup@3.29.4)(vue@3.4.21)
+      '@nuxt-themes/elements': 0.9.5(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
+      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
+      '@nuxt-themes/typography': 0.11.0(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
+      '@nuxt/content': 2.12.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(ioredis@5.3.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
+      '@nuxthq/studio': 1.0.11(rollup@4.14.0)
+      '@vueuse/integrations': 10.9.0(change-case@4.1.2)(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/nuxt': 10.8.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
       focus-trap: 7.5.4
       fuse.js: 6.6.2
     transitivePeerDependencies:
@@ -9753,10 +9930,10 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt-themes/elements@0.9.5(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)':
+  '@nuxt-themes/elements@0.9.5(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)
-      '@vueuse/core': 9.13.0(vue@3.4.21)
+      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/core': 9.13.0(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - postcss
@@ -9765,10 +9942,10 @@ snapshots:
       - supports-color
       - vue
 
-  '@nuxt-themes/tokens@1.9.1(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)':
+  '@nuxt-themes/tokens@1.9.1(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxtjs/color-mode': 3.3.2(rollup@3.29.4)
-      '@vueuse/core': 9.13.0(vue@3.4.21)
+      '@nuxtjs/color-mode': 3.3.2(rollup@4.14.0)
+      '@vueuse/core': 9.13.0(vue@3.4.21(typescript@5.4.4))
       pinceau: 0.18.9(postcss@8.4.38)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -9778,11 +9955,11 @@ snapshots:
       - supports-color
       - vue
 
-  '@nuxt-themes/typography@0.11.0(postcss@8.4.38)(rollup@3.29.4)(vue@3.4.21)':
+  '@nuxt-themes/typography@0.11.0(postcss@8.4.38)(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxtjs/color-mode': 3.3.2(rollup@3.29.4)
-      nuxt-config-schema: 0.4.6(rollup@3.29.4)
-      nuxt-icon: 0.3.3(rollup@3.29.4)(vue@3.4.21)
+      '@nuxtjs/color-mode': 3.3.2(rollup@4.14.0)
+      nuxt-config-schema: 0.4.6(rollup@4.14.0)
+      nuxt-icon: 0.3.3(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
       pinceau: 0.18.9(postcss@8.4.38)
       ufo: 1.5.3
     transitivePeerDependencies:
@@ -9792,13 +9969,13 @@ snapshots:
       - supports-color
       - vue
 
-  '@nuxt/content@2.12.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@3.29.4)(vue@3.4.21)':
+  '@nuxt/content@2.12.0(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(ioredis@5.3.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@nuxtjs/mdc': 0.5.0(rollup@3.29.4)
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/head': 2.0.0(vue@3.4.21)
-      '@vueuse/nuxt': 10.8.0(nuxt@3.11.2)(rollup@3.29.4)(vue@3.4.21)
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxtjs/mdc': 0.5.0(rollup@4.14.0)
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/head': 2.0.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/nuxt': 10.8.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -9846,24 +10023,24 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.1.5(nuxt@3.11.2)(rollup@3.29.4)(vite@5.2.8)':
+  '@nuxt/devtools-kit@1.1.5(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@nuxt/schema': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@nuxt/schema': 3.11.2(rollup@2.79.1)
       execa: 7.2.0
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
-      vite: 5.2.8
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.1.5(nuxt@3.11.2)(rollup@4.14.0)(vite@5.2.8)':
+  '@nuxt/devtools-kit@1.1.5(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.14.0)
       '@nuxt/schema': 3.11.2(rollup@4.14.0)
       execa: 7.2.0
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
-      vite: 5.2.8
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -9881,15 +10058,15 @@ snapshots:
       rc9: 2.1.1
       semver: 7.6.0
 
-  '@nuxt/devtools@1.1.5(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@3.29.4)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)':
-    dependencies:
+  ? '@nuxt/devtools@1.1.5(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))'
+  : dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.1.5(nuxt@3.11.2)(rollup@3.29.4)(vite@5.2.8)
+      '@nuxt/devtools-kit': 1.1.5(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       '@nuxt/devtools-wizard': 1.1.5
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@vue/devtools-applet': 7.0.25(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)
-      '@vue/devtools-core': 7.0.25(vite@5.2.8)(vue@3.4.21)
-      '@vue/devtools-kit': 7.0.25(vue@3.4.21)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@vue/devtools-applet': 7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-core': 7.0.25(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-kit': 7.0.25(vue@3.4.21(typescript@5.4.4))
       birpc: 0.2.17
       consola: 3.2.3
       cronstrue: 2.49.0
@@ -9905,7 +10082,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.3
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 17.0.6
@@ -9917,10 +10094,10 @@ snapshots:
       semver: 7.6.0
       simple-git: 3.24.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@3.29.4)
-      vite: 5.2.8
-      vite-plugin-inspect: 0.8.3(@nuxt/kit@3.11.2)(rollup@3.29.4)(vite@5.2.8)
-      vite-plugin-vue-inspector: 4.0.2(vite@5.2.8)
+      unimport: 3.7.1(rollup@2.79.1)
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vite-plugin-inspect: 0.8.3(@nuxt/kit@3.11.2(rollup@2.79.1))(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -9946,15 +10123,15 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@1.1.5(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@4.14.0)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)':
-    dependencies:
+  ? '@nuxt/devtools@1.1.5(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))'
+  : dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.1.5(nuxt@3.11.2)(rollup@4.14.0)(vite@5.2.8)
+      '@nuxt/devtools-kit': 1.1.5(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       '@nuxt/devtools-wizard': 1.1.5
       '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      '@vue/devtools-applet': 7.0.25(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)
-      '@vue/devtools-core': 7.0.25(vite@5.2.8)(vue@3.4.21)
-      '@vue/devtools-kit': 7.0.25(vue@3.4.21)
+      '@vue/devtools-applet': 7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-core': 7.0.25(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-kit': 7.0.25(vue@3.4.21(typescript@5.4.4))
       birpc: 0.2.17
       consola: 3.2.3
       cronstrue: 2.49.0
@@ -9970,7 +10147,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.3
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 17.0.6
@@ -9983,9 +10160,9 @@ snapshots:
       simple-git: 3.24.0
       sirv: 2.0.4
       unimport: 3.7.1(rollup@4.14.0)
-      vite: 5.2.8
-      vite-plugin-inspect: 0.8.3(@nuxt/kit@3.11.2)(rollup@4.14.0)(vite@5.2.8)
-      vite-plugin-vue-inspector: 4.0.2(vite@5.2.8)
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vite-plugin-inspect: 0.8.3(@nuxt/kit@3.11.2(rollup@4.14.0))(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -10011,9 +10188,9 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@3.11.2(rollup@3.29.4)':
+  '@nuxt/kit@3.11.2(rollup@2.79.1)':
     dependencies:
-      '@nuxt/schema': 3.11.2(rollup@3.29.4)
+      '@nuxt/schema': 3.11.2(rollup@2.79.1)
       c12: 1.10.0
       consola: 3.2.3
       defu: 6.1.4
@@ -10029,7 +10206,7 @@ snapshots:
       semver: 7.6.0
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@2.79.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -10059,7 +10236,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.11.2(rollup@3.29.4)':
+  '@nuxt/schema@3.11.2(rollup@2.79.1)':
     dependencies:
       '@nuxt/ui-templates': 1.3.2
       consola: 3.2.3
@@ -10070,7 +10247,7 @@ snapshots:
       scule: 1.3.0
       std-env: 3.7.0
       ufo: 1.5.3
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@2.79.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -10093,9 +10270,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.5.3(rollup@3.29.4)':
+  '@nuxt/telemetry@2.5.3(rollup@2.79.1)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -10139,11 +10316,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/test-utils@3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@4.14.0)(vite@5.2.8)(vitest@1.4.0)(vue-router@4.3.0)(vue@3.4.21)':
+  '@nuxt/test-utils@3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      '@nuxt/schema': 3.11.2(rollup@4.14.0)
-      '@vue/test-utils': 2.4.5
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@nuxt/schema': 3.11.2(rollup@2.79.1)
       c12: 1.10.0
       consola: 3.2.3
       defu: 6.1.4
@@ -10153,7 +10329,6 @@ snapshots:
       fake-indexeddb: 5.0.2
       get-port-please: 3.1.2
       h3: 1.11.1
-      happy-dom: 10.5.2
       local-pkg: 0.5.0
       magic-string: 0.30.9
       node-fetch-native: 1.6.4
@@ -10166,23 +10341,26 @@ snapshots:
       ufo: 1.5.3
       unenv: 1.9.0
       unplugin: 1.10.1
-      vite: 5.2.8
-      vitest: 1.4.0(happy-dom@10.5.2)
-      vitest-environment-nuxt: 1.0.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@4.14.0)(vite@5.2.8)(vitest@1.4.0)(vue-router@4.3.0)(vue@3.4.21)
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vitest-environment-nuxt: 1.0.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))
       vue: 3.4.21(typescript@5.4.4)
-      vue-router: 4.3.0(vue@3.4.21)
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      '@vue/test-utils': 2.4.5
+      happy-dom: 10.5.2
+      vitest: 1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
   '@nuxt/ui-templates@1.3.2': {}
 
-  '@nuxt/vite-builder@3.11.2(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)':
+  '@nuxt/vite-builder@3.11.2(@types/node@20.8.6)(eslint@8.57.0)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@rollup/plugin-replace': 5.0.5(rollup@3.29.4)
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.8)(vue@3.4.21)
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.8)(vue@3.4.21)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@rollup/plugin-replace': 5.0.5(rollup@2.79.1)
+      '@vitejs/plugin-vue': 5.0.4(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
       autoprefixer: 10.4.19(postcss@8.4.38)
       clear: 0.1.0
       consola: 3.2.3
@@ -10203,15 +10381,15 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       postcss: 8.4.38
-      rollup-plugin-visualizer: 5.12.0(rollup@3.29.4)
+      rollup-plugin-visualizer: 5.12.0(rollup@2.79.1)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.3
       unenv: 1.9.0
       unplugin: 1.10.1
-      vite: 5.2.8
-      vite-node: 1.4.0
-      vite-plugin-checker: 0.6.4(eslint@8.57.0)(typescript@5.4.4)(vite@5.2.8)(vue-tsc@2.0.10)
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vite-node: 1.4.0(@types/node@20.8.6)(terser@5.22.0)
+      vite-plugin-checker: 0.6.4(eslint@8.57.0)(optionator@0.9.3)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
       vue: 3.4.21(typescript@5.4.4)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -10234,12 +10412,12 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxt/vite-builder@3.11.2(eslint@8.57.0)(rollup@4.14.0)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)':
+  '@nuxt/vite-builder@3.11.2(@types/node@20.8.6)(eslint@8.57.0)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.14.0)
       '@rollup/plugin-replace': 5.0.5(rollup@4.14.0)
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.8)(vue@3.4.21)
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.8)(vue@3.4.21)
+      '@vitejs/plugin-vue': 5.0.4(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
       autoprefixer: 10.4.19(postcss@8.4.38)
       clear: 0.1.0
       consola: 3.2.3
@@ -10266,9 +10444,9 @@ snapshots:
       ufo: 1.5.3
       unenv: 1.9.0
       unplugin: 1.10.1
-      vite: 5.2.8
-      vite-node: 1.4.0
-      vite-plugin-checker: 0.6.4(eslint@8.57.0)(typescript@5.4.4)(vite@5.2.8)(vue-tsc@2.0.10)
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vite-node: 1.4.0(@types/node@20.8.6)(terser@5.22.0)
+      vite-plugin-checker: 0.6.4(eslint@8.57.0)(optionator@0.9.3)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
       vue: 3.4.21(typescript@5.4.4)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -10291,12 +10469,12 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxthq/studio@1.0.11(rollup@3.29.4)':
+  '@nuxthq/studio@1.0.11(rollup@4.14.0)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
       defu: 6.1.4
       git-url-parse: 14.0.0
-      nuxt-component-meta: 0.6.3(rollup@3.29.4)
+      nuxt-component-meta: 0.6.3(rollup@4.14.0)
       parse-git-config: 3.0.0
       pkg-types: 1.0.3
       socket.io-client: 4.7.4
@@ -10308,9 +10486,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxtjs/color-mode@3.3.2(rollup@3.29.4)':
+  '@nuxtjs/color-mode@3.3.2(rollup@2.79.1)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       lodash.template: 4.5.0
       pathe: 1.1.2
     transitivePeerDependencies:
@@ -10326,15 +10504,15 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxtjs/i18n@8.3.0(rollup@4.14.0)(vue@3.4.21)':
+  '@nuxtjs/i18n@8.3.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@intlify/h3': 0.5.0
       '@intlify/shared': 9.9.1
-      '@intlify/unplugin-vue-i18n': 3.0.1(rollup@4.14.0)(vue-i18n@9.9.1)
+      '@intlify/unplugin-vue-i18n': 3.0.1(rollup@2.79.1)(vue-i18n@9.9.1(vue@3.4.21(typescript@5.4.4)))
       '@intlify/utils': 0.12.0
-      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.14.0)
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      '@rollup/plugin-yaml': 4.1.2(rollup@4.14.0)
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@2.79.1)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@rollup/plugin-yaml': 4.1.2(rollup@2.79.1)
       '@vue/compiler-sfc': 3.4.21
       debug: 4.3.4
       defu: 6.1.4
@@ -10348,8 +10526,8 @@ snapshots:
       sucrase: 3.35.0
       ufo: 1.5.3
       unplugin: 1.10.1
-      vue-i18n: 9.9.1(vue@3.4.21)
-      vue-router: 4.3.0(vue@3.4.21)
+      vue-i18n: 9.9.1(vue@3.4.21(typescript@5.4.4))
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - petite-vue-i18n
       - rollup
@@ -10357,9 +10535,9 @@ snapshots:
       - vue
       - vue-i18n-bridge
 
-  '@nuxtjs/mdc@0.5.0(rollup@3.29.4)':
+  '@nuxtjs/mdc@0.5.0(rollup@4.14.0)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
       '@shikijs/transformers': 1.1.7
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.3
@@ -10461,10 +10639,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@pinia/nuxt@0.5.1(rollup@4.14.0)(typescript@5.4.4)(vue@3.4.21)':
+  '@pinia/nuxt@0.5.1(rollup@2.79.1)(typescript@5.4.4)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      pinia: 2.1.7(typescript@5.4.4)(vue@3.4.21)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      pinia: 2.1.7(typescript@5.4.4)(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
@@ -10480,6 +10658,29 @@ snapshots:
   '@polka/url@1.0.0-next.24': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@remirror/core-constants@2.0.2': {}
 
@@ -10505,13 +10706,15 @@ snapshots:
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
     dependencies:
-      rollup: 3.29.4
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 3.29.4
 
   '@rollup/plugin-alias@5.1.0(rollup@4.14.0)':
     dependencies:
-      rollup: 4.14.0
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 4.14.0
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.24.4)(rollup@2.79.1)':
     dependencies:
@@ -10528,6 +10731,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-commonjs@25.0.7(rollup@4.14.0)':
@@ -10538,6 +10742,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.9
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/plugin-inject@5.0.5(rollup@4.14.0)':
@@ -10545,16 +10750,19 @@ snapshots:
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
       estree-walker: 2.0.2
       magic-string: 0.30.9
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/plugin-json@6.1.0(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-json@6.1.0(rollup@4.14.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/plugin-node-resolve@11.2.1(rollup@2.79.1)':
@@ -10575,6 +10783,7 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.14.0)':
@@ -10585,6 +10794,7 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/plugin-replace@2.4.2(rollup@2.79.1)':
@@ -10593,31 +10803,42 @@ snapshots:
       magic-string: 0.25.9
       rollup: 2.79.1
 
+  '@rollup/plugin-replace@5.0.5(rollup@2.79.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      magic-string: 0.30.9
+    optionalDependencies:
+      rollup: 2.79.1
+
   '@rollup/plugin-replace@5.0.5(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       magic-string: 0.30.9
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-replace@5.0.5(rollup@4.14.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
       magic-string: 0.30.9
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/plugin-terser@0.4.4(rollup@4.14.0)':
     dependencies:
-      rollup: 4.14.0
       serialize-javascript: 6.0.1
       smob: 1.4.0
       terser: 5.22.0
-
-  '@rollup/plugin-yaml@4.1.2(rollup@4.14.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
-      js-yaml: 4.1.0
+    optionalDependencies:
       rollup: 4.14.0
+
+  '@rollup/plugin-yaml@4.1.2(rollup@2.79.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
+    optionalDependencies:
+      rollup: 2.79.1
 
   '@rollup/pluginutils@3.1.0(rollup@2.79.1)':
     dependencies:
@@ -10631,11 +10852,20 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
+  '@rollup/pluginutils@5.1.0(rollup@2.79.1)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 2.79.1
+
   '@rollup/pluginutils@5.1.0(rollup@3.29.4)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/pluginutils@5.1.0(rollup@4.14.0)':
@@ -10643,6 +10873,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 4.14.0
 
   '@rollup/rollup-android-arm-eabi@4.14.0':
@@ -10795,108 +11026,108 @@ snapshots:
     dependencies:
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/extension-blockquote@2.2.4(@tiptap/core@2.2.4)':
+  '@tiptap/extension-blockquote@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
 
-  '@tiptap/extension-bold@2.2.4(@tiptap/core@2.2.4)':
+  '@tiptap/extension-bold@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
 
-  '@tiptap/extension-bubble-menu@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/pm': 2.2.4
-      tippy.js: 6.3.7
-
-  '@tiptap/extension-bullet-list@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-character-count@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/pm': 2.2.4
-
-  '@tiptap/extension-code-block@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/pm': 2.2.4
-
-  '@tiptap/extension-code@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-document@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-dropcursor@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/pm': 2.2.4
-
-  '@tiptap/extension-floating-menu@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/extension-bubble-menu@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
       tippy.js: 6.3.7
 
-  '@tiptap/extension-gapcursor@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/extension-bullet-list@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-character-count@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/extension-hard-break@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-heading@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-history@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/extension-code-block@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/extension-horizontal-rule@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/extension-code@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-document@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-dropcursor@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/extension-italic@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-list-item@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-mention@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)(@tiptap/suggestion@2.2.4)':
+  '@tiptap/extension-floating-menu@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
-      '@tiptap/suggestion': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+      tippy.js: 6.3.7
 
-  '@tiptap/extension-ordered-list@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-paragraph@2.2.4(@tiptap/core@2.2.4)':
-    dependencies:
-      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-
-  '@tiptap/extension-placeholder@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/extension-gapcursor@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/extension-strike@2.2.4(@tiptap/core@2.2.4)':
+  '@tiptap/extension-hard-break@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
 
-  '@tiptap/extension-text@2.2.4(@tiptap/core@2.2.4)':
+  '@tiptap/extension-heading@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-history@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+      '@tiptap/pm': 2.2.4
+
+  '@tiptap/extension-horizontal-rule@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+      '@tiptap/pm': 2.2.4
+
+  '@tiptap/extension-italic@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-list-item@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-mention@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)(@tiptap/suggestion@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+      '@tiptap/pm': 2.2.4
+      '@tiptap/suggestion': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-ordered-list@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-paragraph@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-placeholder@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+      '@tiptap/pm': 2.2.4
+
+  '@tiptap/extension-strike@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
+    dependencies:
+      '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
+
+  '@tiptap/extension-text@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
 
@@ -10924,37 +11155,37 @@ snapshots:
   '@tiptap/starter-kit@2.2.4(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/extension-blockquote': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-bold': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-bullet-list': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-code': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-code-block': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-document': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-dropcursor': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-gapcursor': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-hard-break': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-heading': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-history': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-horizontal-rule': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-italic': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-list-item': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-ordered-list': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-paragraph': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-strike': 2.2.4(@tiptap/core@2.2.4)
-      '@tiptap/extension-text': 2.2.4(@tiptap/core@2.2.4)
+      '@tiptap/extension-blockquote': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-bold': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-bullet-list': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-code': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-code-block': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-document': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-dropcursor': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-gapcursor': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-hard-break': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-heading': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-history': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-horizontal-rule': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-italic': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-list-item': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-ordered-list': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-paragraph': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-strike': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
+      '@tiptap/extension-text': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))
     transitivePeerDependencies:
       - '@tiptap/pm'
 
-  '@tiptap/suggestion@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)':
+  '@tiptap/suggestion@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
 
-  '@tiptap/vue-3@2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)(vue@3.4.21)':
+  '@tiptap/vue-3@2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@tiptap/core': 2.2.4(@tiptap/pm@2.2.4)
-      '@tiptap/extension-bubble-menu': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
-      '@tiptap/extension-floating-menu': 2.2.4(@tiptap/core@2.2.4)(@tiptap/pm@2.2.4)
+      '@tiptap/extension-bubble-menu': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
+      '@tiptap/extension-floating-menu': 2.2.4(@tiptap/core@2.2.4(@tiptap/pm@2.2.4))(@tiptap/pm@2.2.4)
       '@tiptap/pm': 2.2.4
       vue: 3.4.21(typescript@5.4.4)
 
@@ -11014,6 +11245,8 @@ snapshots:
     dependencies:
       '@types/node': 20.8.6
 
+  '@types/long@4.0.2': {}
+
   '@types/mdast@3.0.11':
     dependencies:
       '@types/unist': 3.0.2
@@ -11064,7 +11297,7 @@ snapshots:
     dependencies:
       '@types/node': 20.8.6
 
-  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0)(eslint@8.57.0)(typescript@5.4.4)':
+  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)':
     dependencies:
       '@eslint-community/regexpp': 4.6.2
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.4)
@@ -11079,6 +11312,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.0
       ts-api-utils: 1.0.1(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11091,6 +11325,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.4
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11122,6 +11357,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.0.1(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11143,6 +11379,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11157,6 +11394,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.0.1(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11171,6 +11409,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.0.1(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11185,6 +11424,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.0.1(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -11287,7 +11527,7 @@ snapshots:
       '@unhead/schema': 1.9.4
       '@unhead/shared': 1.9.4
 
-  '@unhead/vue@1.9.4(vue@3.4.21)':
+  '@unhead/vue@1.9.4(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@unhead/schema': 1.9.4
       '@unhead/shared': 1.9.4
@@ -11297,21 +11537,50 @@ snapshots:
 
   '@unlazy/core@0.11.2': {}
 
-  '@unlazy/nuxt@0.11.2(rollup@4.14.0)':
+  '@unlazy/nuxt@0.11.2(rollup@2.79.1)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       defu: 6.1.4
       unlazy: 0.11.2
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@unocss/astro@0.58.9(rollup@4.14.0)(vite@5.2.8)':
+  '@unocss/astro@0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
     dependencies:
       '@unocss/core': 0.58.9
       '@unocss/reset': 0.58.9
-      '@unocss/vite': 0.58.9(rollup@4.14.0)(vite@5.2.8)
-      vite: 5.2.8
+      '@unocss/vite': 0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+    optionalDependencies:
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    transitivePeerDependencies:
+      - rollup
+
+  '@unocss/astro@0.58.9(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
+    dependencies:
+      '@unocss/core': 0.58.9
+      '@unocss/reset': 0.58.9
+      '@unocss/vite': 0.58.9(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+    optionalDependencies:
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    transitivePeerDependencies:
+      - rollup
+
+  '@unocss/cli@0.58.9(rollup@2.79.1)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@unocss/config': 0.58.9
+      '@unocss/core': 0.58.9
+      '@unocss/preset-uno': 0.58.9
+      cac: 6.7.14
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      consola: 3.2.3
+      fast-glob: 3.3.2
+      magic-string: 0.30.9
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
     transitivePeerDependencies:
       - rollup
 
@@ -11371,9 +11640,9 @@ snapshots:
       gzip-size: 6.0.0
       sirv: 2.0.4
 
-  '@unocss/nuxt@0.58.9(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8)(webpack@5.89.0)':
+  '@unocss/nuxt@0.58.9(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(webpack@5.89.0(esbuild@0.20.2))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       '@unocss/config': 0.58.9
       '@unocss/core': 0.58.9
       '@unocss/preset-attributify': 0.58.9
@@ -11384,9 +11653,9 @@ snapshots:
       '@unocss/preset-web-fonts': 0.58.9
       '@unocss/preset-wind': 0.58.9
       '@unocss/reset': 0.58.9
-      '@unocss/vite': 0.58.9(rollup@4.14.0)(vite@5.2.8)
-      '@unocss/webpack': 0.58.9(rollup@4.14.0)(webpack@5.89.0)
-      unocss: 0.58.9(@unocss/webpack@0.58.9)(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8)
+      '@unocss/vite': 0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      '@unocss/webpack': 0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2))
+      unocss: 0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -11487,7 +11756,23 @@ snapshots:
     dependencies:
       '@unocss/core': 0.58.9
 
-  '@unocss/vite@0.58.9(rollup@4.14.0)(vite@5.2.8)':
+  '@unocss/vite@0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@unocss/config': 0.58.9
+      '@unocss/core': 0.58.9
+      '@unocss/inspector': 0.58.9
+      '@unocss/scope': 0.58.9
+      '@unocss/transformer-directives': 0.58.9
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      magic-string: 0.30.9
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    transitivePeerDependencies:
+      - rollup
+
+  '@unocss/vite@0.58.9(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
@@ -11499,11 +11784,26 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.9
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0)':
+  '@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@unocss/config': 0.58.9
+      '@unocss/core': 0.58.9
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      magic-string: 0.30.9
+      unplugin: 1.10.1
+      webpack: 5.89.0(esbuild@0.20.2)
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - rollup
+
+  '@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
@@ -11513,10 +11813,11 @@ snapshots:
       fast-glob: 3.3.2
       magic-string: 0.30.9
       unplugin: 1.10.1
-      webpack: 5.89.0
+      webpack: 5.89.0(esbuild@0.20.2)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - rollup
+    optional: true
 
   '@upstash/redis@1.25.1':
     dependencies:
@@ -11530,9 +11831,9 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.25.1
 
-  '@vercel/nft@0.26.4':
+  '@vercel/nft@0.26.4(encoding@0.1.13)':
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.10
+      '@mapbox/node-pre-gyp': 1.0.10(encoding@0.1.13)
       '@rollup/pluginutils': 4.2.1
       acorn: 8.11.3
       acorn-import-attributes: 1.9.2(acorn@8.11.3)
@@ -11548,19 +11849,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.2.8)(vue@3.4.21)':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.24.4)
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.8)(vue@3.4.21)':
+  '@vitejs/plugin-vue@5.0.4(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
       vue: 3.4.21(typescript@5.4.4)
 
   '@vitest/expect@1.4.0':
@@ -11646,50 +11947,63 @@ snapshots:
       muggle-string: 0.2.2
       vue-template-compiler: 2.7.14
 
-  '@vue-macros/api@0.8.3(rollup@3.29.4)(vue@3.4.21)':
+  '@vue-macros/api@0.8.3(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
-      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       resolve.exports: 2.0.2
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/api@0.8.3(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/api@0.8.3(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))
       resolve.exports: 2.0.2
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/better-define@1.6.9(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/better-define@1.6.9(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/api': 0.8.3(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/api': 0.8.3(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/boolean-prop@0.1.1(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/boolean-prop@0.1.1(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-core': 3.4.21
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/chain-call@0.1.3(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/chain-call@0.1.3(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/common@1.7.0(rollup@3.29.4)(vue@3.4.21)':
+  '@vue-macros/common@1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
+    dependencies:
+      '@babel/types': 7.24.0
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@vue/compiler-sfc': 3.4.21
+      ast-kit: 0.9.5(rollup@2.79.1)
+      local-pkg: 0.4.3
+      magic-string-ast: 0.3.0
+    optionalDependencies:
+      vue: 3.4.21(typescript@5.4.4)
+    transitivePeerDependencies:
+      - rollup
+
+  '@vue-macros/common@1.7.0(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -11697,47 +12011,38 @@ snapshots:
       ast-kit: 0.9.5(rollup@3.29.4)
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.7.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/common@1.7.2(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/compiler-sfc': 3.4.21
-      ast-kit: 0.9.5(rollup@4.14.0)
+      ast-kit: 0.10.0(rollup@2.79.1)
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.7.2(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/common@1.8.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/compiler-sfc': 3.4.21
-      ast-kit: 0.10.0(rollup@4.14.0)
+      ast-kit: 0.11.2(rollup@2.79.1)
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.8.0(rollup@3.29.4)(vue@3.4.21)':
-    dependencies:
-      '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      '@vue/compiler-sfc': 3.4.21
-      ast-kit: 0.11.2(rollup@3.29.4)
-      local-pkg: 0.4.3
-      magic-string-ast: 0.3.0
-      vue: 3.4.21(typescript@5.4.4)
-    transitivePeerDependencies:
-      - rollup
-
-  '@vue-macros/common@1.8.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/common@1.8.0(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/types': 7.24.0
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
@@ -11745,137 +12050,131 @@ snapshots:
       ast-kit: 0.11.2(rollup@4.14.0)
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-emit@0.1.13(vue@3.4.21)':
+  '@vue-macros/define-emit@0.1.13(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/api': 0.8.3(rollup@3.29.4)(vue@3.4.21)
-      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21)
+      '@vue-macros/api': 0.8.3(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))
       rollup: 3.29.4
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
 
-  '@vue-macros/define-models@1.0.13(@vueuse/core@10.9.0)(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/define-models@1.0.13(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      ast-walker-scope: 0.5.0(rollup@4.14.0)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      ast-walker-scope: 0.5.0(rollup@2.79.1)
       unplugin: 1.10.1
+    optionalDependencies:
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/define-prop@0.2.4(vue@3.4.21)':
+  '@vue-macros/define-prop@0.2.4(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/api': 0.8.3(rollup@3.29.4)(vue@3.4.21)
-      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21)
+      '@vue-macros/api': 0.8.3(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/common': 1.7.0(rollup@3.29.4)(vue@3.4.21(typescript@5.4.4))
       rollup: 3.29.4
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
 
-  '@vue-macros/define-props-refs@1.1.7(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/define-props-refs@1.1.7(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-props@1.0.17(@vue-macros/reactivity-transform@0.3.19)(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/define-props@1.0.17(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/reactivity-transform': 0.3.19(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/reactivity-transform': 0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-props@1.0.17(@vue-macros/reactivity-transform@0.3.23)(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/define-render@1.4.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/reactivity-transform': 0.3.23(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-render@1.4.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/define-slots@1.0.12(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-slots@1.0.12(rollup@4.14.0)(vue@3.4.21)':
-    dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      unplugin: 1.10.1
-      vue: 3.4.21(typescript@5.4.4)
-    transitivePeerDependencies:
-      - rollup
-
-  '@vue-macros/devtools@0.1.3(typescript@5.4.4)(vite@5.2.8)':
+  '@vue-macros/devtools@0.1.3(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))':
     dependencies:
       sirv: 2.0.4
-      vite: 5.2.8
       vue: 3.4.21(typescript@5.4.4)
+    optionalDependencies:
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - typescript
 
-  '@vue-macros/export-expose@0.0.10(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/export-expose@0.0.10(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-sfc': 3.4.21
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/export-props@0.3.15(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/export-props@0.3.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/hoist-static@1.4.9(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/hoist-static@1.4.9(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/jsx-directive@0.3.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/jsx-directive@0.3.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.2(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.2(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/named-template@0.3.16(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/named-template@0.3.16(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-dom': 3.4.21
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/nuxt@1.6.0(@vue-macros/reactivity-transform@0.3.23)(@vueuse/core@10.9.0)(nuxt@3.11.2)(rollup@4.14.0)(typescript@5.4.4)(vite@5.2.8)(vue-tsc@2.0.10)(vue@3.4.21)(webpack@5.89.0)':
+  '@vue-macros/nuxt@1.6.0(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(esbuild@0.20.2)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))(webpack@5.89.0(esbuild@0.20.2))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      '@vue-macros/boolean-prop': 0.1.1(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/common': 1.7.2(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/short-vmodel': 1.2.15(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/volar': 0.13.3(@vue-macros/reactivity-transform@0.3.23)(rollup@4.14.0)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
-      unplugin-vue-macros: 2.4.4(@vueuse/core@10.9.0)(rollup@4.14.0)(typescript@5.4.4)(vite@5.2.8)(vue@3.4.21)(webpack@5.89.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@vue-macros/boolean-prop': 0.1.1(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/common': 1.7.2(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/short-vmodel': 1.2.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/volar': 0.13.3(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
+      unplugin-vue-macros: 2.4.4(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(esbuild@0.20.2)(rollup@2.79.1)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))(webpack@5.89.0(esbuild@0.20.2))
     transitivePeerDependencies:
       - '@vue-macros/reactivity-transform'
       - '@vueuse/core'
@@ -11888,10 +12187,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@vue-macros/reactivity-transform@0.3.19(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@babel/parser': 7.24.4
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
       magic-string: 0.30.9
@@ -11900,67 +12199,56 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/reactivity-transform@0.3.23(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/setup-block@0.2.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@babel/parser': 7.24.4
-      '@vue-macros/common': 1.8.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue/compiler-core': 3.4.21
-      '@vue/shared': 3.4.21
-      magic-string: 0.30.9
-      unplugin: 1.10.1
-      vue: 3.4.21(typescript@5.4.4)
-    transitivePeerDependencies:
-      - rollup
-
-  '@vue-macros/setup-block@0.2.15(rollup@4.14.0)(vue@3.4.21)':
-    dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-dom': 3.4.21
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/setup-component@0.16.16(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/setup-component@0.16.16(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/setup-sfc@0.16.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/setup-sfc@0.16.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/short-emits@1.4.7(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/short-emits@1.4.7(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/short-vmodel@1.2.15(rollup@4.14.0)(vue@3.4.21)':
+  '@vue-macros/short-vmodel@1.2.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/compiler-core': 3.4.21
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/volar@0.13.3(@vue-macros/reactivity-transform@0.3.23)(rollup@4.14.0)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)':
+  '@vue-macros/volar@0.13.3(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@volar/language-core': 1.10.0
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-props': 1.0.17(@vue-macros/reactivity-transform@0.3.23)(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/short-vmodel': 1.2.15(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-props': 1.0.17(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/short-vmodel': 1.2.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       '@vue/language-core': 1.8.8(typescript@5.4.4)
+    optionalDependencies:
       vue-tsc: 2.0.10(typescript@5.4.4)
     transitivePeerDependencies:
       - '@vue-macros/reactivity-transform'
@@ -12017,16 +12305,16 @@ snapshots:
 
   '@vue/devtools-api@6.6.1': {}
 
-  '@vue/devtools-applet@7.0.25(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)':
+  '@vue/devtools-applet@7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue/devtools-core': 7.0.25(vite@5.2.8)(vue@3.4.21)
-      '@vue/devtools-kit': 7.0.25(vue@3.4.21)
+      '@vue/devtools-core': 7.0.25(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-kit': 7.0.25(vue@3.4.21(typescript@5.4.4))
       '@vue/devtools-shared': 7.0.25
-      '@vue/devtools-ui': 7.0.25(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9)(vue@3.4.21)
+      '@vue/devtools-ui': 7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vue@3.4.21(typescript@5.4.4))
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
       vue: 3.4.21(typescript@5.4.4)
-      vue-virtual-scroller: 2.0.0-beta.8(vue@3.4.21)
+      vue-virtual-scroller: 2.0.0-beta.8(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@unocss/reset'
       - '@vue/composition-api'
@@ -12045,19 +12333,47 @@ snapshots:
       - unocss
       - vite
 
-  '@vue/devtools-core@7.0.25(vite@5.2.8)(vue@3.4.21)':
+  '@vue/devtools-applet@7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vue/devtools-kit': 7.0.25(vue@3.4.21)
+      '@vue/devtools-core': 7.0.25(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-kit': 7.0.25(vue@3.4.21(typescript@5.4.4))
+      '@vue/devtools-shared': 7.0.25
+      '@vue/devtools-ui': 7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vue@3.4.21(typescript@5.4.4))
+      perfect-debounce: 1.0.0
+      splitpanes: 3.1.5
+      vue: 3.4.21(typescript@5.4.4)
+      vue-virtual-scroller: 2.0.0-beta.8(vue@3.4.21(typescript@5.4.4))
+    transitivePeerDependencies:
+      - '@unocss/reset'
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - floating-vue
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - universal-cookie
+      - unocss
+      - vite
+
+  '@vue/devtools-core@7.0.25(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))':
+    dependencies:
+      '@vue/devtools-kit': 7.0.25(vue@3.4.21(typescript@5.4.4))
       '@vue/devtools-shared': 7.0.25
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.2.8)
+      vite-hot-client: 0.2.3(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
     transitivePeerDependencies:
       - vite
       - vue
 
-  '@vue/devtools-kit@7.0.25(vue@3.4.21)':
+  '@vue/devtools-kit@7.0.25(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@vue/devtools-shared': 7.0.25
       hookable: 5.5.3
@@ -12070,16 +12386,41 @@ snapshots:
     dependencies:
       rfdc: 1.3.1
 
-  '@vue/devtools-ui@7.0.25(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9)(vue@3.4.21)':
+  '@vue/devtools-ui@7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@unocss/reset': 0.58.9
-      '@vueuse/components': 10.9.0(vue@3.4.21)
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21)
+      '@vueuse/components': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/integrations': 10.9.0(change-case@4.1.2)(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21(typescript@5.4.4))
       colord: 2.9.3
-      floating-vue: 5.2.2(vue@3.4.21)
+      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4))
       focus-trap: 7.5.4
-      unocss: 0.58.9(@unocss/webpack@0.58.9)(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8)
+      unocss: 0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      vue: 3.4.21(typescript@5.4.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - universal-cookie
+
+  '@vue/devtools-ui@7.0.25(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vue@3.4.21(typescript@5.4.4))':
+    dependencies:
+      '@unocss/reset': 0.58.9
+      '@vueuse/components': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/integrations': 10.9.0(change-case@4.1.2)(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21(typescript@5.4.4))
+      colord: 2.9.3
+      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4))
+      focus-trap: 7.5.4
+      unocss: 0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -12105,8 +12446,9 @@ snapshots:
       minimatch: 9.0.3
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 5.4.4
       vue-template-compiler: 2.7.14
+    optionalDependencies:
+      typescript: 5.4.4
 
   '@vue/language-core@1.8.8(typescript@5.4.4)':
     dependencies:
@@ -12117,8 +12459,9 @@ snapshots:
       '@vue/shared': 3.4.21
       minimatch: 9.0.3
       muggle-string: 0.3.1
-      typescript: 5.4.4
       vue-template-compiler: 2.7.14
+    optionalDependencies:
+      typescript: 5.4.4
 
   '@vue/language-core@2.0.10(typescript@5.4.4)':
     dependencies:
@@ -12128,8 +12471,9 @@ snapshots:
       computeds: 0.0.1
       minimatch: 9.0.3
       path-browserify: 1.0.1
-      typescript: 5.4.4
       vue-template-compiler: 2.7.14
+    optionalDependencies:
+      typescript: 5.4.4
 
   '@vue/reactivity@3.4.21':
     dependencies:
@@ -12146,7 +12490,7 @@ snapshots:
       '@vue/shared': 3.4.21
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.21(vue@3.4.21)':
+  '@vue/server-renderer@3.4.21(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
@@ -12159,77 +12503,79 @@ snapshots:
       js-beautify: 1.14.9
       vue-component-type-helpers: 2.0.6
 
-  '@vueuse/components@10.9.0(vue@3.4.21)':
+  '@vueuse/components@10.9.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/shared': 10.9.0(vue@3.4.21)
-      vue-demi: 0.14.7(vue@3.4.21)
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/shared': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@10.8.0(vue@3.4.21)':
+  '@vueuse/core@10.8.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.8.0
-      '@vueuse/shared': 10.8.0(vue@3.4.21)
-      vue-demi: 0.14.7(vue@3.4.21)
+      '@vueuse/shared': 10.8.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@10.9.0(vue@3.4.21)':
+  '@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.9.0
-      '@vueuse/shared': 10.9.0(vue@3.4.21)
-      vue-demi: 0.14.7(vue@3.4.21)
+      '@vueuse/shared': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@9.13.0(vue@3.4.21)':
+  '@vueuse/core@9.13.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@types/web-bluetooth': 0.0.16
       '@vueuse/metadata': 9.13.0
-      '@vueuse/shared': 9.13.0(vue@3.4.21)
-      vue-demi: 0.14.7(vue@3.4.21)
+      '@vueuse/shared': 9.13.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/gesture@2.0.0(vue@3.4.21)':
+  '@vueuse/gesture@2.0.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       chokidar: 3.6.0
       consola: 3.2.3
       upath: 2.0.1
       vue: 3.4.21(typescript@5.4.4)
-      vue-demi: 0.14.7(vue@3.4.21)
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
 
-  '@vueuse/head@2.0.0(vue@3.4.21)':
+  '@vueuse/head@2.0.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@unhead/dom': 1.9.4
       '@unhead/schema': 1.9.4
       '@unhead/ssr': 1.9.4
-      '@unhead/vue': 1.9.4(vue@3.4.21)
+      '@unhead/vue': 1.9.4(vue@3.4.21(typescript@5.4.4))
       vue: 3.4.21(typescript@5.4.4)
 
-  '@vueuse/integrations@10.9.0(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21)':
+  '@vueuse/integrations@10.9.0(change-case@4.1.2)(focus-trap@7.5.4)(fuse.js@6.6.2)(idb-keyval@6.2.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/shared': 10.9.0(vue@3.4.21)
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/shared': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      change-case: 4.1.2
       focus-trap: 7.5.4
       fuse.js: 6.6.2
       idb-keyval: 6.2.1
-      vue-demi: 0.14.7(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/math@10.8.0(vue@3.4.21)':
+  '@vueuse/math@10.8.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vueuse/shared': 10.8.0(vue@3.4.21)
-      vue-demi: 0.14.7(vue@3.4.21)
+      '@vueuse/shared': 10.8.0(vue@3.4.21(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12240,67 +12586,67 @@ snapshots:
 
   '@vueuse/metadata@9.13.0': {}
 
-  '@vueuse/motion@2.1.0(rollup@4.14.0)(vue@3.4.21)':
+  '@vueuse/motion@2.1.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/shared': 10.9.0(vue@3.4.21)
+      '@vueuse/core': 10.9.0(vue@3.4.21(typescript@5.4.4))
+      '@vueuse/shared': 10.9.0(vue@3.4.21(typescript@5.4.4))
       csstype: 3.1.3
       framesync: 6.1.2
       popmotion: 11.0.5
       style-value-types: 5.1.2
       vue: 3.4.21(typescript@5.4.4)
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
       - supports-color
 
-  '@vueuse/nuxt@10.8.0(nuxt@3.11.2)(rollup@3.29.4)(vue@3.4.21)':
+  '@vueuse/nuxt@10.8.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@vueuse/core': 10.8.0(vue@3.4.21)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@vueuse/core': 10.8.0(vue@3.4.21(typescript@5.4.4))
       '@vueuse/metadata': 10.8.0
       local-pkg: 0.5.0
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
-      vue-demi: 0.14.7(vue@3.4.21)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
       - supports-color
       - vue
 
-  '@vueuse/nuxt@10.8.0(nuxt@3.11.2)(rollup@4.14.0)(vue@3.4.21)':
+  '@vueuse/nuxt@10.8.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.14.0)
-      '@vueuse/core': 10.8.0(vue@3.4.21)
+      '@vueuse/core': 10.8.0(vue@3.4.21(typescript@5.4.4))
       '@vueuse/metadata': 10.8.0
       local-pkg: 0.5.0
-      nuxt: 3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10)
-      vue-demi: 0.14.7(vue@3.4.21)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4))
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
       - supports-color
       - vue
 
-  '@vueuse/shared@10.8.0(vue@3.4.21)':
+  '@vueuse/shared@10.8.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      vue-demi: 0.14.7(vue@3.4.21)
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@10.9.0(vue@3.4.21)':
+  '@vueuse/shared@10.9.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      vue-demi: 0.14.7(vue@3.4.21)
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@9.13.0(vue@3.4.21)':
+  '@vueuse/shared@9.13.0(vue@3.4.21(typescript@5.4.4))':
     dependencies:
-      vue-demi: 0.14.7(vue@3.4.21)
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12380,6 +12726,14 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
+
+  '@xenova/transformers@2.17.1':
+    dependencies:
+      '@huggingface/jinja': 0.2.2
+      onnxruntime-web: 1.14.0
+      sharp: 0.32.6
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12533,18 +12887,18 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
-  ast-kit@0.10.0(rollup@4.14.0):
+  ast-kit@0.10.0(rollup@2.79.1):
     dependencies:
       '@babel/parser': 7.24.4
-      '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
 
-  ast-kit@0.11.2(rollup@3.29.4):
+  ast-kit@0.11.2(rollup@2.79.1):
     dependencies:
       '@babel/parser': 7.24.4
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -12553,6 +12907,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.24.4
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
+      pathe: 1.1.2
+    transitivePeerDependencies:
+      - rollup
+
+  ast-kit@0.9.5(rollup@2.79.1):
+    dependencies:
+      '@babel/parser': 7.24.4
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -12577,10 +12939,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  ast-walker-scope@0.5.0(rollup@3.29.4):
+  ast-walker-scope@0.5.0(rollup@2.79.1):
     dependencies:
       '@babel/parser': 7.24.4
-      ast-kit: 0.9.5(rollup@3.29.4)
+      ast-kit: 0.9.5(rollup@2.79.1)
     transitivePeerDependencies:
       - rollup
 
@@ -12641,6 +13003,29 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bare-events@2.2.2:
+    optional: true
+
+  bare-fs@2.3.0:
+    dependencies:
+      bare-events: 2.2.2
+      bare-path: 2.1.3
+      bare-stream: 1.0.0
+    optional: true
+
+  bare-os@2.3.0:
+    optional: true
+
+  bare-path@2.1.3:
+    dependencies:
+      bare-os: 2.3.0
+    optional: true
+
+  bare-stream@1.0.0:
+    dependencies:
+      streamx: 2.16.1
+    optional: true
+
   base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
@@ -12654,6 +13039,12 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   birpc@0.2.17: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   blurhash@2.0.5: {}
 
@@ -12684,6 +13075,11 @@ snapshots:
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -12866,6 +13262,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -13149,9 +13547,15 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.3:
     dependencies:
       type-detect: 4.0.8
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -13281,6 +13685,10 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
     optional: true
+
+  end-of-stream@1.4.4:
+    dependencies:
+      once: 1.4.0
 
   engine.io-client@6.5.3:
     dependencies:
@@ -13593,12 +14001,13 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.1.0: {}
 
-  eslint-plugin-perfectionist@2.6.0(eslint@8.57.0)(typescript@5.4.4)(vue-eslint-parser@9.4.2):
+  eslint-plugin-perfectionist@2.6.0(eslint@8.57.0)(typescript@5.4.4)(vue-eslint-parser@9.4.2(eslint@8.57.0)):
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.4)
       eslint: 8.57.0
       minimatch: 9.0.3
       natural-compare-lite: 1.4.0
+    optionalDependencies:
       vue-eslint-parser: 9.4.2(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
@@ -13636,18 +14045,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@7.2.0)(eslint@8.57.0):
+  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0)(eslint@8.57.0)(typescript@5.4.4)
       eslint: 8.57.0
       eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)
 
-  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.2.0)(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0):
+  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0)):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0)(eslint@8.57.0)(typescript@5.4.4)
       '@typescript-eslint/utils': 7.5.0(eslint@8.57.0)(typescript@5.4.4)
       eslint: 8.57.0
-      vitest: 1.4.0(happy-dom@10.5.2)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.4))(eslint@8.57.0)(typescript@5.4.4)
+      vitest: 1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13816,6 +14227,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expand-template@2.0.3: {}
+
   exponential-backoff@3.1.1: {}
 
   extend@3.0.2: {}
@@ -13897,13 +14310,25 @@ snapshots:
 
   flat@6.0.1: {}
 
+  flatbuffers@1.12.0: {}
+
   flatted@3.3.1: {}
 
-  floating-vue@5.2.2(vue@3.4.21):
+  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@floating-ui/dom': 1.1.1
       vue: 3.4.21(typescript@5.4.4)
-      vue-resize: 2.0.0-alpha.1(vue@3.4.21)
+      vue-resize: 2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+
+  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)):
+    dependencies:
+      '@floating-ui/dom': 1.1.1
+      vue: 3.4.21(typescript@5.4.4)
+      vue-resize: 2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
 
   focus-trap@7.5.4:
     dependencies:
@@ -13931,6 +14356,8 @@ snapshots:
       tslib: 2.4.0
 
   fresh@0.5.2: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.2.0:
     dependencies:
@@ -14052,6 +14479,8 @@ snapshots:
     dependencies:
       git-up: 7.0.0
 
+  github-from-package@0.0.0: {}
+
   github-reserved-names@2.0.4: {}
 
   github-slugger@2.0.0: {}
@@ -14140,6 +14569,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  guid-typescript@1.0.9: {}
 
   gzip-size@6.0.0:
     dependencies:
@@ -14829,6 +15260,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  long@4.0.0: {}
+
   longest-streak@3.1.0: {}
 
   loupe@2.3.7:
@@ -15299,6 +15732,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -15316,6 +15751,8 @@ snapshots:
   minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
 
   minipass-collect@1.0.2:
     dependencies:
@@ -15365,6 +15802,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   mkdist@1.2.0(typescript@5.4.4):
@@ -15377,6 +15816,7 @@ snapshots:
       mlly: 1.6.1
       mri: 1.2.0
       pathe: 1.1.2
+    optionalDependencies:
       typescript: 5.4.4
 
   mlly@1.6.1:
@@ -15412,6 +15852,8 @@ snapshots:
 
   nanoid@4.0.2: {}
 
+  napi-build-utils@1.0.2: {}
+
   natural-compare-lite@1.4.0: {}
 
   natural-compare@1.4.0: {}
@@ -15420,7 +15862,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nitropack@2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1):
+  nitropack@2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(encoding@0.1.13)(idb-keyval@6.2.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.1
       '@netlify/functions': 2.6.0
@@ -15433,7 +15875,7 @@ snapshots:
       '@rollup/plugin-terser': 0.4.4(rollup@4.14.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
       '@types/http-proxy': 1.17.14
-      '@vercel/nft': 0.26.4
+      '@vercel/nft': 0.26.4(encoding@0.1.13)
       archiver: 7.0.1
       c12: 1.10.0
       chalk: 5.3.0
@@ -15514,6 +15956,12 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.6.2
 
+  node-abi@3.62.0:
+    dependencies:
+      semver: 7.6.0
+
+  node-addon-api@6.1.0: {}
+
   node-addon-api@7.0.0: {}
 
   node-emoji@2.1.3:
@@ -15525,9 +15973,11 @@ snapshots:
 
   node-fetch-native@1.6.4: {}
 
-  node-fetch@2.6.12:
+  node-fetch@2.6.12(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-forge@1.3.1: {}
 
@@ -15647,9 +16097,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt-component-meta@0.6.3(rollup@3.29.4):
+  nuxt-component-meta@0.6.3(rollup@4.14.0):
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
       citty: 0.1.6
       scule: 1.3.0
       typescript: 5.4.4
@@ -15658,9 +16108,9 @@ snapshots:
       - rollup
       - supports-color
 
-  nuxt-config-schema@0.4.6(rollup@3.29.4):
+  nuxt-config-schema@0.4.6(rollup@4.14.0):
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
       defu: 6.1.4
       jiti: 1.21.0
       pathe: 1.1.2
@@ -15669,50 +16119,50 @@ snapshots:
       - rollup
       - supports-color
 
-  nuxt-csurf@1.2.0(rollup@4.14.0):
+  nuxt-csurf@1.2.0(rollup@2.79.1):
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       defu: 6.1.4
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  nuxt-icon@0.3.3(rollup@3.29.4)(vue@3.4.21):
+  nuxt-icon@0.3.3(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4)):
     dependencies:
-      '@iconify/vue': 4.1.1(vue@3.4.21)
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      nuxt-config-schema: 0.4.6(rollup@3.29.4)
+      '@iconify/vue': 4.1.1(vue@3.4.21(typescript@5.4.4))
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      nuxt-config-schema: 0.4.6(rollup@4.14.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - vue
 
-  nuxt-security@0.13.1(patch_hash=bd6cmp7ukwwiwrxafbbotwkihe)(rollup@4.14.0):
+  nuxt-security@0.13.1(patch_hash=bd6cmp7ukwwiwrxafbbotwkihe)(rollup@2.79.1):
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
       basic-auth: 2.0.1
       defu: 6.1.4
       limiter: 2.1.0
       memory-cache: 0.2.0
-      nuxt-csurf: 1.2.0(rollup@4.14.0)
+      nuxt-csurf: 1.2.0(rollup@2.79.1)
       pathe: 1.1.2
       xss: 1.0.14
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  nuxt@3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.1.5(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@3.29.4)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@nuxt/schema': 3.11.2(rollup@3.29.4)
-      '@nuxt/telemetry': 2.5.3(rollup@3.29.4)
+      '@nuxt/devtools': 1.1.5(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@2.79.1))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@2.79.1)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@nuxt/schema': 3.11.2(rollup@2.79.1)
+      '@nuxt/telemetry': 2.5.3(rollup@2.79.1)
       '@nuxt/ui-templates': 1.3.2
-      '@nuxt/vite-builder': 3.11.2(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.8.6)(eslint@8.57.0)(optionator@0.9.3)(rollup@2.79.1)(terser@5.22.0)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))
       '@unhead/dom': 1.9.4
       '@unhead/ssr': 1.9.4
-      '@unhead/vue': 1.9.4(vue@3.4.21)
+      '@unhead/vue': 1.9.4(vue@3.4.21(typescript@5.4.4))
       '@vue/shared': 3.4.21
       acorn: 8.11.3
       c12: 1.10.0
@@ -15733,7 +16183,7 @@ snapshots:
       knitwork: 1.1.0
       magic-string: 0.30.9
       mlly: 1.6.1
-      nitropack: 2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)
+      nitropack: 2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(encoding@0.1.13)(idb-keyval@6.2.1)
       nuxi: 3.11.1
       nypm: 0.3.8
       ofetch: 1.3.4
@@ -15750,15 +16200,18 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@2.79.1)
       unplugin: 1.10.1
-      unplugin-vue-router: 0.7.0(rollup@3.29.4)(vue-router@4.3.0)(vue@3.4.21)
+      unplugin-vue-router: 0.7.0(rollup@2.79.1)(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))
       unstorage: 1.10.2(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(ioredis@5.3.2)
       untyped: 1.4.2
       vue: 3.4.21(typescript@5.4.4)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.3.0(vue@3.4.21)
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      '@parcel/watcher': 2.4.1
+      '@types/node': 20.8.6
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15814,18 +16267,18 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.11.2(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(eslint@8.57.0)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(rollup@4.14.0)(typescript@5.4.4)(unocss@0.58.9)(vite@5.2.8)(vue-tsc@2.0.10):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.1.5(@unocss/reset@0.58.9)(floating-vue@5.2.2)(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2)(rollup@4.14.0)(unocss@0.58.9)(vite@5.2.8)(vue@3.4.21)
+      '@nuxt/devtools': 1.1.5(@unocss/reset@0.58.9)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.8.6)(@unocss/reset@0.58.9)(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.14.0))(vue@3.4.21(typescript@5.4.4)))(fuse.js@6.6.2)(idb-keyval@6.2.1)(ioredis@5.3.2)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)))(rollup@4.14.0)(unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)))(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))
       '@nuxt/kit': 3.11.2(rollup@4.14.0)
       '@nuxt/schema': 3.11.2(rollup@4.14.0)
       '@nuxt/telemetry': 2.5.3(rollup@4.14.0)
       '@nuxt/ui-templates': 1.3.2
-      '@nuxt/vite-builder': 3.11.2(eslint@8.57.0)(rollup@4.14.0)(typescript@5.4.4)(vue-tsc@2.0.10)(vue@3.4.21)
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.8.6)(eslint@8.57.0)(optionator@0.9.3)(rollup@4.14.0)(terser@5.22.0)(typescript@5.4.4)(vue-tsc@2.0.10(typescript@5.4.4))(vue@3.4.21(typescript@5.4.4))
       '@unhead/dom': 1.9.4
       '@unhead/ssr': 1.9.4
-      '@unhead/vue': 1.9.4(vue@3.4.21)
+      '@unhead/vue': 1.9.4(vue@3.4.21(typescript@5.4.4))
       '@vue/shared': 3.4.21
       acorn: 8.11.3
       c12: 1.10.0
@@ -15846,7 +16299,7 @@ snapshots:
       knitwork: 1.1.0
       magic-string: 0.30.9
       mlly: 1.6.1
-      nitropack: 2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)
+      nitropack: 2.9.6(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(encoding@0.1.13)(idb-keyval@6.2.1)
       nuxi: 3.11.1
       nypm: 0.3.8
       ofetch: 1.3.4
@@ -15865,13 +16318,16 @@ snapshots:
       unenv: 1.9.0
       unimport: 3.7.1(rollup@4.14.0)
       unplugin: 1.10.1
-      unplugin-vue-router: 0.7.0(rollup@4.14.0)(vue-router@4.3.0)(vue@3.4.21)
+      unplugin-vue-router: 0.7.0(rollup@4.14.0)(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))
       unstorage: 1.10.2(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(ioredis@5.3.2)
       untyped: 1.4.2
       vue: 3.4.21(typescript@5.4.4)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.3.0(vue@3.4.21)
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      '@parcel/watcher': 2.4.1
+      '@types/node': 20.8.6
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15984,6 +16440,26 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  onnx-proto@4.0.4:
+    dependencies:
+      protobufjs: 6.11.4
+
+  onnxruntime-common@1.14.0: {}
+
+  onnxruntime-node@1.14.0:
+    dependencies:
+      onnxruntime-common: 1.14.0
+    optional: true
+
+  onnxruntime-web@1.14.0:
+    dependencies:
+      flatbuffers: 1.12.0
+      guid-typescript: 1.0.9
+      long: 4.0.0
+      onnx-proto: 4.0.4
+      onnxruntime-common: 1.14.0
+      platform: 1.3.6
 
   open@10.0.3:
     dependencies:
@@ -16215,12 +16691,13 @@ snapshots:
       - sass
       - supports-color
 
-  pinia@2.1.7(typescript@5.4.4)(vue@3.4.21):
+  pinia@2.1.7(typescript@5.4.4)(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@vue/devtools-api': 6.6.1
-      typescript: 5.4.4
       vue: 3.4.21(typescript@5.4.4)
-      vue-demi: 0.14.7(vue@3.4.21)
+      vue-demi: 0.14.7(vue@3.4.21(typescript@5.4.4))
+    optionalDependencies:
+      typescript: 5.4.4
 
   pirates@4.0.6: {}
 
@@ -16229,6 +16706,8 @@ snapshots:
       jsonc-parser: 3.2.0
       mlly: 1.6.1
       pathe: 1.1.2
+
+  platform@1.3.6: {}
 
   pluralize@8.0.0: {}
 
@@ -16261,7 +16740,7 @@ snapshots:
 
   postcss-custom-properties@13.1.4(postcss@8.4.38):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 1.0.3(@csstools/css-parser-algorithms@2.3.0)(@csstools/css-tokenizer@2.1.1)
+      '@csstools/cascade-layer-name-parser': 1.0.3(@csstools/css-parser-algorithms@2.3.0(@csstools/css-tokenizer@2.1.1))(@csstools/css-tokenizer@2.1.1)
       '@csstools/css-parser-algorithms': 2.3.0(@csstools/css-tokenizer@2.1.1)
       '@csstools/css-tokenizer': 2.1.1
       postcss: 8.4.38
@@ -16416,6 +16895,21 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.2.0
 
+  prebuild-install@7.1.2:
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 1.0.2
+      node-abi: 3.62.0
+      pump: 3.0.0
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.1
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -16481,10 +16975,12 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-view: 1.32.7
 
-  prosemirror-highlight@0.5.0(prosemirror-model@1.19.4)(prosemirror-state@1.4.3)(prosemirror-view@1.32.7)(shiki@1.1.7):
-    dependencies:
+  prosemirror-highlight@0.5.0(@types/hast@3.0.4)(prosemirror-model@1.19.4)(prosemirror-state@1.4.3)(prosemirror-transform@1.8.0)(prosemirror-view@1.32.7)(shiki@1.1.7):
+    optionalDependencies:
+      '@types/hast': 3.0.4
       prosemirror-model: 1.19.4
       prosemirror-state: 1.4.3
+      prosemirror-transform: 1.8.0
       prosemirror-view: 1.32.7
       shiki: 1.1.7
 
@@ -16566,7 +17062,28 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@6.11.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      '@types/node': 20.8.6
+      long: 4.0.0
+
   protocols@2.0.1: {}
+
+  pump@3.0.0:
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
 
   punycode.js@2.3.1: {}
 
@@ -16589,6 +17106,13 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.3
       flat: 5.0.2
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-is@18.2.0: {}
 
@@ -16858,21 +17382,23 @@ snapshots:
       serialize-javascript: 4.0.0
       terser: 5.22.0
 
-  rollup-plugin-visualizer@5.12.0(rollup@3.29.4):
+  rollup-plugin-visualizer@5.12.0(rollup@2.79.1):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: 3.29.4
       source-map: 0.7.4
       yargs: 17.7.2
+    optionalDependencies:
+      rollup: 2.79.1
 
   rollup-plugin-visualizer@5.12.0(rollup@4.14.0):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: 4.14.0
       source-map: 0.7.4
       yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.14.0
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -16998,6 +17524,17 @@ snapshots:
       ico-endec: 0.1.6
       sharp: 0.33.3
 
+  sharp@0.32.6:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.3
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.2
+      semver: 7.6.0
+      simple-get: 4.0.1
+      tar-fs: 3.0.6
+      tunnel-agent: 0.6.0
+
   sharp@0.33.3:
     dependencies:
       color: 4.2.3
@@ -17059,6 +17596,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-git-hooks@2.11.1: {}
 
   simple-git@3.24.0:
@@ -17101,7 +17646,7 @@ snapshots:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
 
-  slimeform@0.9.1(vue@3.4.21):
+  slimeform@0.9.1(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       vue: 3.4.21(typescript@5.4.4)
 
@@ -17203,13 +17748,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  stale-dep@0.7.0:
+  stale-dep@0.7.0(@nuxt/kit@3.11.2(rollup@2.79.1))(@nuxt/schema@3.11.2(rollup@2.79.1)):
     dependencies:
       cac: 6.7.14
       consola: 3.2.3
       find-up: 6.3.0
       fs-extra: 11.2.0
       md5: 2.3.0
+    optionalDependencies:
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
+      '@nuxt/schema': 3.11.2(rollup@2.79.1)
 
   standard-as-callback@2.1.0: {}
 
@@ -17221,6 +17769,14 @@ snapshots:
     dependencies:
       fast-fifo: 1.3.0
       queue-tick: 1.0.1
+
+  streamx@2.16.1:
+    dependencies:
+      fast-fifo: 1.3.0
+      queue-tick: 1.0.1
+    optionalDependencies:
+      bare-events: 2.2.2
+    optional: true
 
   string-argv@0.3.2: {}
 
@@ -17312,6 +17868,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -17405,6 +17963,29 @@ snapshots:
 
   tapable@2.2.1: {}
 
+  tar-fs@2.1.1:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
+
+  tar-fs@3.0.6:
+    dependencies:
+      pump: 3.0.0
+      tar-stream: 3.1.6
+    optionalDependencies:
+      bare-fs: 2.3.0
+      bare-path: 2.1.3
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.6:
     dependencies:
       b4a: 1.6.4
@@ -17437,14 +18018,16 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.9(webpack@5.89.0):
+  terser-webpack-plugin@5.3.9(esbuild@0.20.2)(webpack@5.89.0(esbuild@0.20.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.22.0
-      webpack: 5.89.0
+      webpack: 5.89.0(esbuild@0.20.2)
+    optionalDependencies:
+      esbuild: 0.20.2
 
   terser@5.22.0:
     dependencies:
@@ -17548,6 +18131,10 @@ snapshots:
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:
@@ -17683,9 +18270,9 @@ snapshots:
       trough: 2.1.0
       vfile: 6.0.1
 
-  unimport@3.7.1(rollup@3.29.4):
+  unimport@3.7.1(rollup@2.79.1):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       acorn: 8.11.3
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -17768,9 +18355,39 @@ snapshots:
     dependencies:
       '@unlazy/core': 0.11.2
 
-  unocss@0.58.9(@unocss/webpack@0.58.9)(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8):
+  unocss@0.58.9(@unocss/webpack@0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
     dependencies:
-      '@unocss/astro': 0.58.9(rollup@4.14.0)(vite@5.2.8)
+      '@unocss/astro': 0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      '@unocss/cli': 0.58.9(rollup@2.79.1)
+      '@unocss/core': 0.58.9
+      '@unocss/extractor-arbitrary-variants': 0.58.9
+      '@unocss/postcss': 0.58.9(postcss@8.4.38)
+      '@unocss/preset-attributify': 0.58.9
+      '@unocss/preset-icons': 0.58.9
+      '@unocss/preset-mini': 0.58.9
+      '@unocss/preset-tagify': 0.58.9
+      '@unocss/preset-typography': 0.58.9
+      '@unocss/preset-uno': 0.58.9
+      '@unocss/preset-web-fonts': 0.58.9
+      '@unocss/preset-wind': 0.58.9
+      '@unocss/reset': 0.58.9
+      '@unocss/transformer-attributify-jsx': 0.58.9
+      '@unocss/transformer-attributify-jsx-babel': 0.58.9
+      '@unocss/transformer-compile-class': 0.58.9
+      '@unocss/transformer-directives': 0.58.9
+      '@unocss/transformer-variant-group': 0.58.9
+      '@unocss/vite': 0.58.9(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+    optionalDependencies:
+      '@unocss/webpack': 0.58.9(rollup@2.79.1)(webpack@5.89.0(esbuild@0.20.2))
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    transitivePeerDependencies:
+      - postcss
+      - rollup
+      - supports-color
+
+  unocss@0.58.9(@unocss/webpack@0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2)))(postcss@8.4.38)(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
+    dependencies:
+      '@unocss/astro': 0.58.9(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
       '@unocss/cli': 0.58.9(rollup@4.14.0)
       '@unocss/core': 0.58.9
       '@unocss/extractor-arbitrary-variants': 0.58.9
@@ -17789,57 +18406,60 @@ snapshots:
       '@unocss/transformer-compile-class': 0.58.9
       '@unocss/transformer-directives': 0.58.9
       '@unocss/transformer-variant-group': 0.58.9
-      '@unocss/vite': 0.58.9(rollup@4.14.0)(vite@5.2.8)
-      '@unocss/webpack': 0.58.9(rollup@4.14.0)(webpack@5.89.0)
-      vite: 5.2.8
+      '@unocss/vite': 0.58.9(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+    optionalDependencies:
+      '@unocss/webpack': 0.58.9(rollup@4.14.0)(webpack@5.89.0(esbuild@0.20.2))
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - postcss
       - rollup
       - supports-color
 
-  unplugin-combine@0.7.0(rollup@4.14.0)(vite@5.2.8)(webpack@5.89.0):
+  unplugin-combine@0.7.0(esbuild@0.20.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(webpack@5.89.0(esbuild@0.20.2)):
     dependencies:
       '@antfu/utils': 0.7.7
-      rollup: 4.14.0
       unplugin: 1.10.1
-      vite: 5.2.8
-      webpack: 5.89.0
+    optionalDependencies:
+      esbuild: 0.20.2
+      rollup: 2.79.1
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      webpack: 5.89.0(esbuild@0.20.2)
 
-  unplugin-vue-define-options@1.3.15(rollup@4.14.0)(vue@3.4.21):
+  unplugin-vue-define-options@1.3.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)):
     dependencies:
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      ast-walker-scope: 0.5.0(rollup@4.14.0)
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      ast-walker-scope: 0.5.0(rollup@2.79.1)
       unplugin: 1.10.1
     transitivePeerDependencies:
       - rollup
       - vue
 
-  unplugin-vue-macros@2.4.4(@vueuse/core@10.9.0)(rollup@4.14.0)(typescript@5.4.4)(vite@5.2.8)(vue@3.4.21)(webpack@5.89.0):
+  unplugin-vue-macros@2.4.4(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(esbuild@0.20.2)(rollup@2.79.1)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue@3.4.21(typescript@5.4.4))(webpack@5.89.0(esbuild@0.20.2)):
     dependencies:
-      '@vue-macros/better-define': 1.6.9(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/chain-call': 0.1.3(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/common': 1.7.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-emit': 0.1.13(vue@3.4.21)
-      '@vue-macros/define-models': 1.0.13(@vueuse/core@10.9.0)(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-prop': 0.2.4(vue@3.4.21)
-      '@vue-macros/define-props': 1.0.17(@vue-macros/reactivity-transform@0.3.19)(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-props-refs': 1.1.7(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-render': 1.4.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/define-slots': 1.0.12(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/devtools': 0.1.3(typescript@5.4.4)(vite@5.2.8)
-      '@vue-macros/export-expose': 0.0.10(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/export-props': 0.3.15(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/hoist-static': 1.4.9(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/jsx-directive': 0.3.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/named-template': 0.3.16(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/reactivity-transform': 0.3.19(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/setup-block': 0.2.15(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/setup-component': 0.16.16(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/setup-sfc': 0.16.0(rollup@4.14.0)(vue@3.4.21)
-      '@vue-macros/short-emits': 1.4.7(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/better-define': 1.6.9(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/chain-call': 0.1.3(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/common': 1.7.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-emit': 0.1.13(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-models': 1.0.13(@vueuse/core@10.9.0(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-prop': 0.2.4(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-props': 1.0.17(@vue-macros/reactivity-transform@0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4)))(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-props-refs': 1.1.7(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-render': 1.4.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/define-slots': 1.0.12(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/devtools': 0.1.3(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))
+      '@vue-macros/export-expose': 0.0.10(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/export-props': 0.3.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/hoist-static': 1.4.9(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/jsx-directive': 0.3.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/named-template': 0.3.16(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/reactivity-transform': 0.3.19(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/setup-block': 0.2.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/setup-component': 0.16.16(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/setup-sfc': 0.16.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      '@vue-macros/short-emits': 1.4.7(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       unplugin: 1.10.1
-      unplugin-combine: 0.7.0(rollup@4.14.0)(vite@5.2.8)(webpack@5.89.0)
-      unplugin-vue-define-options: 1.3.15(rollup@4.14.0)(vue@3.4.21)
+      unplugin-combine: 0.7.0(esbuild@0.20.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(webpack@5.89.0(esbuild@0.20.2))
+      unplugin-vue-define-options: 1.3.15(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
       vue: 3.4.21(typescript@5.4.4)
     transitivePeerDependencies:
       - '@vueuse/core'
@@ -17849,12 +18469,12 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-router@0.7.0(rollup@3.29.4)(vue-router@4.3.0)(vue@3.4.21):
+  unplugin-vue-router@0.7.0(rollup@2.79.1)(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      '@vue-macros/common': 1.8.0(rollup@3.29.4)(vue@3.4.21)
-      ast-walker-scope: 0.5.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@vue-macros/common': 1.8.0(rollup@2.79.1)(vue@3.4.21(typescript@5.4.4))
+      ast-walker-scope: 0.5.0(rollup@2.79.1)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -17863,17 +18483,18 @@ snapshots:
       pathe: 1.1.2
       scule: 1.3.0
       unplugin: 1.10.1
-      vue-router: 4.3.0(vue@3.4.21)
       yaml: 2.3.4
+    optionalDependencies:
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - rollup
       - vue
 
-  unplugin-vue-router@0.7.0(rollup@4.14.0)(vue-router@4.3.0)(vue@3.4.21):
+  unplugin-vue-router@0.7.0(rollup@4.14.0)(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@babel/types': 7.24.0
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
-      '@vue-macros/common': 1.8.0(rollup@4.14.0)(vue@3.4.21)
+      '@vue-macros/common': 1.8.0(rollup@4.14.0)(vue@3.4.21(typescript@5.4.4))
       ast-walker-scope: 0.5.0(rollup@4.14.0)
       chokidar: 3.6.0
       fast-glob: 3.3.2
@@ -17883,8 +18504,9 @@ snapshots:
       pathe: 1.1.2
       scule: 1.3.0
       unplugin: 1.10.1
-      vue-router: 4.3.0(vue@3.4.21)
       yaml: 2.3.4
+    optionalDependencies:
+      vue-router: 4.3.0(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - rollup
       - vue
@@ -17898,20 +18520,21 @@ snapshots:
 
   unstorage@1.10.2(@upstash/redis@1.27.1)(@vercel/kv@1.0.1)(idb-keyval@6.2.1)(ioredis@5.3.2):
     dependencies:
-      '@upstash/redis': 1.27.1
-      '@vercel/kv': 1.0.1
       anymatch: 3.1.3
       chokidar: 3.6.0
       destr: 2.0.3
       h3: 1.11.1
-      idb-keyval: 6.2.1
-      ioredis: 5.3.2
       listhen: 1.7.2
       lru-cache: 10.2.0
       mri: 1.2.0
       node-fetch-native: 1.6.4
       ofetch: 1.3.4
       ufo: 1.5.3
+    optionalDependencies:
+      '@upstash/redis': 1.27.1
+      '@vercel/kv': 1.0.1
+      idb-keyval: 6.2.1
+      ioredis: 5.3.2
     transitivePeerDependencies:
       - uWebSockets.js
 
@@ -18003,17 +18626,17 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-hot-client@0.2.3(vite@5.2.8):
+  vite-hot-client@0.2.3(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
     dependencies:
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
 
-  vite-node@1.4.0:
+  vite-node@1.4.0(@types/node@20.8.6)(terser@5.22.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18024,33 +18647,34 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.4(eslint@8.57.0)(typescript@5.4.4)(vite@5.2.8)(vue-tsc@2.0.10):
+  vite-plugin-checker@0.6.4(eslint@8.57.0)(optionator@0.9.3)(typescript@5.4.4)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vue-tsc@2.0.10(typescript@5.4.4)):
     dependencies:
       '@babel/code-frame': 7.24.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       chokidar: 3.6.0
       commander: 8.3.0
-      eslint: 8.57.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       npm-run-path: 4.0.1
       semver: 7.6.0
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      typescript: 5.4.4
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
+    optionalDependencies:
+      eslint: 8.57.0
+      optionator: 0.9.3
+      typescript: 5.4.4
       vue-tsc: 2.0.10(typescript@5.4.4)
 
-  vite-plugin-inspect@0.8.3(@nuxt/kit@3.11.2)(rollup@3.29.4)(vite@5.2.8):
+  vite-plugin-inspect@0.8.3(@nuxt/kit@3.11.2(rollup@2.79.1))(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/kit': 3.11.2(rollup@3.29.4)
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -18058,15 +18682,16 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.11.2(rollup@2.79.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.3(@nuxt/kit@3.11.2)(rollup@4.14.0)(vite@5.2.8):
+  vite-plugin-inspect@0.8.3(@nuxt/kit@3.11.2(rollup@4.14.0))(rollup@4.14.0)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/kit': 3.11.2(rollup@4.14.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.14.0)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
@@ -18075,23 +18700,25 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.11.2(rollup@4.14.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-pwa@0.19.2(vite@5.2.8)(workbox-build@7.0.0)(workbox-window@7.0.0):
+  vite-plugin-pwa@0.19.2(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(workbox-build@7.0.0)(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.4
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
       workbox-build: 7.0.0
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@4.0.2(vite@5.2.8):
+  vite-plugin-vue-inspector@4.0.2(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.24.4)
@@ -18102,21 +18729,23 @@ snapshots:
       '@vue/compiler-dom': 3.4.21
       kolorist: 1.8.0
       magic-string: 0.30.9
-      vite: 5.2.8
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.2.8:
+  vite@5.2.8(@types/node@20.8.6)(terser@5.22.0):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.14.0
     optionalDependencies:
+      '@types/node': 20.8.6
       fsevents: 2.3.3
+      terser: 5.22.0
 
-  vitest-environment-nuxt@1.0.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@4.14.0)(vite@5.2.8)(vitest@1.4.0)(vue-router@4.3.0)(vue@3.4.21):
+  vitest-environment-nuxt@1.0.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4)):
     dependencies:
-      '@nuxt/test-utils': 3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@4.14.0)(vite@5.2.8)(vitest@1.4.0)(vue-router@4.3.0)(vue@3.4.21)
+      '@nuxt/test-utils': 3.12.0(@vue/test-utils@2.4.5)(h3@1.11.1)(happy-dom@10.5.2)(rollup@2.79.1)(vite@5.2.8(@types/node@20.8.6)(terser@5.22.0))(vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0))(vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)))(vue@3.4.21(typescript@5.4.4))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -18135,7 +18764,7 @@ snapshots:
       - vue
       - vue-router
 
-  vitest@1.4.0(happy-dom@10.5.2):
+  vitest@1.4.0(@types/node@20.8.6)(happy-dom@10.5.2)(terser@5.22.0):
     dependencies:
       '@vitest/expect': 1.4.0
       '@vitest/runner': 1.4.0
@@ -18146,7 +18775,6 @@ snapshots:
       chai: 4.3.10
       debug: 4.3.4
       execa: 8.0.1
-      happy-dom: 10.5.2
       local-pkg: 0.5.0
       magic-string: 0.30.9
       pathe: 1.1.2
@@ -18155,9 +18783,12 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.5.1
       tinypool: 0.8.2
-      vite: 5.2.8
-      vite-node: 1.4.0
+      vite: 5.2.8(@types/node@20.8.6)(terser@5.22.0)
+      vite-node: 1.4.0(@types/node@20.8.6)(terser@5.22.0)
       why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 20.8.6
+      happy-dom: 10.5.2
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18190,7 +18821,7 @@ snapshots:
 
   vscode-uri@3.0.7: {}
 
-  vue-advanced-cropper@2.8.8(vue@3.4.21):
+  vue-advanced-cropper@2.8.8(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       classnames: 2.3.2
       debounce: 1.2.1
@@ -18206,14 +18837,15 @@ snapshots:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.4.4)
       path-browserify: 1.0.1
-      typescript: 5.4.4
       vue-component-type-helpers: 1.8.27
+    optionalDependencies:
+      typescript: 5.4.4
 
   vue-component-type-helpers@1.8.27: {}
 
   vue-component-type-helpers@2.0.6: {}
 
-  vue-demi@0.14.7(vue@3.4.21):
+  vue-demi@0.14.7(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       vue: 3.4.21(typescript@5.4.4)
 
@@ -18232,22 +18864,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@9.9.1(vue@3.4.21):
+  vue-i18n@9.9.1(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@intlify/core-base': 9.9.1
       '@intlify/shared': 9.9.1
       '@vue/devtools-api': 6.6.1
       vue: 3.4.21(typescript@5.4.4)
 
-  vue-observe-visibility@2.0.0-alpha.1(vue@3.4.21):
+  vue-observe-visibility@2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       vue: 3.4.21(typescript@5.4.4)
 
-  vue-resize@2.0.0-alpha.1(vue@3.4.21):
+  vue-resize@2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       vue: 3.4.21(typescript@5.4.4)
 
-  vue-router@4.3.0(vue@3.4.21):
+  vue-router@4.3.0(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       '@vue/devtools-api': 6.6.1
       vue: 3.4.21(typescript@5.4.4)
@@ -18264,20 +18896,21 @@ snapshots:
       semver: 7.6.0
       typescript: 5.4.4
 
-  vue-virtual-scroller@2.0.0-beta.8(vue@3.4.21):
+  vue-virtual-scroller@2.0.0-beta.8(vue@3.4.21(typescript@5.4.4)):
     dependencies:
       mitt: 2.1.0
       vue: 3.4.21(typescript@5.4.4)
-      vue-observe-visibility: 2.0.0-alpha.1(vue@3.4.21)
-      vue-resize: 2.0.0-alpha.1(vue@3.4.21)
+      vue-observe-visibility: 2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4))
+      vue-resize: 2.0.0-alpha.1(vue@3.4.21(typescript@5.4.4))
 
   vue@3.4.21(typescript@5.4.4):
     dependencies:
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/runtime-dom': 3.4.21
-      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/server-renderer': 3.4.21(vue@3.4.21(typescript@5.4.4))
       '@vue/shared': 3.4.21
+    optionalDependencies:
       typescript: 5.4.4
 
   w3c-keyname@2.2.8: {}
@@ -18299,7 +18932,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.1: {}
 
-  webpack@5.89.0:
+  webpack@5.89.0(esbuild@0.20.2):
     dependencies:
       '@types/eslint-scope': 3.7.6
       '@types/estree': 1.0.5
@@ -18322,7 +18955,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(esbuild@0.20.2)(webpack@5.89.0(esbuild@0.20.2))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
This feature adds a Copilot-AI to the image-alt-text editor so it is possible to click a button that just generates an example text for the image.

https://github.com/elk-zone/elk/assets/7195563/47e99e73-7fe2-4234-bdca-672016be0636

Open TODOs:

- [ ] Style the button so it is inside the textarea in the upper right corner and looks like in VSCode commit title field
- [ ] Add a warning to inform the user that this feature will download ~250 MiB into the browsers cache
  _The download will only be done when the user confirms_
- [ ] Display error messages if something went wrong
- [ ] `props.attachment.url` might not be usable due to cors error?!