### PR TITLE
fix(ui): generate only one thread composer in `PublishWidgetList` and provide it to each widget

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -5,6 +5,7 @@ import type { mastodon } from 'masto'
 import type { DraftItem } from '~/types'
 
 const {
+  threadComposer,
   draftKey,
   draftItemIndex,
   expanded = false,
@@ -15,6 +16,7 @@ const {
   draftKey: string
   draftItemIndex: number
   initial?: () => DraftItem
+  threadComposer?: ReturnType<typeof useThreadComposer>
   placeholder?: string
   inReplyToId?: string
   inReplyToVisibility?: mastodon.v1.StatusVisibility
@@ -28,7 +30,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const { threadItems, threadIsActive, publishThread } = useThreadComposer(draftKey)
+const { threadItems, threadIsActive, publishThread } = threadComposer ?? useThreadComposer(draftKey)
 
 const draft = computed({
   get: () => threadItems.value[draftItemIndex],

--- a/components/publish/PublishWidgetList.vue
+++ b/components/publish/PublishWidgetList.vue
@@ -20,9 +20,8 @@ const {
   dialogLabelledBy?: string
 }>()
 
-const threadItems = computed(() =>
-  useThreadComposer(draftKey, initial).threadItems.value,
-)
+const threadComposer = useThreadComposer(draftKey, initial)
+const threadItems = computed(() => threadComposer.threadItems.value)
 
 onDeactivated(() => {
   clearEmptyDrafts()
@@ -38,6 +37,7 @@ function isFirstItem(index: number) {
     <PublishWidget
       v-for="(_, index) in threadItems" :key="`${draftKey}-${index}`"
       v-bind="$attrs"
+      :thread-composer="threadComposer"
       :draft-key="draftKey"
       :draft-item-index="index"
       :expanded="isFirstItem(index) ? expanded : true"


### PR DESCRIPTION
This PR builds the composer in the list sfc and pass it to each widget: the widget will use the provided or build a new one composer depending on the new optional `thread-composer` prop.

(fixes the vue setup warning from this https://github.com/elk-zone/elk/pull/2946#pullrequestreview-2297350986)

@patak-dev @danielroe @shuuji3 I didn't did anything about the composer logic, maybe you can help me to test this PR properly

![imagen](https://github.com/user-attachments/assets/d33fb9f6-a084-454f-b341-5db3524ae15e)
