### PR TITLE
chore: pause codeflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,6 @@ Refer also to https://github.com/antfu/contribute.
 
 For guidelines on contributing to the documentation, refer to the [docs README](./docs/README.md).
 
-### Online
-
-You can use [StackBlitz Codeflow](https://stackblitz.com/codeflow) to fix bugs or implement features. You'll also see a Codeflow button on PRs to review them without a local setup. Once the elk repo has been cloned in Codeflow, the dev server will start automatically and print the URL to open the App. You should receive a prompt in the bottom-right suggesting to open it in the Editor or in another Tab. To learn more, check out the [Codeflow docs](https://developer.stackblitz.com/codeflow/what-is-codeflow).
-
-[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/elk-zone/elk)
-
 ### Local Setup
 
 To develop and test the Elk package:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A nimble Mastodon web client
 <br/>
 <p align="center">
   <a href="https://chat.elk.zone"><img src="https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord" alt="discord chat"></a>
-  <a href="https://pr.new/elk-zone/elk"><img src="https://developer.stackblitz.com/img/start_pr_dark_small.svg" alt="Start new PR in StackBlitz Codeflow"></a>
   <a href="https://volta.net/elk-zone/elk?utm_source=elk_readme"><img src="https://user-images.githubusercontent.com/904724/209143798-32345f6c-3cf8-4e06-9659-f4ace4a6acde.svg" alt="Open board on Volta"></a>
 </p>
 <br/>
@@ -103,12 +102,6 @@ We would also appreciate sponsoring other contributors to the Elk project. If so
 ## 🧑‍💻 Contributing
 
 We're really excited that you're interested in contributing to Elk! Before submitting your contribution, please read through the following guide.
-
-### Online
-
-You can use [StackBlitz Codeflow](https://stackblitz.com/codeflow) to fix bugs or implement features. You'll also see a Codeflow button on PRs to review them without a local setup. Once the elk repo has been cloned in Codeflow, the dev server will start automatically and print the URL to open the App. You should receive a prompt in the bottom-right suggesting to open it in the Editor or in another Tab. To learn more, check out the [Codeflow docs](https://developer.stackblitz.com/codeflow/what-is-codeflow).
-
-[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/elk-zone/elk)
 
 ### Local Setup
 

--- a/docs/components/global/TranslationState.vue
+++ b/docs/components/global/TranslationState.vue
@@ -76,18 +76,7 @@ async function copyToClipboard() {
       <caption>
         <div>You can see the detail (missing and outdated keys) by clicking on the corresponding row.</div>
         <div>
-          If you want to send a PR, click on <strong>Edit</strong> link on the corresponding translation file, it will open <strong>Codeflow</strong>:
-          <NuxtLink
-            class="inline"
-            target="_blank"
-            href="https://developer.stackblitz.com/codeflow/working-in-codeflow-ide#making-a-pr-with-codeflow-ide"
-            title="How to make a PR with Codeflow IDE (opens in new window)"
-          >
-            read the following guide
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
-              <path fill="currentColor" d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h7v2H5v14h14v-7h2v7q0 .825-.587 1.413Q19.825 21 19 21Zm4.7-5.3l-1.4-1.4L17.6 5H14V3h7v7h-2V6.4Z" />
-            </svg>
-          </NuxtLink>
+          If you want to send a PR, click on <strong>Edit</strong> link on the corresponding translation file, it will open the translation file in GitHub
         </div>
       </caption>
       <thead>
@@ -128,10 +117,10 @@ async function copyToClipboard() {
               </td>
               <td>
                 <NuxtLink
-                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
+                  :href="`https://github.com/elk-zone/elk/tree/main/locales/${useFile}`"
                   target="_blank"
-                  class="codeflow"
-                  title="Raise a PR with Codeflow (opens in new window)"
+                  class="edit-in-github"
+                  title="Edit Translation File (opens in new window)"
                   @click.stop
                 >
                   Edit
@@ -154,10 +143,10 @@ async function copyToClipboard() {
               <td><strong>{{ `${total}` }}</strong></td>
               <td>
                 <NuxtLink
-                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
+                  :href="`https://github.com/elk-zone/elk/tree/main/locales/${useFile}`"
                   target="_blank"
-                  class="codeflow"
-                  title="Raise a PR with Codeflow (opens in new window)"
+                  class="edit-in-github"
+                  title="Edit Translation File (opens in new window)"
                   @click.stop
                 >
                   Edit
@@ -255,7 +244,7 @@ tr.expandable, tr.expandable td {
   cursor: pointer;
 }
 
-a.codeflow,
+a.edit-in-github,
 a.inline,
 td.expandable div {
   display: flex;

--- a/docs/content/1.guide/3.contributing.md
+++ b/docs/content/1.guide/3.contributing.md
@@ -2,12 +2,6 @@
 
 We're really excited that you're interested in contributing to Elk! Before submitting your contribution, please read through the following guide.
 
-## Online
-
-You can use [StackBlitz Codeflow](https://stackblitz.com/codeflow) to fix bugs or implement features. You'll also see a Codeflow button on PRs to review them without a local setup. Once the elk repo has been cloned in Codeflow, the dev server will start automatically and print the URL to open the App. You should receive a prompt in the bottom-right suggesting to open it in the Editor or in another Tab. To learn more, check out the [Codeflow docs](https://developer.stackblitz.com/codeflow/what-is-codeflow).
-
-[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/elk-zone/elk)
-
 ## Local Setup
 
 Clone the repository and run on the root folder:


### PR DESCRIPTION
I paused the codeflow app a while ago, but didn't remove the links to it in the guides. This PR removes these references as currently codeflow isn't working correctly for Elk.