### PR TITLE
perf: reduce timeline limit on slow connection

### DIFF
--- a/components/timeline/TimelineHome.vue
+++ b/components/timeline/TimelineHome.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const paginator = useMastoClient().v1.timelines.home.list({ limit: 30 })
+const { isSupported, effectiveType } = useNetwork()
+const isSlow = computed(() => isSupported.value && effectiveType.value && ['slow-2g', '2g', '3g'].includes(effectiveType.value))
+const limit = computed(() => isSlow.value ? 10 : 30)
+
+const paginator = useMastoClient().v1.timelines.home.list({ limit: limit.value })
 const stream = useStreaming(client => client.user.subscribe())
 function reorderAndFilter(items: mastodon.v1.Status[]) {
   return reorderedTimeline(items, 'home')


### PR DESCRIPTION
This reduces the limit for timeline post to 10 when used on slow connection

with this change:
![image](https://github.com/user-attachments/assets/f5c88335-3fd5-4813-aa3e-e18638ccbfd2)

without this change:
![image](https://github.com/user-attachments/assets/c3d77f00-4957-4fdf-b755-f7840fc766c3)
