### PR TITLE
fix(ui): profile name gets cut off by roles

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -189,7 +189,6 @@ async function copyAccountName() {
         <div flex="~ col gap1" pt2>
           <div flex gap2 items-center flex-wrap>
             <AccountDisplayName :account="account" font-bold sm:text-2xl text-xl />
-            <AccountRolesIndicator v-if="account.roles?.length" :account="account" />
             <AccountLockIndicator v-if="account.locked" show-label />
             <AccountBotIndicator v-if="account.bot" show-label />
           </div>
@@ -201,6 +200,9 @@ async function copyAccountName() {
                 <span sr-only>{{ $t('account.copy_account_name') }}</span>
               </button>
             </CommonTooltip>
+          </div>
+          <div self-start mt-1>
+            <AccountRolesIndicator v-if="account.roles?.length" :account="account" />
           </div>
         </div>
       </div>

--- a/components/account/AccountHoverCard.vue
+++ b/components/account/AccountHoverCard.vue
@@ -12,7 +12,7 @@ const relationship = useRelationship(account)
   <div v-show="relationship" flex="~ col gap2" rounded min-w-90 max-w-120 z-100 overflow-hidden p-4>
     <div flex="~ gap2" items-center>
       <NuxtLink :to="getAccountRoute(account)" flex-auto rounded-full hover:bg-active transition-100 pe5 me-a>
-        <AccountInfo :account="account" />
+        <AccountInfo :account="account" :hover-card="true" />
       </NuxtLink>
       <AccountFollowButton text-sm :account="account" :relationship="relationship" />
     </div>

--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -16,18 +16,21 @@ const { account, as = 'div' } = defineProps<{
 <!-- TODO: Make this work for both buttons and links -->
 <!-- This is sometimes (like in the sidebar) used directly as a button, and sometimes, like in follow notifications, as a link. I think this component may need a second refactor that either lets an implementation pass in a link or an action and adapt to what's passed in, or the implementations need to be updated to wrap in the action they want to take and this be just the layout for these items -->
 <template>
-  <component :is="as" flex gap-3 v-bind="$attrs">
+  <component :is="as" flex items-center gap-3 v-bind="$attrs">
     <AccountHoverWrapper :disabled="!hoverCard" :account="account">
       <AccountBigAvatar :account="account" shrink-0 :square="square" />
     </AccountHoverWrapper>
-    <div flex="~ col" shrink pt-1 h-full overflow-hidden justify-center leading-none select-none>
+    <div flex="~ col" shrink h-full overflow-hidden justify-center leading-none select-none p-1>
       <div flex="~" gap-2>
         <AccountDisplayName :account="account" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
-        <AccountRolesIndicator v-if="account.roles?.length" :account="account" :limit="1" />
         <AccountLockIndicator v-if="account.locked" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
+        <AccountRolesIndicator v-if="hoverCard && account.roles?.length" :account="account" :limit="1" />
       </div>
       <AccountHandle :account="account" text-secondary-light />
+      <div v-if="!hoverCard" self-start mt-1>
+        <AccountRolesIndicator v-if="account.roles?.length" :account="account" :limit="1" />
+      </div>
     </div>
   </component>
 </template>

--- a/components/account/AccountInfo.vue
+++ b/components/account/AccountInfo.vue
@@ -25,10 +25,9 @@ const { account, as = 'div' } = defineProps<{
         <AccountDisplayName :account="account" font-bold line-clamp-1 ws-pre-wrap break-all text-lg />
         <AccountLockIndicator v-if="account.locked" text-xs />
         <AccountBotIndicator v-if="account.bot" text-xs />
-        <AccountRolesIndicator v-if="hoverCard && account.roles?.length" :account="account" :limit="1" />
       </div>
       <AccountHandle :account="account" text-secondary-light />
-      <div v-if="!hoverCard" self-start mt-1>
+      <div self-start mt-1>
         <AccountRolesIndicator v-if="account.roles?.length" :account="account" :limit="1" />
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixes the UI issue with the profile name getting cut off when the user has roles.

On the bottom-left profile card, the roles UI was moved to be below the username.

It _could_ be in-between the name and username, but because this is a list of roles, for some users that list would look better as the last list item.

### Minor tweaks

For this taller profile info card, the avatar was centered. `AccountHoverCard.vue` originally was not using the `hoverCard` prop on `AccountInfo.vue`, this was added since the hover card has the space to show roles inline with the profile name.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/ef2ba45c-1bdb-4327-8ac5-6de84f885fca)

After:

![image](https://github.com/user-attachments/assets/8f97ecb4-2147-48dd-aa52-53e70081ed6b)

The hover card remains untouched since it has the extra space:

![image](https://github.com/user-attachments/assets/371511b8-92ae-4428-96a2-64a2adcaf3d6)

Mobile:

![image](https://github.com/user-attachments/assets/4485759e-b3d8-4f9e-b87b-1b8db5699fc2)

Multiple users:

![image](https://github.com/user-attachments/assets/d573f53d-cdcc-4a02-99e3-aacffc82056c)

## Misc

- [X] Linted
- [X] Passed tests

fixes: #2914 