### PR TITLE
fix: Right-click causes image drag on ModalMediaPreviewCarousel

### DIFF
--- a/components/modal/ModalMediaPreviewCarousel.vue
+++ b/components/modal/ModalMediaPreviewCarousel.vue
@@ -32,6 +32,7 @@ const y = ref(0)
 
 const isDragging = ref(false)
 const isPinching = ref(false)
+const isRightClicking = ref(false)
 
 const maxZoomOut = ref(1)
 const isZoomedIn = computed(() => scale.value > 1)
@@ -78,6 +79,10 @@ useGesture({
       goToFocusedSlide()
   },
   onDrag({ movement, delta, pinching, tap, last, swipe, event, xy }) {
+    // Ignore right-click events
+    if (isRightClicking.value)
+      return
+
     event.preventDefault()
 
     if (pinching)
@@ -87,6 +92,14 @@ useGesture({
       handleLastDrag(tap, swipe, movement, xy)
     else
       handleDrag(delta, movement)
+  },
+  onDragStart({ event }) {
+    isRightClicking.value = event.button === 2
+    isDragging.value = true
+  },
+  onDragEnd() {
+    isRightClicking.value = false
+    isDragging.value = false
   },
 }, {
   domTarget: view,


### PR DESCRIPTION
## Description

When a drag on the image preview (the "modal media preview carousel") begins, check if the mouse right-click button is down. If it is down, prevent the carousel drag behavior.

This is to fix the issue where you right-click on an image to show the browser right-click menu, but the carousel thinks you're now dragging the carousel.

## Videos

The video below first shows the bug on the current stable build. And then it shows the behavior on the dev build with the new code. The image is no longer dragged on right-click.

https://github.com/user-attachments/assets/5d3716a4-4eff-4685-b22c-64422fa7ca22


- [X] Tested
- [X] Linted

Fixes #3264 

## Misc Notes

Vertical dragging should probably be supressed, as well as dragging when there is only a single media component. But, to keep this PR focused, I did not try to fix those UX quirks.