### PR TITLE
feat: pass origin as website when loging into server

### DIFF
--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -60,7 +60,7 @@ async function fetchAppInfo(origin: string, server: string) {
       },
       body: {
         client_name: APP_NAME + (env !== 'release' ? ` (${env})` : ''),
-        website: 'https://elk.zone',
+        website: origin,
         redirect_uris: getRedirectURI(origin, server),
         scopes: 'read write follow push',
       },


### PR DESCRIPTION
- helps users know which elk server(s) they have active login sessions with
- currently all login sessions are 'elk.zone'


# testing
- npm run dev
-  logged into my gotosocial server, inspected tokens under /settings/user/tokens, confirmed "App website" pointed to my local elk dev instance