### PR TITLE
fix(ui): Avoid duplicate IDs for grouped notifications

### DIFF
--- a/components/notification/NotificationPaginator.vue
+++ b/components/notification/NotificationPaginator.vue
@@ -15,6 +15,8 @@ const groupCapacity = Number.MAX_VALUE // No limit
 
 const includeNotificationTypes: mastodon.v1.NotificationType[] = ['update', 'mention', 'poll', 'status']
 
+let id = 0
+
 function includeNotificationsForStatusCard({ type, status }: mastodon.v1.Notification) {
   // Exclude update, mention, pool and status notifications without the status entry:
   // no makes sense to include them
@@ -44,7 +46,6 @@ function hasHeader(account: mastodon.v1.Account) {
 function groupItems(items: mastodon.v1.Notification[]): NotificationSlot[] {
   const results: NotificationSlot[] = []
 
-  let id = 0
   let currentGroupId = ''
   let currentGroup: mastodon.v1.Notification[] = []
   const processGroup = () => {


### PR DESCRIPTION
Steps to reproduce are in https://github.com/elk-zone/elk/issues/2216#issuecomment-2424229983. This fixes #2216 and #2889.

The issue here is function `groupItems` issuing identical IDs for different objects. In the first update it creates a `GroupedLikeNotifications` instance with ID `grouped-0`. Then we get a second update, and it again creates a `GroupedLikeNotifications` instance with ID `grouped-0`. Since both have the same key, Vue attempts to reuse the existing node for the new object. It replaces the existing `vnode` in `StatusBody` by one that belongs to a different status, and it fails miserably updating the display. So we get a correct internal structure but a completely messed up display. The solution is using a global ID counter, so that this function never re-issues the same ID.