### PR TITLE
feat: add support for the Translation API

### DIFF
--- a/app/components/status/StatusBody.vue
+++ b/app/components/status/StatusBody.vue
@@ -11,7 +11,7 @@ const {
   withAction?: boolean
 }>()
 
-const { translation } = useTranslation(status, getLanguageCode())
+const { translation } = await useTranslation(status, getLanguageCode())
 
 const emojisObject = useEmojisFallback(() => status.emojis)
 const vnode = computed(() => {

--- a/app/components/status/StatusTranslation.vue
+++ b/app/components/status/StatusTranslation.vue
@@ -9,7 +9,7 @@ const {
   toggle: _toggleTranslation,
   translation,
   enabled: isTranslationEnabled,
-} = useTranslation(status, getLanguageCode())
+} = await useTranslation(status, getLanguageCode())
 const preferenceHideTranslation = usePreferences('hideTranslation')
 
 const showButton = computed(() =>

--- a/app/composables/masto/translate.ts
+++ b/app/composables/masto/translate.ts
@@ -115,16 +115,15 @@ export async function useTranslation(status: mastodon.v1.Status | mastodon.v1.St
   const translation = translations.get(status)!
   const userSettings = useUserSettings()
 
-  let shouldTranslate = false as boolean
+  let shouldTranslate = false
   if ('language' in status) {
-    shouldTranslate = !!(status.language && status.language !== to
-      && !userSettings.value.disabledTranslationLanguages.includes(status.language))
+    shouldTranslate = typeof status.language === 'string' && status.language !== to && !userSettings.value.disabledTranslationLanguages.includes(status.language)
     if (!translationAPISupported) {
-      shouldTranslate = supportedTranslationCodes.includes(to as any)
+      shouldTranslate = shouldTranslate && supportedTranslationCodes.includes(to as any)
         && supportedTranslationCodes.includes(status.language as any)
     }
     else {
-      shouldTranslate = (await (globalThis as any).Translator.availability({
+      shouldTranslate = shouldTranslate && (await (globalThis as any).Translator.availability({
         sourceLanguage: status.language,
         targetLanguage: to,
       })) !== 'unavailable'

--- a/app/composables/masto/translate.ts
+++ b/app/composables/masto/translate.ts
@@ -42,6 +42,10 @@ export const supportedTranslationCodes = [
   'zh',
 ] as const
 
+const translationAPISupported = 'Translator' in globalThis && 'LanguageDetector' in globalThis
+
+const anchorMarkupRegEx = /<a[^>]*>.*?<\/a>/g
+
 export function getLanguageCode() {
   let code = 'en'
   const getCode = (code: string) => code.replace(/-.*$/, '')
@@ -58,6 +62,13 @@ interface TranslationErr {
   }
 }
 
+function replaceTranslatedLinksWithOriginal(text: string) {
+  return text.replace(anchorMarkupRegEx, (match) => {
+    const tagLink = anchorMarkupRegEx.exec(text)
+    return tagLink ? tagLink[0] : match
+  })
+}
+
 export async function translateText(text: string, from: string | null | undefined, to: string) {
   const config = useRuntimeConfig()
   const status = ref({
@@ -65,7 +76,6 @@ export async function translateText(text: string, from: string | null | undefine
     error: '',
     text: '',
   })
-  const regex = /<a[^>]*>.*?<\/a>/g
   try {
     const response = await ($fetch as any)(config.public.translateApi, {
       method: 'POST',
@@ -78,11 +88,7 @@ export async function translateText(text: string, from: string | null | undefine
       },
     }) as TranslationResponse
     status.value.success = true
-    // replace the translated links with the original
-    status.value.text = response.translatedText.replace(regex, (match) => {
-      const tagLink = regex.exec(text)
-      return tagLink ? tagLink[0] : match
-    })
+    status.value.text = replaceTranslatedLinksWithOriginal(response.translatedText)
   }
   catch (err) {
     // TODO: improve type
@@ -102,17 +108,25 @@ const translations = new WeakMap<mastodon.v1.Status | mastodon.v1.StatusEdit, {
   error: string
 }>()
 
-export function useTranslation(status: mastodon.v1.Status | mastodon.v1.StatusEdit, to: string) {
+export async function useTranslation(status: mastodon.v1.Status | mastodon.v1.StatusEdit, to: string) {
   if (!translations.has(status))
     translations.set(status, reactive({ visible: false, text: '', success: false, error: '' }))
 
   const translation = translations.get(status)!
   const userSettings = useUserSettings()
 
-  const shouldTranslate = 'language' in status && status.language && status.language !== to
-    && supportedTranslationCodes.includes(to as any)
-    && supportedTranslationCodes.includes(status.language as any)
+  let shouldTranslate = 'language' in status && status.language && status.language !== to
     && !userSettings.value.disabledTranslationLanguages.includes(status.language)
+  if (!translationAPISupported) {
+    shouldTranslate = supportedTranslationCodes.includes(to as any)
+      && supportedTranslationCodes.includes(status.language as any)
+  }
+  else {
+    shouldTranslate = (await (globalThis as any).Translator.availability({
+      sourceLanguage: status.language,
+      targetLanguage: to,
+    })) !== 'unavailable'
+  }
   const enabled = /*! !useRuntimeConfig().public.translateApi && */ shouldTranslate
 
   async function toggle() {
@@ -120,12 +134,55 @@ export function useTranslation(status: mastodon.v1.Status | mastodon.v1.StatusEd
       return
 
     if (!translation.text) {
-      const translated = await translateText(status.content, status.language, to)
+      let translated = {
+        value: {
+          error: '',
+          text: '',
+          success: false,
+        },
+      }
+      if (translationAPISupported) {
+        let sourceLanguage = status.language
+        if (!sourceLanguage) {
+          const languageDetector = await (globalThis as any).LanguageDetector.create()
+          // Make sure HTML markup doesn't derail language detection.
+          const p = document.createElement('p')
+          p.innerHTML = status.content
+          // eslint-disable-next-line unicorn/prefer-dom-node-text-content
+          const detectedLanguages = await languageDetector.detect(p.innerText)
+          sourceLanguage = detectedLanguages[0].detectedLanguage
+          if (sourceLanguage === 'und') {
+            throw new Error('Could not detect source language.')
+          }
+        }
+        const translator = await (globalThis as any).Translator.create({
+          sourceLanguage,
+          targetLanguage: to,
+        })
+        try {
+          let text = await translator.translate(status.content)
+          text = replaceTranslatedLinksWithOriginal(text)
+          translated.value = {
+            error: '',
+            text,
+            success: true,
+          }
+        }
+        catch (error) {
+          translated.value = {
+            error: (error as Error).message,
+            text: '',
+            success: false,
+          }
+        }
+      }
+      else {
+        translated = await translateText(status.content, status.language, to)
+      }
       translation.error = translated.value.error
       translation.text = translated.value.text
       translation.success = translated.value.success
     }
-
     translation.visible = !translation.visible
   }
 

--- a/app/composables/masto/translate.ts
+++ b/app/composables/masto/translate.ts
@@ -148,10 +148,10 @@ export async function useTranslation(status: mastodon.v1.Status | mastodon.v1.St
         if (!sourceLanguage) {
           const languageDetector = await (globalThis as any).LanguageDetector.create()
           // Make sure HTML markup doesn't derail language detection.
-          const p = document.createElement('p')
-          p.innerHTML = status.content
+          const div = document.createElement('div')
+          div.innerHTML = status.content
           // eslint-disable-next-line unicorn/prefer-dom-node-text-content
-          const detectedLanguages = await languageDetector.detect(p.innerText)
+          const detectedLanguages = await languageDetector.detect(div.innerText)
           sourceLanguage = detectedLanguages[0].detectedLanguage
           if (sourceLanguage === 'und') {
             throw new Error('Could not detect source language.')


### PR DESCRIPTION
Currently, translations happen on the server by making a `POST` request to `https://translate.elk.zone/translate` as can be seen in Elk's production version and by inspecting the **Network** tab, filtering for `"translate"`:

![Screenshot 2025-06-16 at 19 18 22](https://github.com/user-attachments/assets/dad76a78-4b76-442f-89a4-9d4c32601ae6)

This PR adds support for the experimental [Translation API](https://developer.chrome.com/docs/ai/translator-api) in Chrome, which consists of the Language Detector and the Translator API. These two APIa are currently in origin trials ([Translator API](https://developer.chrome.com/origintrials/#/view_trial/4445615782168100865), [Language Detector API](https://developer.chrome.com/origintrials/#/view_trial/662592095176884225)), so they can be tested already by real users.

![Screenshot 2025-06-16 at 19 20 02](https://github.com/user-attachments/assets/2720ea28-2baf-463e-9526-556f6966f48b)

The advantage over the current approach is reduced server costs for Elk, and full offline support, which, for example, would allow for using this API to translate DMs in a privacy-preserving way.