### PR TITLE
feat: show server info on aside when not signed in

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -12,6 +12,7 @@ const showUserPicker = logicAnd(
 )
 
 const isGrayscale = usePreferences('grayscaleMode')
+const instance = instanceStorage.value[currentServer.value]
 </script>
 
 <template>
@@ -63,8 +64,17 @@ const isGrayscale = usePreferences('grayscaleMode')
         <div sticky top-0 h-100dvh flex="~ col" gap-2 py3 ms-2>
           <slot name="right">
             <SearchWidget mt-4 mx-1 hidden xl:block />
-            <div flex-auto />
 
+            <!-- server info -->
+            <div v-if="!currentUser" grid gap-3 m3>
+              <span text-size-lg text-primary font-bold>{{ instance.title }}</span>
+              <img rounded-3 :src="instance.thumbnail.url">
+              <p text-secondary>
+                {{ instance.description }}
+              </p>
+            </div>
+
+            <div flex-auto />
             <PwaPrompt />
             <PwaInstallPrompt />
             <LazyCommonPreviewPrompt v-if="info.env === 'preview'" />

--- a/pages/[[server]]/index.vue
+++ b/pages/[[server]]/index.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+const instance = instanceStorage.value[currentServer.value]
+try {
+  clearError({ redirect: currentUser.value ? '/home' : `/${currentServer.value}/public/local` })
+}
+catch (err) {
+  console.error(err)
+}
+</script>
+
+<template>
+  <MainContent text-base grid gap-3 m3>
+    <img rounded-3 :src="instance.thumbnail.url">
+  </MainContent>
+</template>


### PR DESCRIPTION
This will show the instance information (title, thumbnail, description) when there is no signed in user.

## Screenshots

<img width="1260" alt="Screenshot 2025-04-25 at 23 57 48" src="https://github.com/user-attachments/assets/b6585d35-0f34-4ec0-8971-571a1058822c" />
<img width="1237" alt="Screenshot 2025-04-25 at 23 58 04" src="https://github.com/user-attachments/assets/cf5fd632-1c35-4712-bb40-1ae59c9df58d" />
<img width="1205" alt="Screenshot 2025-04-25 at 23 58 35" src="https://github.com/user-attachments/assets/f5ffe3b1-88a4-4147-98f0-adb2716754e9" />

## How it looks on mastodon web app

<img width="1234" alt="Screenshot 2025-04-26 at 00 01 14" src="https://github.com/user-attachments/assets/b01f5624-7a27-437c-a384-86460e292067" />
<img width="1235" alt="Screenshot 2025-04-26 at 00 01 20" src="https://github.com/user-attachments/assets/70b60c76-12be-45e1-b93b-f3d14d0122a1" />
<img width="1244" alt="Screenshot 2025-04-26 at 00 01 31" src="https://github.com/user-attachments/assets/37b567f7-ac8b-4e97-ade7-77fd74933055" />
