### PR TITLE
feat: adopt to `/api/v2/instance` to fetch app `vapid_key`

### DIFF
--- a/server/cache-driver.ts
+++ b/server/cache-driver.ts
@@ -16,10 +16,10 @@ export default defineDriver((driver: Driver = memory()) => {
 
       return driver.hasItem(key, {})
     },
-    async setItem(key: string, value: any) {
+    async setItem(key: string, value: any, opts: any = {}) {
       await Promise.all([
         memoryDriver.setItem?.(key, value, {}),
-        driver.setItem?.(key, value, {}),
+        driver.setItem?.(key, value, opts),
       ])
     },
     async getItem(key: string) {

--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -93,7 +93,9 @@ export async function getApp(origin: string, server: string) {
     if (await storage.hasItem(key))
       return (storage.getItem(key, {}) as Promise<AppInfo>)
     const appInfo = await fetchAppInfo(origin, server)
-    await storage.setItem(key, appInfo)
+    // cache `appInfo` for 1 week to prevent permanent lockout
+    // note that `unstorage` supports `ttl` only for some storage drivers like cloudflare
+    await storage.setItem(key, appInfo, { ttl: 60 * 60 * 24 * 7 /* 1 week */ })
     return appInfo
   }
   catch {


### PR DESCRIPTION
Currently, the vapid key in AppInfo (needed for push notification) is retrieved from the response of `POST /api/v1/apps` and stored permanently to the server storage, when someone first tries to log in to the server from the Elk. But it was deprecated since Mastodon v4.3.0 (ref. https://docs.joinmastodon.org/methods/apps/#create). This change uses the recommended `GET /api/v2/instance` value.

This also updates the key of the storage for AppInfo (`servers:v3:${server}:` -> `servers:v4:${server}:`) because some (non-Mastodon) servers may return different values with this change. As a side effect, this will partially solve the existing lock-out issue (ref. #3150).

Mastodon server returns the exact same vapid key value from `POST /api/v1/apps` and `GET /api/v2/instance`, so there should not be any difference for Mastodon.
