### PR TITLE
docs: add crab.bumscode.com to list of community elk deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These are known deployments using Elk as an alternative Web client for Mastodon 
 - [elk.mstdn.ca](https://elk.mstdn.ca) - Use Elk for the `mstdn.ca` Server
 - [elk.mastodonapp.uk](https://elk.mastodonapp.uk) - Use Elk for the `mastodonapp.uk` Server
 - [elk.bolha.us](https://elk.bolha.us) - Use Elk for the `bolha.us` Server
+- [crab.bumscode.com](https://crab.bumscode.com) - Use [crab](https://github.com/maybeanerd/crab) - a soft fork of Elk - for the `bumscode.com` Server
 
 > **Note**: Community deployments are **NOT** maintained by the Elk team. It may not be synced with Elk's source code. Please do your own research about the host servers before using them.
 


### PR DESCRIPTION
this adds our deployment of elk to the list of community deployments

Not sure if it's okay, as it's a soft fork and not vanilla elk, but I thought It'd be nice to show that you can even deploy a slight variation of elk without much effort