### PR TITLE
[WIP] fix: temporary mitigation for locale number format issue

### DIFF
--- a/composables/i18n.ts
+++ b/composables/i18n.ts
@@ -22,9 +22,18 @@ export function useHumanReadableNumber() {
   }
 
   return {
-    formatHumanReadableNumber: (num: MaybeRef<number>) => fn(unref(num)),
-    formatNumber: (num: MaybeRef<number>) => n(unref(num), 'smallCounting', locale.value),
-    formatPercentage: (num: MaybeRef<number>) => n(unref(num), 'percentage', locale.value),
+    formatHumanReadableNumber: (num: MaybeRef<number>) => {
+      return String(unref(num))
+      return fn(unref(num))
+    },
+    formatNumber: (num: MaybeRef<number>) => {
+      return String(unref(num))
+      return n(unref(num), 'smallCounting', locale.value)
+    },
+    formatPercentage: (num: MaybeRef<number>) => {
+      return String(unref(num))
+      return n(unref(num), 'percentage', locale.value)
+    },
     forSR: (num: MaybeRef<number>) => unref(num) > 10000,
   }
 }


### PR DESCRIPTION
fix #3241

My findings so far:
- In [`LocalizedNumber.vue`](https://github.com/elk-zone/elk/blob/60b1d0224c2b2d371c6280cc2d477e669944e852/components/common/LocalizedNumber.vue#L13-L15), `count` has the right number but `formatNumber(count)` and `formatHumanReadableNumber(count)` returns `''` causing no number presented.
- Custom formats like `smallCounting` are defined in [`config/i18n.ts`](https://github.com/elk-zone/elk/blob/55ad2438ed7703331d38b26888e128ee824bd6e6/config/i18n.ts#L326-L343). I guess those are not used properly now. This might be caused by `vue-i18n`'s upgrade (now v10.0.5) and the possible `n()` function's behavior change. But I don't understand how `vue-i18n` works yet.