### PR TITLE
fix: account profile page title

### DIFF
--- a/pages/[[server]]/@[account]/index/index.vue
+++ b/pages/[[server]]/@[account]/index/index.vue
@@ -28,7 +28,7 @@ const postPaginator = useMastoClient().v1.accounts.$select(account.id).statuses.
 
 if (account) {
   useHydratedHead({
-    title: () => `${t('account.posts')} | ${getDisplayName(account)} (@${account.acct})`,
+    title: () => `${t('nav.profile')} | ${getDisplayName(account)} (@${account.acct})`,
   })
 }
 </script>


### PR DESCRIPTION
When visiting someone's account page, the page's title shows "Posts" (here "messages" in french) 
![image](https://github.com/user-attachments/assets/5d44c51b-7016-47fe-8b8c-e4302d86e758)

Using `nav.profile`  instead of  `account.posts` to show "Profile" 