### PR TITLE
feat: support 'annual_report' notification type

### DIFF
--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -111,5 +111,22 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
     <template v-else-if="notification.type === 'mention' || notification.type === 'poll' || notification.type === 'status'">
       <StatusCard :status="notification.status!" />
     </template>
+    <template v-else-if="notification.type === 'annual_report'">
+      <div flex p4 items-center bg-shaded>
+        <div i-mdi:party-popper text-xl me-4 color-purple />
+        <div class="content-rich">
+          <p>
+            Your 2024 <NuxtLink to="/tags/Wrapstodon">
+              #Wrapstodon
+            </NuxtLink> awaits! Unveil your year's highlights and memorable moments on Mastodon!
+          </p>
+          <p>
+            <NuxtLink :to="`https://${currentServer}/notifications`" target="_blank">
+              View #Wrapstodon on Mastodon
+            </NuxtLink>
+          </p>
+        </div>
+      </div>
+    </template>
   </article>
 </template>

--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
+// Add undocumented 'annual_report' type introduced in v4.3
+// ref. https://github.com/mastodon/documentation/issues/1211#:~:text=api/v1/annual_reports
+type NotificationType = mastodon.v1.Notification['type'] | 'annual_report'
+type Notification = Omit<mastodon.v1.Notification, 'type'> & { type: NotificationType }
+
 const { notification } = defineProps<{
-  notification: mastodon.v1.Notification
+  notification: Notification
 }>()
 
 const { t } = useI18n()
 
 // list of notification types Elk currently implemented
 // type 'favourite' and 'reblog' should always rendered by NotificationGroupedLikes
-const supportedNotificationTypes: mastodon.v1.NotificationType[] = [
+const supportedNotificationTypes: NotificationType[] = [
   'follow',
   'admin.sign_up',
   'admin.report',
@@ -19,6 +24,7 @@ const supportedNotificationTypes: mastodon.v1.NotificationType[] = [
   'poll',
   'update',
   'status',
+  'annual_report',
 ]
 
 // well-known emoji reactions types Elk does not support yet

--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -7,10 +7,26 @@ const { notification } = defineProps<{
 
 const { t } = useI18n()
 
+// list of notification types Elk currently implemented
+// type 'favourite' and 'reblog' should always rendered by NotificationGroupedLikes
+const supportedNotificationTypes: mastodon.v1.NotificationType[] = [
+  'follow',
+  'admin.sign_up',
+  'admin.report',
+  'follow_request',
+  'update',
+  'mention',
+  'poll',
+  'update',
+  'status',
+]
+
 // well-known emoji reactions types Elk does not support yet
 const unsupportedEmojiReactionTypes = ['pleroma:emoji_reaction', 'reaction']
-if (unsupportedEmojiReactionTypes.includes(notification.type))
+
+if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotificationTypes.includes(notification.type)) {
   console.warn(`[DEV] ${t('notification.missing_type')} '${notification.type}' (notification.id: ${notification.id})`)
+}
 </script>
 
 <template>
@@ -94,13 +110,6 @@ if (unsupportedEmojiReactionTypes.includes(notification.type))
     </template>
     <template v-else-if="notification.type === 'mention' || notification.type === 'poll' || notification.type === 'status'">
       <StatusCard :status="notification.status!" />
-    </template>
-    <template v-else-if="!unsupportedEmojiReactionTypes.includes(notification.type)">
-      <!-- prevent showing errors for dev for known emoji reaction types -->
-      <!-- type 'favourite' and 'reblog' should always rendered by NotificationGroupedLikes -->
-      <div text-red font-bold>
-        [DEV] {{ $t('notification.missing_type') }} '{{ notification.type }}'
-      </div>
     </template>
   </article>
 </template>


### PR DESCRIPTION
- add support for 'annual_report' notification type
- output warning message to console instead of showing red message (see #3077)


## Mastodon
![Screenshot of Mastodon notification page writes "Your 2024 #Wrapstodon awaits! Unveil your year's highlights and memorable moments on Mastodon! View #Wrapstodon"](https://github.com/user-attachments/assets/cc47eaa6-bb3d-47c2-8e92-83e2b3d990d2)


## Elk
The new notification will be rendered like this:

![Screenshot of Elk notification page writes "Your 2024 #Wrapstodon awaits! Unveil your year's highlights and memorable moments on Mastodon! View #Wrapstodon on Mastodon"](https://github.com/user-attachments/assets/beca93be-d7d5-4a16-819a-964003a98e84)


```html
<article flex="" flex-col="" relative="" hover:bg-active="" border="b base">
  <div flex="" p4="" items-center="" bg-shaded="">
    <div i-mdi:party-popper="" text-xl="" me-4="" color-purple=""></div>
    <div class="content-rich">
      <p> Your 2024 <a href="/tags/Wrapstodon" class="">#Wrapstodon</a> awaits! Unveil your year's highlights and memorable moments on Mastodon! </p>
      <p><a href="https://mastodon.social/notifications" rel="noopener noreferrer" target="_blank">View #Wrapstodon on Mastodon</a></p>
    </div>
  </div>
</article>
```

The summary panel seems to be rendered within Mastodon's client and there is no URL for the card, so I put an external link to Mastodon's notification page.