### PR TITLE
fix(ui): Asterisk pairs are removed in code block

### DIFF
--- a/app/composables/content-parse.ts
+++ b/app/composables/content-parse.ts
@@ -104,11 +104,12 @@ export function parseMastodonHTML(
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')
           .replace(/`/g, '&#96;')
+          .replace(/\*/g, '&ast;')
         const classes = lang ? ` class="language-${lang}"` : ''
         return `><pre><code${classes}>${code}</code></pre>`
       })
       .replace(/`([^`\n]*)`/g, (_1, raw) => {
-        return raw ? `<code>${htmlToText(raw).replace(/</g, '&lt;').replace(/>/g, '&gt;')}</code>` : ''
+        return raw ? `<code>${htmlToText(raw).replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\*/g, '&ast;')}</code>` : ''
       })
   }
 

--- a/tests/nuxt/__snapshots__/content-rich.test.ts.snap
+++ b/tests/nuxt/__snapshots__/content-rich.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`content-rich > asterisk paris in code block 1`] = `"<p><pre class="code-block">1 * 2 * 3</pre></p>"`;
+
 exports[`content-rich > block with backticks 1`] = `"<p><pre class="code-block">[(\`number string) (\`tag string)]</pre></p>"`;
 
 exports[`content-rich > block with injected html, with a known language 1`] = `

--- a/tests/nuxt/__snapshots__/content-rich.test.ts.snap
+++ b/tests/nuxt/__snapshots__/content-rich.test.ts.snap
@@ -2,6 +2,11 @@
 
 exports[`content-rich > asterisk paris in code block 1`] = `"<p><pre class="code-block">1 * 2 * 3</pre></p>"`;
 
+exports[`content-rich > asterisk paris in inline code 1`] = `
+"<p><code>1 * 2 * 3</code></p>
+"
+`;
+
 exports[`content-rich > block with backticks 1`] = `"<p><pre class="code-block">[(\`number string) (\`tag string)]</pre></p>"`;
 
 exports[`content-rich > block with injected html, with a known language 1`] = `

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -186,6 +186,11 @@ describe('content-rich', () => {
     `)
     expect(formatted).toMatchSnapshot()
   })
+
+  it ('asterisk paris in code block', async () => {
+    const { formatted } = await render('<p>```<br />1 * 2 * 3<br />```</p>')
+    expect(formatted).toMatchSnapshot()
+  })
 })
 
 describe('editor', () => {

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -187,6 +187,11 @@ describe('content-rich', () => {
     expect(formatted).toMatchSnapshot()
   })
 
+  it ('asterisk paris in inline code', async () => {
+    const { formatted } = await render('<p>`1 * 2 * 3`</p>')
+    expect(formatted).toMatchSnapshot()
+  })
+
   it ('asterisk paris in code block', async () => {
     const { formatted } = await render('<p>```<br />1 * 2 * 3<br />```</p>')
     expect(formatted).toMatchSnapshot()


### PR DESCRIPTION
### Fix for #3266

Fix: Asterisk Rendering in Code Blocks
I've fixed the problem where pairs of asterisks were disappearing inside code blocks. My solution involves converting these asterisk pairs into HTML entities, which makes sure they now render correctly.

![image](https://github.com/user-attachments/assets/1862414e-7a0b-4c5e-8903-0e21f43c9da1)
