### PR TITLE
feat: allow partial match in profile metadata label

### DIFF
--- a/composables/masto/icons.ts
+++ b/composables/masto/icons.ts
@@ -54,15 +54,10 @@ export const accountFieldIcons: Record<string, string> = Object.fromEntries(Obje
   Zhihu: 'i-ri:zhihu-line',
 }).sort(([a], [b]) => a.localeCompare(b)))
 
-const accountFieldIconsLowercase = Object.fromEntries(
-  Object.entries(accountFieldIcons).map(([k, v]) =>
-    [k.toLowerCase(), v],
-  ),
-)
+const accountFieldIconsRegex = Object.entries(accountFieldIcons).map(([name, icon]) => [name, icon])
 
 export function getAccountFieldIcon(value: string) {
-  const name = value.trim().toLowerCase()
-  return accountFieldIconsLowercase[name] || undefined
+  return accountFieldIconsRegex.find(([name]) => new RegExp(name, 'i').test(value))
 }
 
 export const statusVisibilities = [


### PR DESCRIPTION
resolve #3194

## Before
![Screenshot of profile metadata settings. three links: "mastodon" with mastodon icon, "mastodon (sub)" with question mark icon. "my youtube channel" with question mark icon](https://github.com/user-attachments/assets/6e3bcd49-aa46-40d0-ba08-97ac8686cac1)


## After
![Screenshot of profile metadata settings. three links: "mastodon" with mastodon icon, "mastodon (sub)" with mastodon icon. "my youtube channel" with youtube icon](https://github.com/user-attachments/assets/b2c60d86-1a8a-48d2-b077-248578356b3c)
