### PR TITLE
fix(ui): change apple app status bar style

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -261,7 +261,7 @@ export default defineNuxtConfig({
         { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
       ],
       meta: [
-        { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+        { name: 'apple-mobile-web-app-status-bar-style', content: 'default' },
         // open graph social image
         { property: 'og:title', content: 'Elk' },
         { property: 'og:description', content: 'A nimble Mastodon web client' },

--- a/plugins/color-mode.ts
+++ b/plugins/color-mode.ts
@@ -12,7 +12,7 @@ export default defineNuxtPlugin(() => {
       {
         id: 'apple-mobile-web-app-status-bar-style',
         name: 'apple-mobile-web-app-status-bar-style',
-        content: () => 'default'
+        content: () => 'default',
       }],
   })
 })

--- a/plugins/color-mode.ts
+++ b/plugins/color-mode.ts
@@ -13,6 +13,7 @@ export default defineNuxtPlugin(() => {
         id: 'apple-mobile-web-app-status-bar-style',
         name: 'apple-mobile-web-app-status-bar-style',
         content: () => 'default',
-      }],
+      },
+    ],
   })
 })

--- a/plugins/color-mode.ts
+++ b/plugins/color-mode.ts
@@ -3,17 +3,10 @@ import { THEME_COLORS } from '~/constants'
 export default defineNuxtPlugin(() => {
   const colorMode = useColorMode()
   useHead({
-    meta: [
-      {
-        id: 'theme-color',
-        name: 'theme-color',
-        content: () => colorMode.value === 'dark' ? THEME_COLORS.themeDark : THEME_COLORS.themeLight,
-      },
-      {
-        id: 'apple-mobile-web-app-status-bar-style',
-        name: 'apple-mobile-web-app-status-bar-style',
-        content: () => 'default',
-      },
-    ],
+    meta: [{
+      id: 'theme-color',
+      name: 'theme-color',
+      content: () => colorMode.value === 'dark' ? THEME_COLORS.themeDark : THEME_COLORS.themeLight,
+    }],
   })
 })

--- a/plugins/color-mode.ts
+++ b/plugins/color-mode.ts
@@ -3,10 +3,16 @@ import { THEME_COLORS } from '~/constants'
 export default defineNuxtPlugin(() => {
   const colorMode = useColorMode()
   useHead({
-    meta: [{
-      id: 'theme-color',
-      name: 'theme-color',
-      content: () => colorMode.value === 'dark' ? THEME_COLORS.themeDark : THEME_COLORS.themeLight,
-    }],
+    meta: [
+      {
+        id: 'theme-color',
+        name: 'theme-color',
+        content: () => colorMode.value === 'dark' ? THEME_COLORS.themeDark : THEME_COLORS.themeLight,
+      },
+      {
+        id: 'apple-mobile-web-app-status-bar-style',
+        name: 'apple-mobile-web-app-status-bar-style',
+        content: () => 'default'
+      }],
   })
 })


### PR DESCRIPTION
![image](https://github.com/elk-zone/elk/assets/82600264/928891b0-ede1-437d-b52c-cc19fd6688c0)

On my iPhone, with a PWA, the status bar is always white, which makes it unreadable in white mode.

In this PR, I try to get this to work with the selected theme.

Because I don't know how to debug it differently, I'll use the hosted PR example to test.

Closes #2384