### PR TITLE
fix(i18n): Allowed translating "No posts here" text

### DIFF
--- a/components/timeline/TimelinePaginator.vue
+++ b/components/timeline/TimelinePaginator.vue
@@ -55,7 +55,7 @@ const showOriginSite = computed(() =>
             {{ $t('menu.open_in_original_site') }}
           </NuxtLink>
         </template>
-        <span v-else-if="items.length === 0">No posts here!</span>
+        <span v-else-if="items.length === 0">{{ $t('timeline.no_posts') }}</span>
       </div>
     </template>
   </CommonPaginator>

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -705,6 +705,7 @@
     "year_past": "vor 0 Jahren|letztes Jahren|vor {n} Jahren"
   },
   "timeline": {
+    "no_posts": "Noch keine Beiträge hier!",
     "show_new_items": "Zeige {v} neue Beiträge|Zeige {v} neuen Beitrag|Zeige {v} neue Beiträge",
     "view_older_posts": "Ältere Beiträge aus anderen Instanzen werden möglicherweise nicht angezeigt."
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -713,6 +713,7 @@
     "year_past": "0 years ago|last year|{n} years ago"
   },
   "timeline": {
+    "no_posts": "No posts here!",
     "show_new_items": "Show {v} new items|Show {v} new item|Show {v} new items",
     "view_older_posts": "Older posts from other instances may not be displayed."
   },


### PR DESCRIPTION
See https://elk.zone/universeodon.com/@test, the text “No posts here!” will currently show up even if your interface language is non-English. This text cannot be translated.

This PR makes it translatable, which can be tested in German.