### PR TITLE
fix: add new service worker

### DIFF
--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -7,7 +7,7 @@ export const pwa: VitePWANuxtOptions = {
   disable: /* temporarily test in CI isPreview || */ (isDevelopment && process.env.VITE_DEV_PWA !== 'true'),
   scope: '/',
   srcDir: './service-worker',
-  filename: 'sw.ts',
+  filename: 'elk-sw.ts',
   strategies: 'injectManifest',
   injectRegister: false,
   includeManifestIcons: false,

--- a/modules/pwa/index.ts
+++ b/modules/pwa/index.ts
@@ -202,6 +202,11 @@ export default defineNuxtModule<VitePWANuxtOptions>({
             'Cache-Control': 'public, max-age=0, must-revalidate',
           },
         }
+        nitroConfig.routeRules!['/elk-sw.js'] = {
+          headers: {
+            'Cache-Control': 'public, max-age=0, must-revalidate',
+          },
+        }
         for (const locale of pwaLocales) {
           nitroConfig.routeRules![`/manifest-${locale.code}.webmanifest`] = {
             headers: {

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -20,7 +20,7 @@ function handleShowCommit() {
   <MainContent back-on-small-screen>
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.about.label') }}</span>
+        <span>{{ $t('settings.about.label') }}X</span>
       </div>
     </template>
 

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -20,7 +20,7 @@ function handleShowCommit() {
   <MainContent back-on-small-screen>
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.about.label') }}X</span>
+        <span>{{ $t('settings.about.label') }}</span>
       </div>
     </template>
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,24 @@
+// DON'T REMOVE THIS FILE: IT IS THE OLD sw.js
+self.addEventListener('install', (e) => {
+    self.skipWaiting();
+});
+self.addEventListener('activate', (e) => {
+    self.registration.unregister()
+        .then(() => self.clients.matchAll())
+        .then((clients) => {
+            clients.forEach((client) => {
+                if (client instanceof WindowClient)
+                    client.navigate(client.url);
+            });
+            return Promise.resolve();
+        })
+        .then(() => {
+            self.caches.keys().then((cacheNames) => {
+                Promise.all(
+                    cacheNames.map((cacheName) => {
+                        return self.caches.delete(cacheName);
+                    })
+                );
+            })
+        });
+});

--- a/service-worker/elk-sw.ts
+++ b/service-worker/elk-sw.ts
@@ -43,6 +43,7 @@ if (import.meta.env.PROD) {
     /^\/emojis\//,
     // exclude sw: if the user navigates to it, fallback to index.html
     /^\/sw.js$/,
+    /^\/elk-sw.js$/,
     // exclude webmanifest: has its own cache
     /^\/manifest-(.*).webmanifest$/,
   ]


### PR DESCRIPTION
This is related to #2970 , we will need to:
- remove old service worker
- install a new service worker

Since any client still being controlled by old service worker, the UI is missing and the new service worker cannot be activated (once installed), it will be awaiting to be activated. The user should reopen the browser and visit elk again to activate the new service worker (since we don't have the UI the user maybe close the browser before the new sw is installed and so the problem still there).

I'm going to remove the current  service worker and install a new one: https://vite-pwa-org.netlify.app/guide/unregister-service-worker.html#custom-selfdestroying-service-worker