### PR TITLE
fix: prevent including extra params in repository name on GitHub Card

### DIFF
--- a/components/status/StatusPreviewGitHub.vue
+++ b/components/status/StatusPreviewGitHub.vue
@@ -69,7 +69,7 @@ const meta = computed(() => {
     user,
     titleUrl: `https://github.com/${user}${repo ? `/${repo}` : ''}`,
     details,
-    repo,
+    repo: repo.split('?')[0],
     number,
     avatar,
     author: author

--- a/components/status/StatusPreviewGitHub.vue
+++ b/components/status/StatusPreviewGitHub.vue
@@ -69,7 +69,7 @@ const meta = computed(() => {
     user,
     titleUrl: `https://github.com/${user}${repo ? `/${repo}` : ''}`,
     details,
-    repo: repo.split('?')[0],
+    repo: repo?.split('?')[0],
     number,
     avatar,
     author: author


### PR DESCRIPTION
fix #3171

deploy preview: https://deploy-preview-3181--elk-zone.netlify.app/m.webtoo.ls/@atinux/113872759307282326

---

TODO: investigate

Expected (on local):

![Screenshot of preview card](https://github.com/user-attachments/assets/0f7ea17a-7276-420f-9cbb-4cce1bad5170)

Current Netlify preview:

![screenshot of post but the preview card is not shown at all](https://github.com/user-attachments/assets/56d41343-9320-47ca-a3a1-7ccd5b439a29)

