### PR TITLE
fix: Do not require Git for development

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -32,22 +32,25 @@ export async function getGitInfo() {
   let branch
   try {
     branch = gitBranch || await git.revparse(['--abbrev-ref', 'HEAD'])
-  } catch (e) {
-    branch = "unknown"
+  }
+  catch {
+    branch = 'unknown'
   }
 
   let commit
   try {
     commit = await git.revparse(['HEAD'])
-  } catch (e) {
-    commit = "unknown"
+  }
+  catch {
+    commit = 'unknown'
   }
 
   let shortCommit
   try {
     shortCommit = await git.revparse(['--short=7', 'HEAD'])
-  } catch (e) {
-    shortCommit = "unknown"
+  }
+  catch {
+    shortCommit = 'unknown'
   }
 
   return { branch, commit, shortCommit }

--- a/config/env.ts
+++ b/config/env.ts
@@ -29,9 +29,27 @@ export const isPreview = isPR || process.env.CONTEXT === 'deploy-preview' || pro
 
 const git = Git()
 export async function getGitInfo() {
-  const branch = gitBranch || await git.revparse(['--abbrev-ref', 'HEAD'])
-  const commit = await git.revparse(['HEAD'])
-  const shortCommit = await git.revparse(['--short=7', 'HEAD'])
+  let branch
+  try {
+    branch = gitBranch || await git.revparse(['--abbrev-ref', 'HEAD'])
+  } catch (e) {
+    branch = "unknown"
+  }
+
+  let commit
+  try {
+    commit = await git.revparse(['HEAD'])
+  } catch (e) {
+    commit = "unknown"
+  }
+
+  let shortCommit
+  try {
+    shortCommit = await git.revparse(['--short=7', 'HEAD'])
+  } catch (e) {
+    shortCommit = "unknown"
+  }
+
   return { branch, commit, shortCommit }
 }
 


### PR DESCRIPTION
Running `pnpm nuxt prepare` currently fails for me:

```
ERROR  fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

That’s because the directory in question isn’t a Git repository.

Running from a Git repository or even having Git installed shouldn’t be a requirement. With my change errors originating from Git are ignored. The potential impact is negligible.