### PR TITLE
fix: remove extra padding and hover effect on dark theme

### DIFF
--- a/components/status/StatusPreviewCardMoreFromAuthor.vue
+++ b/components/status/StatusPreviewCardMoreFromAuthor.vue
@@ -15,6 +15,6 @@ defineProps<{
     light:bg-gray-3 dark:bg-gray-8
   >
     <span z-0>More from</span>
-    <AccountInlineInfo :account="account" hover:bg-gray-300 />
+    <AccountInlineInfo :account="account" hover:bg-inherit ps-0 ms-0 />
   </div>
 </template>


### PR DESCRIPTION
fix #3155

- Remove the hover color similar to the light theme
- Remove the extra padding. This was necessary not just for hovering, but the focus border also overflowed on the left side.

### Before
![screenshot of post with "more from" badge, hovering on the account name, its background is white and too much left padding](https://github.com/user-attachments/assets/4df03fe2-6ed3-4c27-ba18-db0523ad9598)
https://deploy-preview-3157--elk-zone.netlify.app/mastodon.social/@Mastodon/113820526480156595
### After

![screenshot of post with "more from" badge, hovering on the account name, no background color change with no extra padding](https://github.com/user-attachments/assets/c5e783db-048c-4385-b2ae-c9815bd12325)
https://deploy-preview-3157--elk-zone.netlify.app/mastodon.social/@Mastodon/113820526480156595