### PR TITLE
feat: bluesky-style follow notification

### DIFF
--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -14,7 +14,7 @@ const follows = computed(() => debugFollows)
 // const follows = computed(() => items.items)
 const visibleFollows = computed(() => follows.value.slice(0, 5))
 const count = computed(() => follows.value.length)
-const countPlus = computed(() => Math.max(count.value - 5 - 1, 0))
+const countPlus = computed(() => Math.max(count.value - 5, 0))
 const isExpanded = ref(false)
 const lang = computed(() => {
   return (count.value > 1 || count.value === 0) ? undefined : items.items[0].status?.language

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -5,10 +5,11 @@ const { items } = defineProps<{
   items: GroupedNotifications
 }>()
 
+const maxVisibleFollows = 5
 const follows = computed(() => items.items)
-const visibleFollows = computed(() => follows.value.slice(0, 5))
+const visibleFollows = computed(() => follows.value.slice(0, maxVisibleFollows))
 const count = computed(() => follows.value.length)
-const countPlus = computed(() => Math.max(count.value - 5, 0))
+const countPlus = computed(() => Math.max(count.value - maxVisibleFollows, 0))
 const isExpanded = ref(false)
 const lang = computed(() => {
   return (count.value > 1 || count.value === 0) ? undefined : items.items[0].status?.language

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -5,13 +5,7 @@ const { items } = defineProps<{
   items: GroupedNotifications
 }>()
 
-// DEBUG start
-const n = 7
-const debugFollows = Array.from({ length: n }).fill(0).map(_ => items.items[0])
-const follows = computed(() => debugFollows)
-// DEBUG end
-
-// const follows = computed(() => items.items)
+const follows = computed(() => items.items)
 const visibleFollows = computed(() => follows.value.slice(0, 5))
 const count = computed(() => follows.value.length)
 const countPlus = computed(() => Math.max(count.value - 5, 0))

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -5,16 +5,16 @@ const { items } = defineProps<{
   items: GroupedNotifications
 }>()
 
-// DEBUG from
+// DEBUG start
 const n = 7
-const follow = items.items[0]
-// eslint-disable-next-line vue/no-mutating-props
-items.items = Array.from({ length: n }).fill(0).map(_ => follow)
+const debugFollows = Array.from({ length: n }).fill(0).map(_ => items.items[0])
+const follows = computed(() => debugFollows)
 // DEBUG end
 
-const visibleFollows = computed(() => items.items.slice(0, 5))
-const count = computed(() => items.items.length)
-const countPlus = computed(() => Math.max(items.items.length - 5 - 1, 0))
+// const follows = computed(() => items.items)
+const visibleFollows = computed(() => follows.value.slice(0, 5))
+const count = computed(() => follows.value.length)
+const countPlus = computed(() => Math.max(count.value - 5 - 1, 0))
 const isExpanded = ref(false)
 const lang = computed(() => {
   return (count.value > 1 || count.value === 0) ? undefined : items.items[0].status?.language
@@ -27,10 +27,10 @@ const lang = computed(() => {
       <div :class="count > 1 ? 'i-ri-group-line' : 'i-ri-user-3-line'" me-3 color-blue text-xl aria-hidden="true" />
       <template v-if="count > 1">
         <AccountHoverWrapper
-          :account="visibleFollows[0].account"
+          :account="follows[0].account"
         >
-          <NuxtLink :to="getAccountRoute(visibleFollows[0].account)">
-            <AccountDisplayName :account="items.items[0].account" font-bold hover:underline />
+          <NuxtLink :to="getAccountRoute(follows[0].account)">
+            <AccountDisplayName :account="follows[0].account" font-bold hover:underline />
           </NuxtLink>
         </AccountHoverWrapper>
         &nbsp;{{ $t('notification.and') }}&nbsp;
@@ -42,9 +42,9 @@ const lang = computed(() => {
         &nbsp;{{ $t('notification.followed_you') }}
       </template>
       <template v-else-if="count === 1">
-        <NuxtLink :to="getAccountRoute(items.items[0].account)">
+        <NuxtLink :to="getAccountRoute(follows[0].account)">
           <AccountDisplayName
-            :account="visibleFollows[0].account"
+            :account="follows[0].account"
             text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
           />
         </NuxtLink>
@@ -60,12 +60,12 @@ const lang = computed(() => {
         @click="isExpanded = !isExpanded"
       >
         <AccountHoverWrapper
-          v-for="item in visibleFollows"
-          :key="item.id"
-          :account="item.account"
+          v-for="follow in visibleFollows"
+          :key="follow.id"
+          :account="follow.account"
         >
-          <NuxtLink :to="getAccountRoute(item.account)">
-            <AccountAvatar :account="item.account" w-12 h-12 />
+          <NuxtLink :to="getAccountRoute(follow.account)">
+            <AccountAvatar :account="follow.account" w-12 h-12 />
           </NuxtLink>
         </AccountHoverWrapper>
         <div flex="~ 1" items-center>
@@ -78,12 +78,16 @@ const lang = computed(() => {
           <div i-ri:arrow-up-s-line ms-2 text-secondary text-xl aria-hidden="true" />
           <span ps-2 text-base>Hide</span>
         </div>
-        <AccountInfo
-          v-for="item in items.items"
-          :key="item.id"
-          :account="item.account"
-          p3
-        />
+        <AccountHoverWrapper
+          v-for="follow in follows"
+          :key="follow.id"
+          :account="follow.account"
+        >
+          <NuxtLink :to="getAccountRoute(follow.account)" flex gap-4 px-4 py-2>
+            <AccountAvatar :account="follow.account" w-12 h-12 />
+            <StatusAccountDetails :account="follow.account" />
+          </NuxtLink>
+        </AccountHoverWrapper>
       </div>
     </div>
   </article>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -5,7 +5,16 @@ const { items } = defineProps<{
   items: GroupedNotifications
 }>()
 
+// DEBUG from
+const n = 7
+const follow = items.items[0]
+// eslint-disable-next-line vue/no-mutating-props
+items.items = Array.from({ length: n }).fill(0).map(_ => follow)
+// DEBUG end
+
+const visibleFollows = computed(() => items.items.slice(0, 5))
 const count = computed(() => items.items.length)
+const countPlus = computed(() => Math.max(items.items.length - 5 - 1, 0))
 const isExpanded = ref(false)
 const lang = computed(() => {
   return (count.value > 1 || count.value === 0) ? undefined : items.items[0].status?.language
@@ -17,15 +26,25 @@ const lang = computed(() => {
     <div flex items-center top-0 left-2 pt-2 px-3>
       <div :class="count > 1 ? 'i-ri-group-line' : 'i-ri-user-3-line'" me-3 color-blue text-xl aria-hidden="true" />
       <template v-if="count > 1">
+        <AccountHoverWrapper
+          :account="visibleFollows[0].account"
+        >
+          <NuxtLink :to="getAccountRoute(visibleFollows[0].account)">
+            <AccountDisplayName :account="items.items[0].account" font-bold hover:underline />
+          </NuxtLink>
+        </AccountHoverWrapper>
+        &nbsp;{{ $t('notification.and') }}&nbsp;
         <CommonLocalizedNumber
-          keypath="notification.followed_you_count"
-          :count="count"
+          keypath="notification.others"
+          :count="count - 1"
+          font-bold
         />
+        &nbsp;{{ $t('notification.followed_you') }}
       </template>
       <template v-else-if="count === 1">
         <NuxtLink :to="getAccountRoute(items.items[0].account)">
           <AccountDisplayName
-            :account="items.items[0].account"
+            :account="visibleFollows[0].account"
             text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
           />
         </NuxtLink>
@@ -35,17 +54,13 @@ const lang = computed(() => {
       </template>
     </div>
     <div pb-2 ps8>
-      <div v-if="isExpanded">
-        <AccountCard
-          v-for="item in items.items"
-          :key="item.id"
-          :account="item.account"
-          p3
-        />
-      </div>
-      <div v-else flex="~ wrap gap-1.75" p4>
+      <div
+        v-if="!isExpanded"
+        flex="~ wrap gap-1.75" p4 items-center cursor-pointer
+        @click="isExpanded = !isExpanded"
+      >
         <AccountHoverWrapper
-          v-for="item in items.items"
+          v-for="item in visibleFollows"
           :key="item.id"
           :account="item.account"
         >
@@ -53,6 +68,22 @@ const lang = computed(() => {
             <AccountAvatar :account="item.account" w-12 h-12 />
           </NuxtLink>
         </AccountHoverWrapper>
+        <div flex="~ 1">
+          <span v-if="countPlus > 0" ps-2 text="base lg">+{{ countPlus }}</span>
+          <div i-ri:arrow-down-s-line mx-1 text-secondary text-xl aria-hidden="true" />
+        </div>
+      </div>
+      <div v-else>
+        <AccountInfo
+          v-for="item in items.items"
+          :key="item.id"
+          :account="item.account"
+          p3
+        />
+        <div flex p-1 cursor-pointer @click="isExpanded = !isExpanded">
+          <div i-ri:arrow-up-s-line mx-1 text-secondary text-xl aria-hidden="true" />
+          <span ps-2 text-base>Hide</span>
+        </div>
       </div>
     </div>
   </article>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -30,7 +30,10 @@ const lang = computed(() => {
           :account="follows[0].account"
         >
           <NuxtLink :to="getAccountRoute(follows[0].account)">
-            <AccountDisplayName :account="follows[0].account" font-bold hover:underline />
+            <AccountDisplayName
+              :account="follows[0].account"
+              text-primary font-bold line-clamp-1 ws-pre-wrap break-all hover:underline
+            />
           </NuxtLink>
         </AccountHoverWrapper>
         &nbsp;{{ $t('notification.and') }}&nbsp;
@@ -55,7 +58,7 @@ const lang = computed(() => {
     </div>
     <div pb-2 ps8>
       <div
-        v-if="!isExpanded"
+        v-if="!isExpanded && count > 1"
         flex="~ wrap gap-1.75" p4 items-center cursor-pointer
         @click="isExpanded = !isExpanded"
       >
@@ -74,7 +77,7 @@ const lang = computed(() => {
         </div>
       </div>
       <div v-else>
-        <div flex p-4 pb-2 cursor-pointer @click="isExpanded = !isExpanded">
+        <div v-if="count > 1" flex p-4 pb-2 cursor-pointer @click="isExpanded = !isExpanded">
           <div i-ri:arrow-up-s-line ms-2 text-secondary text-xl aria-hidden="true" />
           <span ps-2 text-base>Hide</span>
         </div>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -68,7 +68,7 @@ const lang = computed(() => {
             <AccountAvatar :account="item.account" w-12 h-12 />
           </NuxtLink>
         </AccountHoverWrapper>
-        <div flex="~ 1">
+        <div flex="~ 1" items-center>
           <span v-if="countPlus > 0" ps-2 text="base lg">+{{ countPlus }}</span>
           <div i-ri:arrow-down-s-line mx-1 text-secondary text-xl aria-hidden="true" />
         </div>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -74,16 +74,16 @@ const lang = computed(() => {
         </div>
       </div>
       <div v-else>
+        <div flex p-4 pb-2 cursor-pointer @click="isExpanded = !isExpanded">
+          <div i-ri:arrow-up-s-line ms-2 text-secondary text-xl aria-hidden="true" />
+          <span ps-2 text-base>Hide</span>
+        </div>
         <AccountInfo
           v-for="item in items.items"
           :key="item.id"
           :account="item.account"
           p3
         />
-        <div flex p-1 cursor-pointer @click="isExpanded = !isExpanded">
-          <div i-ri:arrow-up-s-line mx-1 text-secondary text-xl aria-hidden="true" />
-          <span ps-2 text-base>Hide</span>
-        </div>
       </div>
     </div>
   </article>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -40,7 +40,7 @@ const lang = computed(() => {
         <CommonLocalizedNumber
           keypath="notification.others"
           :count="count - 1"
-          font-bold
+          text-primary font-bold line-clamp-1 ws-pre-wrap break-all
         />
         &nbsp;{{ $t('notification.followed_you') }}
       </template>
@@ -48,7 +48,7 @@ const lang = computed(() => {
         <NuxtLink :to="getAccountRoute(follows[0].account)">
           <AccountDisplayName
             :account="follows[0].account"
-            text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
+            text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all hover:underline
           />
         </NuxtLink>
         <span me-1 ws-nowrap>

--- a/locales/en.json
+++ b/locales/en.json
@@ -334,10 +334,12 @@
     "zen_mode": "Zen Mode"
   },
   "notification": {
+    "and": "and",
     "favourited_post": "favorited your post",
     "followed_you": "followed you",
     "followed_you_count": "{0} people followed you|{0} person followed you|{0} people followed you",
     "missing_type": "MISSING notification.type:",
+    "others": "{0} others|{0} other|{0} others",
     "reblogged_post": "boosted your post",
     "reported": "{0} reported {1}",
     "request_to_follow": "requested to follow you",


### PR DESCRIPTION
resolve #908

## Screenshots
### Widescreen

#### 1 follower
![screenshot of notification page, 1 follower is shown with avatar and display name](https://github.com/user-attachments/assets/8023c9a8-a973-4514-9997-8b42d91a3eb1)

#### 8 followers
![screenshot of notification page, 5 avatars and "+3" label is shown with icon](https://github.com/user-attachments/assets/14d9086d-7346-4008-a453-458aa4c93b7b)

#### 8 followers (expanded)
![screenshot of notification page, many avatars with names listed with top hide label](https://github.com/user-attachments/assets/794451e7-e871-4738-b4e3-8e065911b46f)

### Mobile

#### 1 follower
![screenshot of notification page similar to widescreen](https://github.com/user-attachments/assets/9c82c839-c6f3-4394-b29e-77e9d1b3273e)

#### 8 followers
![screenshot of notification page similar to widescreen](https://github.com/user-attachments/assets/b9a1179a-83c4-46f8-95df-5af2773c3544)

#### 8 followers (expanded)
![screenshot of notification page similar to widescreen](https://github.com/user-attachments/assets/8fa8d94e-4005-4e0b-8213-8f3d7d007b61)
