### PR TITLE
fix: MenuBottom settings are always empty

### DIFF
--- a/components/settings/SettingsBottomNav.vue
+++ b/components/settings/SettingsBottomNav.vue
@@ -30,7 +30,7 @@ const defaultSelectedNavButtonNames = computed<NavButtonName[]>(() =>
     : ['explore', 'local', 'federated', 'moreMenu'],
 )
 const navButtonNamesSetting = useLocalStorage<NavButtonName[]>(STORAGE_KEY_BOTTOM_NAV_BUTTONS, defaultSelectedNavButtonNames.value)
-const selectedNavButtonNames = ref<NavButtonName[]>([])
+const selectedNavButtonNames = ref<NavButtonName[]>(navButtonNamesSetting.value)
 
 const selectedNavButtons = computed<NavButton[]>(() =>
   selectedNavButtonNames.value.map(name =>


### PR DESCRIPTION
When setting BottomNav menu entries, the space showing which NavButtons are currently shown is always blank. It is not showing the current saved selection neither the base defaults. 