### PR TITLE
feat: redirect code.elk.zone to github repository

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,10 @@ from = "https://chat.elk.zone"
 to = "https://discord.gg/vAZSDU9J"
 status = 301
 force = true
+
+# Redirect to Discord server
+[[redirects]]
+from = "https://code.elk.zone"
+to = "https://github.com/elk-zone/elk"
+status = 301
+force = true


### PR DESCRIPTION
This PR will set a new redirect from `code.elk.zone` to the GitHub repository page, for easy sharing.