### PR TITLE
fix(ui): bind attributes to `PublishWidgetList` list

### DIFF
--- a/components/publish/PublishWidgetList.vue
+++ b/components/publish/PublishWidgetList.vue
@@ -37,6 +37,7 @@ function isFirstItem(index: number) {
   <template v-if="isHydrated && currentUser">
     <PublishWidget
       v-for="(_, index) in threadItems" :key="`${draftKey}-${index}`"
+      v-bind="$attrs"
       :draft-key="draftKey"
       :draft-item-index="index"
       :expanded="isFirstItem(index) ? expanded : true"

--- a/pages/[[server]]/@[account]/[status].vue
+++ b/pages/[[server]]/@[account]/[status].vue
@@ -88,7 +88,7 @@ onReactivated(() => {
           <PublishWidgetList
             v-if="currentUser"
             ref="publishWidget"
-            border="y base"
+            class="border-y border-base"
             :draft-key="replyDraft!.key"
             :initial="replyDraft!.draft"
             @published="refreshContext()"


### PR DESCRIPTION
This PR removes the warning in `PublishWodgetList` SFC about `class` attribute: https://github.com/elk-zone/elk/pull/2946#pullrequestreview-2297350986

(there was another warning about `@published` listener: maybe the cause some publish not being refreshed once published)

I have no idea if we should add `class` attr to all entries: `@published` should