### PR TITLE
fix: apply missing reordering to local public timeline

### DIFF
--- a/components/timeline/TimelinePublicLocal.vue
+++ b/components/timeline/TimelinePublicLocal.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
+import type { mastodon } from 'masto'
+
 const paginator = useMastoClient().v1.timelines.public.list({ limit: 30, local: true })
 const stream = useStreaming(client => client.public.local.subscribe())
+function reorderAndFilter(items: mastodon.v1.Status[]) {
+  return reorderedTimeline(items, 'public')
+}
 </script>
 
 <template>
   <div>
-    <TimelinePaginator v-bind="{ paginator, stream }" context="public" />
+    <TimelinePaginator v-bind="{ paginator, stream }" :preprocess="reorderAndFilter" context="public" />
   </div>
 </template>


### PR DESCRIPTION
This ensures the public local timeline has a consistent view as other timeline views such public timeline and user account timeline.


## References:
public timeline
https://github.com/elk-zone/elk/blob/6c5bb83ac32aecb5868a0e47ed9bcd2195a9d706/components/timeline/TimelinePublic.vue#L13

user account timeline
https://github.com/elk-zone/elk/blob/4caa63e84fd3fee4a8f3b4491a05d222fc3be3e5/components/timeline/TimelineHome.vue#L19).	
