### PR TITLE
fix: mute duration picker was missing

### DIFF
--- a/components/modal/ModalConfirm.vue
+++ b/components/modal/ModalConfirm.vue
@@ -40,7 +40,7 @@ function handleChoice(choice: ConfirmDialogChoice['choice']) {
     </div>
     <div v-if="isMute" flex-col flex gap-4>
       <CommonCheckbox v-model="hasDuration" :label="$t('confirm.mute_account.specify_duration')" prepend-checkbox checked-icon-color="text-primary" />
-      <DurationPicker v-if="hasDuration" v-model="duration" v-model:is-valid="isValidDuration" />
+      <ModalDurationPicker v-if="hasDuration" v-model="duration" v-model:is-valid="isValidDuration" />
       <CommonCheckbox v-model="shouldMuteNotifications" :label="$t('confirm.mute_account.notifications')" prepend-checkbox checked-icon-color="text-primary" />
     </div>
 


### PR DESCRIPTION
fix #3022

The cause was just the change of auto-imported component name.
