### PR TITLE
fix(ui): increase target size of back button

### DIFF
--- a/app/components/main/MainContent.vue
+++ b/app/components/main/MainContent.vue
@@ -35,15 +35,16 @@ const containerClass = computed(() => {
         'backdrop-blur': !getPreferences(userSettings, 'optimizeForLowPerformanceDevice'),
       }"
     >
-      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
-        <div flex gap-3 items-center :overflow-hidden="!noOverflowHidden ? '' : false" py2 w-full>
-          <NuxtLink
-            v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
+      <div flex justify-between gap-2 min-h-53px px5 py1 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
+        <div flex gap-2 items-center :overflow-hidden="!noOverflowHidden ? '' : false" w-full>
+          <button
+            v-if="backOnSmallScreen || back"
+            btn-text flex items-center ms="-3" p-3 xl:hidden
             :aria-label="$t('nav.back')"
             @click="$router.go(-1)"
           >
-            <div i-ri:arrow-left-line class="rtl-flip" />
-          </NuxtLink>
+            <div text-lg i-ri:arrow-left-line class="rtl-flip" />
+          </button>
           <div :truncate="!noOverflowHidden ? '' : false" flex w-full data-tauri-drag-region class="native-mac:justify-start native-mac:text-center">
             <slot name="title" />
           </div>

--- a/app/components/nav/NavTitle.vue
+++ b/app/components/nav/NavTitle.vue
@@ -33,17 +33,16 @@ router.afterEach(() => {
         {{ $t('app_name') }} <sup text-sm italic mt-1>{{ env === 'release' ? 'alpha' : env }}</sup>
       </div>
     </NuxtLink>
-    <div
-      hidden xl:flex items-center me-8 mt-2 gap-1
-    >
-      <CommonTooltip :content="$t('nav.back')">
-        <NuxtLink
+    <div hidden xl:flex items-center me-6 mt-2 gap-1>
+      <CommonTooltip :content="$t('nav.back')" :distance="0">
+        <button
+          type="button"
           :aria-label="$t('nav.back')"
-          :class="{ 'pointer-events-none op0': !back || back === '/', 'xl:flex': $route.name !== 'tag' }"
+          btn-text p-3 :class="{ 'pointer-events-none op0': !back || back === '/', 'xl:flex': $route.name !== 'tag' }"
           @click="$router.go(-1)"
         >
-          <div text-xl i-ri:arrow-left-line class="rtl-flip" btn-text />
-        </NuxtLink>
+          <div text-xl i-ri:arrow-left-line class="rtl-flip" />
+        </button>
       </CommonTooltip>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1836, which has links to the relevant WCAG success criterion, as well as Material Design guidelines and Apple HIG.

This small UI problem has been bothering me as an Elk user for a couple years. I still routinely miss clicks on the header's back button because its target area is so small. So here's a fix at last ^^

This PR:

- Increases the size of the sidebar (large screens) back button's target area from 30x22.5 to 45x45.
- Increases the size of the header (small & medium screens) back button's target area from 18x18 to 42.75x42.75.
- Sets a minimum height on the header, so that its height does not depend only on a combination of nested padding values and the presence or absence or specific buttons or content elements.
- Changes the buttons from `<a>` without a `href` (the result of using `<NuxtLink>` without a `to` or `href` prop) to `<button>` instead, so that the buttons are recognized as, well, buttons, and can be focused. Anchors without a `href` are not considered interactive elements and cannot receive focus.

Elements in Elk's UI are sized using increments of `0.25rem` as well as text sizes also expressed in fractions of `rem`, which can result in fractional pixel values like 42.75x42.75. I’ve kept this style instead of trying to hit specific sizes like 44x44 (Apple HIG) or 48x48 (Material Design). The only exception is the header's min-height, set to 53px (52px for content and 1px for the border).

Here are before-and-after comparisons, with the last image in each group showing the button's clickable area in purple.

![elk-back-button-small-screen](https://github.com/user-attachments/assets/ed2cb425-c48b-4382-99e0-7aab470ef7d6)

![elk-back-button-large-screen](https://github.com/user-attachments/assets/455d16ec-f5f7-4f76-991b-f934c47663ad)
