### PR TITLE
docs: add primary light theme to fix color contrast

### DIFF
--- a/docs/tokens.config.ts
+++ b/docs/tokens.config.ts
@@ -1,8 +1,17 @@
 import { defineTheme } from 'pinceau'
 import { getColors } from 'theme-colors'
 
+const light = getColors('#995e1b')
+const primary = Object
+  .entries(getColors('#d98018'))
+  .reduce((acc, [key, value]) => {
+    acc[key] = {
+      initial: light[key]!,
+      dark: value,
+    }
+    return acc
+  }, {} as Record<string | number, { initial: string, dark: string }>)
+
 export default defineTheme({
-  color: {
-    primary: getColors('#d98018'),
-  },
+  color: { primary },
 })


### PR DESCRIPTION
Upstreaming from https://github.com/nimbus-town/nimbus/pull/34

Using light primary color in #3062

<details>
<summary><i>light</i></summary>

![image](https://github.com/user-attachments/assets/0fb5132e-44ef-4dc8-93f1-dcb5e730c821)
_light_
</details>

<details>
<summary><i>dark (not changed)</i></summary>

![image](https://github.com/user-attachments/assets/07e9e7ca-6cea-46f7-bf55-3b6ec9c46b7a)
_dark (not changed)_
</details>
