### PR TITLE
fix: Proposal to use the "moon" icon for unlisted posts

### DIFF
--- a/app/composables/masto/icons.ts
+++ b/app/composables/masto/icons.ts
@@ -72,7 +72,7 @@ export const statusVisibilities = [
   },
   {
     value: 'unlisted',
-    icon: 'i-ri:lock-unlock-line',
+    icon: 'i-ri:moon-line',
   },
   {
     value: 'private',


### PR DESCRIPTION
Fixes #3309 by changing the unlisted post icon from lock to moon.