### PR TITLE
feat: support wider emoji

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -40,7 +40,7 @@ body {
 .iconify-emoji {
   display: inline-block;
   height: 1.2em;
-  width: 1.2em;
+  max-width: 100%;
   margin-right: 0.075em;
   margin-left: 0.075em;
   object-fit: contain;


### PR DESCRIPTION
resolve #3027 

## Before

![screenshot of the post showing wider emoji in wrong squashed ratio](https://github.com/user-attachments/assets/ae372e17-6a16-4567-af85-5f66a62a28f8)


## After

![screenshot of the post showing wider emoji in correct ratio](https://github.com/user-attachments/assets/13299b16-5022-4d43-ac6b-42921deadfef)
