### PR TITLE
chore: release v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elk-zone/elk",
   "type": "module",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "packageManager": "pnpm@9.15.4",
   "license": "MIT",
   "homepage": "https://elk.zone/",


### PR DESCRIPTION
creating PR as I couldn't take a shortcut for the branch protection rule:

```
[elk-release]  main (3902bac🔖 v0.16.0) [⇡] is 󰏗 v0.16.0 via  v20.18.1 󱇶 shuuji3 ⏱ 3s 
> git push
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: 
remote: - Changes must be made through the merge queue
remote: 
remote: - Required status check "ci" is expected.
To https://github.com/elk-zone/elk.git
 ! [remote rejected]   main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/elk-zone/elk.git'

Done
```