### PR TITLE
fix: fix invalid permissions-policy value for fullscreen

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -299,7 +299,7 @@ export default defineNuxtConfig({
         'upgrade-insecure-requests': true,
       },
       permissionsPolicy: {
-        fullscreen: ['\'self\'', 'https:', 'http:'],
+        fullscreen: '*',
       },
     },
     rateLimiter: false,


### PR DESCRIPTION
fix #2935

The current Elk responds to the request with an invalid value in the `Permissions-Policy` HTTP Header.

This PR replaced the value with `*`, which is the correct value to allow the fullscreen feature for all domains:

```diff
-Permissions-Policy camera=(), display-capture=(), fullscreen='self' https: http:, geolocation=(), microphone=()
+Permissions-Policy camera=(), display-capture=(), fullscreen=*, geolocation=(), microphone=()
```

References:
- [Permissions-Policy - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#examples)
- [webappsec-permissions-policy/permissions-policy-explainer.md at main · w3c/webappsec-permissions-policy](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md)
- [Controlling browser features with Permissions Policy  |  Privacy & Security  |  Chrome for Developers](https://developer.chrome.com/docs/privacy-security/permissions-policy)