### PR TITLE
feat: show notification timestamp

### DIFF
--- a/components/notification/NotificationCard.vue
+++ b/components/notification/NotificationCard.vue
@@ -33,6 +33,9 @@ const unsupportedEmojiReactionTypes = ['pleroma:emoji_reaction', 'reaction']
 if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotificationTypes.includes(notification.type)) {
   console.warn(`[DEV] ${t('notification.missing_type')} '${notification.type}' (notification.id: ${notification.id})`)
 }
+
+const timeAgoOptions = useTimeAgoOptions(true)
+const timeAgo = useTimeAgo(() => notification.createdAt, timeAgoOptions)
 </script>
 
 <template>
@@ -48,7 +51,7 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
           <div i-ri-user-3-line text-xl me-3 color-blue />
           <AccountDisplayName :account="notification.account" text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all />
           <span ws-nowrap>
-            {{ $t('notification.followed_you') }}
+            {{ $t('notification.followed_you') }}・{{ timeAgo }}
           </span>
         </div>
         <AccountBigCard
@@ -65,7 +68,7 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
             :account="notification.account"
             text-purple me-1 font-bold line-clamp-1 ws-pre-wrap break-all
           />
-          <span>{{ $t("notification.signed_up") }}</span>
+          <span>{{ $t("notification.signed_up") }}・{{ timeAgo }}</span>
         </div>
       </NuxtLink>
     </template>
@@ -94,7 +97,7 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
           text-primary me-1 font-bold line-clamp-1 ws-pre-wrap break-all
         />
         <span me-1 ws-nowrap>
-          {{ $t('notification.request_to_follow') }}
+          {{ $t('notification.request_to_follow') }}・{{ timeAgo }}
         </span>
       </div>
       <AccountCard p="s-2 e-4 b-2" hover-card :account="notification.account">
@@ -108,7 +111,7 @@ if (unsupportedEmojiReactionTypes.includes(notification.type) || !supportedNotif
             <div i-ri:edit-2-fill text-xl me-1 text-secondary />
             <AccountInlineInfo :account="notification.account" me1 />
             <span ws-nowrap>
-              {{ $t('notification.update_status') }}
+              {{ $t('notification.update_status') }}・{{ timeAgo }}
             </span>
           </div>
         </template>

--- a/components/notification/NotificationGroupedFollow.vue
+++ b/components/notification/NotificationGroupedFollow.vue
@@ -14,6 +14,9 @@ const isExpanded = ref(false)
 const lang = computed(() => {
   return (count.value > 1 || count.value === 0) ? undefined : items.items[0].status?.language
 })
+
+const timeAgoOptions = useTimeAgoOptions(true)
+const timeAgo = useTimeAgo(() => follows.value[0].createdAt, timeAgoOptions)
 </script>
 
 <template>
@@ -37,7 +40,7 @@ const lang = computed(() => {
           :count="count - 1"
           text-primary font-bold line-clamp-1 ws-pre-wrap break-all
         />
-        &nbsp;{{ $t('notification.followed_you') }}
+        &nbsp;{{ $t('notification.followed_you') }}・{{ timeAgo }}
       </template>
       <template v-else-if="count === 1">
         <NuxtLink :to="getAccountRoute(follows[0].account)">
@@ -47,7 +50,7 @@ const lang = computed(() => {
           />
         </NuxtLink>
         <span me-1 ws-nowrap>
-          {{ $t('notification.followed_you') }}
+          {{ $t('notification.followed_you') }}・{{ timeAgo }}
         </span>
       </template>
     </div>

--- a/components/notification/NotificationGroupedLikes.vue
+++ b/components/notification/NotificationGroupedLikes.vue
@@ -8,6 +8,10 @@ const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 
 const reblogs = computed(() => group.likes.filter(i => i.reblog))
 const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
+
+const timeAgoOptions = useTimeAgoOptions(true)
+const reblogsTimeAgo = useTimeAgo(() => reblogs.value[0].reblog?.createdAt ?? '', timeAgoOptions)
+const likesTimeAgo = useTimeAgo(() => likes.value[0].favourite?.createdAt ?? '', timeAgoOptions)
 </script>
 
 <template>
@@ -24,7 +28,7 @@ const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
             </AccountHoverWrapper>
           </template>
           <div ml1>
-            {{ $t('notification.reblogged_post') }}
+            {{ $t('notification.reblogged_post') }}・{{ reblogsTimeAgo }}
           </div>
         </div>
         <div v-if="likes.length" flex="~ gap-1 wrap">
@@ -37,7 +41,7 @@ const likes = computed(() => group.likes.filter(i => i.favourite && !i.reblog))
             </AccountHoverWrapper>
           </template>
           <div ms-4>
-            {{ $t('notification.favourited_post') }}
+            {{ $t('notification.favourited_post') }} ・{{ likesTimeAgo }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
resolve #3214

- Used the same timestamp formatting function as the post timestamp.
- In the following screenshot, `・2w`, `・3w`, `1min`, and `just now` parts are added.

![Screenshot of notification with label: Ayo Ayco followed you・3w](https://github.com/user-attachments/assets/31755998-330b-4dbc-b0ec-ec327100b900)

![Screenshot of notification with label: boosted your post・3w](https://github.com/user-attachments/assets/92a40686-01d5-44b1-a7a3-02c6aa7f9cfa)

![Screenshot of notification with label: shuuji3 followed you・2w](https://github.com/user-attachments/assets/c711b25f-1f40-4b3d-8961-59151789aa66)

![Screenshot of notification with label: favorited your post ・1min](https://github.com/user-attachments/assets/762b2420-8462-4e23-9f1e-a6109c781938)

![Screenshot of notification with label: favorited your post ・just now](https://github.com/user-attachments/assets/e04bb17d-918a-49bc-8b5a-c253c9156ccb)

