### PR TITLE
fix: remove extra margins before tags

### DIFF
--- a/composables/content-parse.ts
+++ b/composables/content-parse.ts
@@ -90,6 +90,11 @@ export function parseMastodonHTML(
     inReplyToStatus,
   } = options
 
+  // remove newline before Tags
+  html = html.replace(/\n(<[^>]+>)/g, (_1, raw) => {
+    return raw
+  })
+
   if (markdown) {
     // Handle code blocks
     html = html


### PR DESCRIPTION
Finds all HTML tags immediately following a line break (e.g., `\n<div>`) with a regular expression and removes those line breaks, making the HTML output more compact and removing unnecessary whitespace characters. 

fix #3032 