### PR TITLE
feat: add new preference to unmute videos by default

### DIFF
--- a/components/status/StatusAttachment.vue
+++ b/components/status/StatusAttachment.vue
@@ -71,6 +71,7 @@ const isVideo = computed(() => attachment.type === 'video')
 const isGif = computed(() => attachment.type === 'gifv')
 
 const enableAutoplay = usePreferences('enableAutoplay')
+const unmuteVideos = usePreferences('unmuteVideos')
 
 useIntersectionObserver(video, (entries) => {
   const ready = video.value?.dataset.ready === 'true'
@@ -132,7 +133,7 @@ watch(shouldLoadAttachment, () => {
           ref="video"
           preload="none"
           :poster="videoThumbnail"
-          muted
+          :muted="!unmuteVideos"
           loop
           playsinline
           :controls="shouldLoadAttachment"
@@ -172,7 +173,7 @@ watch(shouldLoadAttachment, () => {
           ref="video"
           preload="none"
           :poster="videoThumbnail"
-          muted
+          :muted="!unmuteVideos"
           loop
           playsinline
           rounded-lg

--- a/composables/settings/definition.ts
+++ b/composables/settings/definition.ts
@@ -23,6 +23,7 @@ export interface PreferencesSettings {
   hideNews: boolean
   grayscaleMode: boolean
   enableAutoplay: boolean
+  unmuteVideos: boolean
   optimizeForLowPerformanceDevice: boolean
   enableDataSaving: boolean
   enablePinchToZoom: boolean
@@ -79,6 +80,7 @@ export const DEFAULT__PREFERENCES_SETTINGS: PreferencesSettings = {
   hideNews: false,
   grayscaleMode: false,
   enableAutoplay: true,
+  unmuteVideos: false,
   optimizeForLowPerformanceDevice: false,
   enableDataSaving: false,
   enablePinchToZoom: false,

--- a/locales/en.json
+++ b/locales/en.json
@@ -561,6 +561,7 @@
       "label": "Preferences",
       "optimize_for_low_performance_device": "Optimize for low performance device",
       "title": "Experimental Features",
+      "unmute_videos": "Unmute videos by default",
       "use_star_favorite_icon": "Use star favorite icon",
       "user_picker": "User Picker",
       "user_picker_description": "Displays all avatars of logged accounts in the bottom-left so you can switch quickly between them.",

--- a/pages/settings/preferences/index.vue
+++ b/pages/settings/preferences/index.vue
@@ -52,6 +52,12 @@ const userSettings = useUserSettings()
         {{ $t('settings.preferences.enable_autoplay') }}
       </SettingsToggleItem>
       <SettingsToggleItem
+        :checked="getPreferences(userSettings, 'unmuteVideos')"
+        @click="togglePreferences('unmuteVideos')"
+      >
+        {{ $t('settings.preferences.unmute_videos') }}
+      </SettingsToggleItem>
+      <SettingsToggleItem
         :checked="getPreferences(userSettings, 'optimizeForLowPerformanceDevice')"
         @click="togglePreferences('optimizeForLowPerformanceDevice')"
       >


### PR DESCRIPTION
resolve #3216

Currently, Elk always mutes all videos. This PR adds a new preference to allow users to choose to unmute videos by default.

![screenshot of preference page. it has "Unmute videos by default" checkbox item](https://github.com/user-attachments/assets/e99b6a55-744e-4713-8981-6d01d3e487c9)
