### PR TITLE
fix: fetch for followed tags needs authorized session

### DIFF
--- a/components/timeline/TimelineHome.vue
+++ b/components/timeline/TimelineHome.vue
@@ -11,7 +11,10 @@ function reorderAndFilter(items: mastodon.v1.Status[]) {
   return reorderedTimeline(items, 'home')
 }
 
-const followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+let followedTags: mastodon.v1.Tag[] | undefined
+if (currentUser.value !== undefined) {
+  followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+}
 </script>
 
 <template>

--- a/components/timeline/TimelinePaginator.vue
+++ b/components/timeline/TimelinePaginator.vue
@@ -25,7 +25,7 @@ const showOriginSite = computed(() =>
 function getFollowedTag(status: mastodon.v1.Status): string | null {
   const followedTagNames = followedTags.map(tag => tag.name)
   const followedStatusTags = status.tags.filter(tag => followedTagNames.includes(tag.name))
-  return followedStatusTags.length ? followedStatusTags[0]?.name : null
+  return followedStatusTags.length > 0 ? followedStatusTags[0]?.name : null
 }
 </script>
 

--- a/components/timeline/TimelinePublic.vue
+++ b/components/timeline/TimelinePublic.vue
@@ -7,7 +7,10 @@ function reorderAndFilter(items: mastodon.v1.Status[]) {
   return reorderedTimeline(items, 'public')
 }
 
-const followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+let followedTags: mastodon.v1.Tag[] | undefined
+if (currentUser.value !== undefined) {
+  followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+}
 </script>
 
 <template>

--- a/components/timeline/TimelinePublicLocal.vue
+++ b/components/timeline/TimelinePublicLocal.vue
@@ -7,7 +7,10 @@ function reorderAndFilter(items: mastodon.v1.Status[]) {
   return reorderedTimeline(items, 'public')
 }
 
-const followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+let followedTags: mastodon.v1.Tag[] | undefined
+if (currentUser.value !== undefined) {
+  followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+}
 </script>
 
 <template>

--- a/pages/[[server]]/tags/[tag].vue
+++ b/pages/[[server]]/tags/[tag].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { mastodon } from 'masto'
+
 definePageMeta({
   name: 'tag',
 })
@@ -23,7 +25,11 @@ onReactivated(() => {
   // The user will see the previous content first, and any changes will be updated to the UI when the request is completed
   refresh()
 })
-const followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+
+let followedTags: mastodon.v1.Tag[] | undefined
+if (currentUser.value !== undefined) {
+  followedTags = (await useMasto().client.value.v1.followedTags.list({ limit: 0 }))
+}
 </script>
 
 <template>


### PR DESCRIPTION
Currently main.elk.zone public timelines are broken when there is no user session due to change in #3273 😥

The fetch for "followed tags" need an authorized user session.

This PR will check for a user session before requesting "followed tags"

### Problem:

![Screenshot 2025-04-27 at 21 19 16](https://github.com/user-attachments/assets/310d5fb7-cd08-4467-9569-e39e729ea7f4)
