### PR TITLE
ci: refer `.npmrc` to ensure using consistent node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       # - https://github.com/nodejs/corepack/issues/612#issuecomment-2629496091
       - run: npm i -g corepack@latest && corepack enable
       - uses: actions/setup-node@v4.2.0
+        with:
+          node-version-file: .nvmrc
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: .nvmrc
 
       - run: npx changelogithub
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To develop and test the Elk package:
 
 1. Fork the Elk repository to your own GitHub account and then clone it to your local device.
 
-2. Ensure using the latest Node.js (20.x).
+2. Ensure using the LTS version of Node.js.
 If you have [nvm](https://github.com/nvm-sh/nvm), you can run `nvm i` to install the required version.
 
 3. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/) v9. To use it you must first enable [Corepack](https://github.com/nodejs/corepack) by running `corepack enable`. (Note: on Linux in a standard Node 20+ environment, you should follow the instructions to install via Node's `corepack` rather than using the `curl` command)


### PR DESCRIPTION
follow up of #3227

- This makes sure the same version of Node.js in Workflows
- Update docs