### PR TITLE
refactor: remove redundant imports

### DIFF
--- a/components/modal/ModalConfirm.vue
+++ b/components/modal/ModalConfirm.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { ConfirmDialogChoice, ConfirmDialogOptions } from '~/types'
-import DurationPicker from '~/components/modal/DurationPicker.vue'
 
 const props = defineProps<ConfirmDialogOptions>()
 

--- a/components/tiptap/TiptapEmojiList.vue
+++ b/components/tiptap/TiptapEmojiList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getEmojiMatchesInText } from '@iconify/utils/lib/emoji/replace/find'
-import CommonScrollIntoView from '../common/CommonScrollIntoView.vue'
 import type { CustomEmoji, Emoji } from '~/composables/tiptap/suggestion'
 import { isCustomEmoji } from '~/composables/tiptap/suggestion'
 import { emojiFilename, emojiPrefix, emojiRegEx } from '~~/config/emojis'

--- a/components/tiptap/TiptapHashtagList.vue
+++ b/components/tiptap/TiptapHashtagList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
-import CommonScrollIntoView from '../common/CommonScrollIntoView.vue'
 import type { CommandHandler } from '~/composables/command'
 
 const { items, command } = defineProps<{

--- a/components/tiptap/TiptapMentionList.vue
+++ b/components/tiptap/TiptapMentionList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
-import CommonScrollIntoView from '../common/CommonScrollIntoView.vue'
 import type { CommandHandler } from '~/composables/command'
 
 const { items, command } = defineProps<{


### PR DESCRIPTION
## Description

This PR removes redundant imports from several components to improve code cleanliness and maintainability.

### Changes

- Removed `DurationPicker` import from `ModalConfirm.vue`
- Removed `CommonScrollIntoView` import from:
  - `TiptapEmojiList.vue`
  - `TiptapHashtagList.vue`
  - `TiptapMentionList.vue`

These imports are unnecessary due to Nuxt's Auto Import feature, which automatically imports components.

## Motivation and Context

Keeping our codebase clean and free of unused imports helps improve:

1. Code readability
2. Maintainability