### PR TITLE
chore(utils): remove unnecessary `await`

### DIFF
--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -92,7 +92,7 @@ export async function deleteApp(server: string) {
 export async function listServers() {
   const keys = await storage.getKeys('servers:v3:')
   const servers = new Set<string>()
-  for await (const key of keys) {
+  for (const key of keys) {
     const id = key.split(':')[2]
     if (id)
       servers.add(id.toLocaleLowerCase())


### PR DESCRIPTION
I think here `await` is unnecessary though it will work. But in the previous function `deleteApp` the loop is done without `await`. So I think for consistency, we may remove `await` here.