### PR TITLE
fix: account avatar should not be streched

### DIFF
--- a/components/account/AccountAvatar.vue
+++ b/components/account/AccountAvatar.vue
@@ -24,7 +24,7 @@ const accountAvatarSrc = computed(() => {
     :src="(error || !loaded) ? 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7' : accountAvatarSrc"
     :alt="$t('account.avatar_description', [props.account.username])"
     loading="lazy"
-    class="account-avatar"
+    class="account-avatar object-cover"
     :class="(loaded ? 'bg-base' : 'bg-gray:10') + (props.square ? ' ' : ' rounded-full')"
     :style="{ 'clip-path': props.square ? `url(#avatar-mask)` : 'none' }"
     v-bind="$attrs"


### PR DESCRIPTION
Account avatar are stretched instead of being centered and cropped both on profile page and avatar in status 

Before
![image](https://github.com/user-attachments/assets/c833f65d-66f2-46e1-b380-3b8930fe80a1)

After
![image](https://github.com/user-attachments/assets/47e4ac10-ed6f-43f8-be96-17134affbb47)
