### PR TITLE
fix: Move the dialog position from center to start

### DIFF
--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -144,7 +144,7 @@ useEventListener('keydown', (e: KeyboardEvent) => {
         <div class="dialog-mask" absolute inset-0 z-0 bg-black opacity-48 touch-none h="[calc(100%+0.5px)]" @click="clickMask" />
         <!-- Dialog container -->
         <div class="p-safe-area" absolute inset-0 z-1 pointer-events-none opacity-100 flex>
-          <div flex-1 flex items-center justify-center p-4>
+          <div flex-1 flex items-start justify-center p-4>
             <!-- We use `class` here to make v-bind being able to be override them -->
             <div
               ref="elDialogMain"


### PR DESCRIPTION
## Summary
This pull request relocates the modal dialog from the center of the screen to the top.

## Problem
The current modal dialog is displayed in the center. When the operating system's on-screen keyboard appears, there's a risk that it will cover the dialog, making it difficult or impossible for the user to see or interact with it.

<img src="https://github.com/user-attachments/assets/85b05381-2e54-4006-84f5-3a7b2f242713" height="360" alt="Showing　mobile app editing dialog"><img src="https://github.com/user-attachments/assets/4d44173f-7149-4d3b-88de-5b1355d89e3d" height="360" alt="Android OS keyboard partially obscures the bottom of the dialog">

## Solution
To prevent this potential overlap issue, the modal dialog's vertical alignment has been changed from `items-center` to `items-start`. This ensures the dialog remains visible even when the keyboard is active.

<img src="https://github.com/user-attachments/assets/30c89a55-fc79-4e12-9349-a6e7d3715f7a" height="360" alt="Modal dialog is not covered by the keyboard at the bottom">
