### PR TITLE
Enable auto-import for composables

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,10 +71,11 @@ export default defineNuxtConfig({
   },
   imports: {
     dirs: [
-      './composables/masto',
-      './composables/push-notifications',
+      './composables/masto/*',
+      './composables/push-notifications/*',
       './composables/settings',
-      './composables/tiptap/index.ts',
+      './composables/tiptap/*',
+      './composables/idb',
     ],
     imports: [{
       name: 'useI18n',
@@ -276,8 +277,7 @@ export default defineNuxtConfig({
     },
   },
 
-  // eslint-disable-next-line ts/ban-ts-comment
-  // @ts-ignore nuxt-security is conditional
+  // @ts-expect-error nuxt-security is conditional
   security: {
     headers: {
       crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
This PR enables auto-import for composables. This will simplify import statements in each component, improving code readability.

This change depends on the next PR, "Remove redundant imports." Please merge this PR first.