### PR TITLE
fix(profile): incorrect "pinned post" label shown on other account

### DIFF
--- a/app/components/status/StatusCard.vue
+++ b/app/components/status/StatusCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
 
-const { actions = true, older, newer, hasOlder, hasNewer, main, ...props } = defineProps<{
+const { actions = true, older, newer, hasOlder, hasNewer, main, account, ...props } = defineProps<{
   status: mastodon.v1.Status
   followedTag?: string | null
   actions?: boolean
@@ -20,6 +20,7 @@ const { actions = true, older, newer, hasOlder, hasNewer, main, ...props } = def
   // When looking into a detailed view of a post, we can simplify the replying badges
   // to the main expanded post
   main?: mastodon.v1.Status
+  account?: mastodon.v1.Account
 }>()
 
 const userSettings = useUserSettings()
@@ -60,7 +61,10 @@ const timeago = useTimeAgo(() => status.value.createdAt, timeAgoOptions)
 const isSelfReply = computed(() => status.value.inReplyToAccountId === status.value.account.id)
 const collapseRebloggedBy = computed(() => rebloggedBy.value?.id === status.value.account.id)
 const isDM = computed(() => status.value.visibility === 'direct')
-const isPinned = computed(() => status.value.pinned)
+const isPinned = computed(
+  () =>
+    !!props.status.pinned && account?.id === status.value.account.id,
+)
 
 const showUpperBorder = computed(() => newer && !directReply.value)
 const showReplyTo = computed(() => !replyToMain.value && !directReply.value)

--- a/app/components/timeline/TimelinePaginator.vue
+++ b/app/components/timeline/TimelinePaginator.vue
@@ -39,11 +39,11 @@ function getFollowedTag(status: mastodon.v1.Status): string | null {
     <template #default="{ item, older, newer, active }">
       <template v-if="virtualScroller">
         <DynamicScrollerItem :item="item" :active="active" tag="article">
-          <StatusCard :followed-tag="getFollowedTag(item)" :status="item" :context="context" :older="older" :newer="newer" />
+          <StatusCard :followed-tag="getFollowedTag(item)" :status="item" :context="context" :older="older" :newer="newer" :account="account" />
         </DynamicScrollerItem>
       </template>
       <template v-else>
-        <StatusCard :followed-tag="getFollowedTag(item)" :status="item" :context="context" :older="older" :newer="newer" />
+        <StatusCard :followed-tag="getFollowedTag(item)" :status="item" :context="context" :older="older" :newer="newer" :account="account" />
       </template>
     </template>
     <template v-if="context === 'account' " #done="{ items }">


### PR DESCRIPTION
### Fix for #3161

#### Issue
A post authored by the current user and displayed on someone else's profile page was incorrectly shown as a "pinned post," even though it wasn't actually pinned by the profile owner.

#### Solution
Added logic to check whether the account of the profile being viewed matches the account of the post.
This ensures that pinned posts are only shown on the author's own profile, and not on others' profiles.

This is my first pull request to this project, so I apologize in advance if I've missed any contribution guidelines.