### PR TITLE
add `severed_relationships` notification type

### DIFF
--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import RelationshipSeveranceCard from '~/components/notification/RelationshipSeveranceCard.vue'
 
 // Add undocumented 'annual_report' type introduced in v4.3
 // ref. https://github.com/mastodon/documentation/issues/1211#:~:text=api/v1/annual_reports
@@ -25,6 +26,7 @@ const supportedNotificationTypes: NotificationType[] = [
   'update',
   'status',
   'annual_report',
+  'severed_relationships',
 ]
 
 // well-known emoji reactions types Elk does not support yet
@@ -32,6 +34,7 @@ const unsupportedEmojiReactionTypes = ['pleroma:emoji_reaction', 'reaction']
 
 if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotificationTypes.includes(notification.type)) {
   console.warn(`[DEV] ${t('notification.missing_type')} '${notification.type}' (notification.id: ${notification.id})`)
+  console.warn(notification)
 }
 </script>
 
@@ -131,6 +134,14 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
               View #Wrapstodon on Mastodon
             </NuxtLink>
           </p>
+        </div>
+      </div>
+    </template>
+    <template v-else-if="notification.type === 'severed_relationships'">
+      <div flex p4 items-center>
+        <div i-material-symbols:heart-broken-outline-rounded text-xl me-4 color-red />
+        <div class="content-rich">
+          <RelationshipSeveranceCard :event="notification.event!" />
         </div>
       </div>
     </template>

--- a/components/notification/RelationshipSeveranceCard.vue
+++ b/components/notification/RelationshipSeveranceCard.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+const { event } = defineProps<{
+  event: object
+}>()
+
+const { t } = useI18n()
+
+const type = event.type
+const from = currentServer
+const target = event.targetName
+const followers = event.followersCount
+const following = event.followingCount
+</script>
+
+<template>
+  <p v-if="type === 'account_suspension'">
+    {{ t('notification.relationship_severance.account_suspension', [from, target]) }}
+  </p>
+  <p v-else-if="type === 'domain_block'">
+    {{ t('notification.relationship_severance.domain_block', { from, target, followers, n: following }) }}
+  </p>
+  <p v-else-if="type === 'user_domain_block'">
+    {{ t("notification.relationship_severance.user_domain_block", { target, followers, n: following }) }}
+  </p>
+
+  <NuxtLink :to="`https://${currentServer}/severed_relationships`" target="_blank">
+    Learn more
+  </NuxtLink>
+</template>

--- a/locales/en.json
+++ b/locales/en.json
@@ -339,6 +339,11 @@
     "followed_you_count": "{0} people followed you|{0} person followed you|{0} people followed you",
     "missing_type": "MISSING notification.type:",
     "reblogged_post": "boosted your post",
+    "relationship_severance": {
+      "account_suspension": "An admin from {0} has suspended {1}, which means you can no longer receive updates from them or interact with them.",
+      "domain_block": "An admin from {from} has blocked {target}, including {followers} of your followers and {n} account you follow.|An admin from {from} has blocked {target}, including {followers} of your followers and {n} accounts you follow.",
+      "user_domain_block": "You have blocked {target}, removing {followers} of your followers and {n} account you follow.|You have blocked {target}, removing {followers} of your followers and {n} accounts you follow."
+    },
     "reported": "{0} reported {1}",
     "request_to_follow": "requested to follow you",
     "signed_up": "signed up",


### PR DESCRIPTION
kind of a follow-up to #3077 and #3084, which added the console logging for unsupported noti types, but not the notification for `severed_relationships`.

currently looks like this:
![image](https://github.com/user-attachments/assets/4f4f223c-55c5-4872-9ecd-391b63357262)

compared to my instance's: 
![image](https://github.com/user-attachments/assets/a5b09869-21a7-42e7-892d-cb95a758b929)

copied the language from [upstream](https://github.com/mastodon/mastodon/blob/0db75588220719d5f812b33a3e45970118c6acb9/app/javascript/mastodon/features/notifications/components/relationships_severance_event.jsx), I can probably just use their localisations too, right?

I'll probably expand the PR to add in `moderation_warning` if I can get a pic of how it should look like (or barring that, just copying [upstream](https://github.com/mastodon/mastodon/blob/0db75588220719d5f812b33a3e45970118c6acb9/app/javascript/mastodon/features/notifications/components/moderation_warning.tsx)'s impl)

(and maybe refactor `annual_report` to use localisations too?)