### PR TITLE
feat(ui): disable publish button

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -522,6 +522,7 @@ function stopQuestionMarkPropagation(e: KeyboardEvent) {
                 v-if="!threadIsActive || isFinalItemOfThread"
                 btn-solid rounded-3 text-sm w-full flex="~ gap1" items-center md:w-fit class="publish-button"
                 :aria-disabled="isPublishDisabled || isExceedingCharacterLimit" aria-describedby="publish-tooltip"
+                :disabled="isPublishDisabled || isExceedingCharacterLimit"
                 @click="publish"
               >
                 <span v-if="isSending" block animate-spin preserve-3d>


### PR DESCRIPTION
This will add `disabled` attribute to actually disable the publish button when condition is met (e.g., post exceeds server char. limit). Previously we only had `aria-disabled`.

discovered with issue: #3068