### PR TITLE
fix: update `status` ref to use `status.value`

### DIFF
--- a/composables/masto/status.ts
+++ b/composables/masto/status.ts
@@ -42,7 +42,7 @@ export function useStatusActions(props: StatusActionsProps) {
       if (isCancel && countField && prevCount === newStatus[countField])
         newStatus[countField] -= 1
 
-      Object.assign(status, newStatus)
+      Object.assign(status.value, newStatus)
       cacheStatus(newStatus, undefined, true)
     }).finally(() => {
       isLoading.value[action] = false


### PR DESCRIPTION
This PR changes `Object.assign(status, newStatus)` in `toggleStatusAction` to `Object.assign(status.value, newStatus)` because `status` is a ref. This ensures that the new status is updated properly after calling `fetchNewStatus`.