### PR TITLE
fix(ui): back-on-small-screen logic in settings

### DIFF
--- a/app/components/main/MainContent.vue
+++ b/app/components/main/MainContent.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-defineProps<{
-  /** Show the back button on small screens */
-  backOnSmallScreen?: boolean
-  /** Show the back button on both small and big screens */
-  back?: boolean
+const { back = false } = defineProps<{
+  /**
+   * Should we show a back button?
+   * Note: this will be forced to false on xl screens to avoid duplicating the sidebar's back button.
+   */
+  back?: boolean | 'small-only'
   /** Do not applying overflow hidden to let use floatable components in title */
   noOverflowHidden?: boolean
 }>()
@@ -22,6 +23,17 @@ const containerClass = computed(() => {
 
   return 'lg:sticky lg:top-0'
 })
+
+const showBackButton = computed(() => {
+  switch (back) {
+    case 'small-only':
+      return isSmallOrMediumScreen.value
+    case true:
+      return !isExtraLargeScreen.value
+    default:
+      return false
+  }
+})
 </script>
 
 <template>
@@ -38,8 +50,8 @@ const containerClass = computed(() => {
       <div flex justify-between gap-2 min-h-53px px5 py1 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
         <div flex gap-2 items-center :overflow-hidden="!noOverflowHidden ? '' : false" w-full>
           <button
-            v-if="backOnSmallScreen || back"
-            btn-text flex items-center ms="-3" p-3 xl:hidden
+            v-if="showBackButton"
+            btn-text flex items-center ms="-3" p-3
             :aria-label="$t('nav.back')"
             @click="$router.go(-1)"
           >

--- a/app/composables/screen.ts
+++ b/app/composables/screen.ts
@@ -2,6 +2,7 @@ import { breakpointsTailwind } from '@vueuse/core'
 
 export const breakpoints = useBreakpoints(breakpointsTailwind)
 
-export const isSmallScreen = breakpoints.smallerOrEqual('sm')
+export const isSmallScreen = breakpoints.smaller('sm')
+export const isSmallOrMediumScreen = breakpoints.smaller('lg')
 export const isMediumOrLargeScreen = breakpoints.between('sm', 'xl')
-export const isExtraLargeScreen = breakpoints.smallerOrEqual('xl')
+export const isExtraLargeScreen = breakpoints.greaterOrEqual('xl')

--- a/app/pages/settings/about/index.vue
+++ b/app/pages/settings/about/index.vue
@@ -17,7 +17,7 @@ function handleShowCommit() {
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.about.label') }}</span>

--- a/app/pages/settings/interface/index.vue
+++ b/app/pages/settings/interface/index.vue
@@ -7,7 +7,7 @@ useHydratedHead({
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.interface.label') }}</span>

--- a/app/pages/settings/language/index.vue
+++ b/app/pages/settings/language/index.vue
@@ -15,7 +15,7 @@ const status = computed(() => {
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.language.label') }}</span>

--- a/app/pages/settings/notifications/index.vue
+++ b/app/pages/settings/notifications/index.vue
@@ -12,7 +12,7 @@ useHydratedHead({
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.notifications.label') }}</span>

--- a/app/pages/settings/preferences/index.vue
+++ b/app/pages/settings/preferences/index.vue
@@ -9,7 +9,7 @@ const userSettings = useUserSettings()
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <h1 text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         {{ $t('settings.preferences.label') }}

--- a/app/pages/settings/profile/index.vue
+++ b/app/pages/settings/profile/index.vue
@@ -11,7 +11,7 @@ useHydratedHead({
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.profile.label') }}</span>

--- a/app/pages/settings/users/index.vue
+++ b/app/pages/settings/users/index.vue
@@ -66,7 +66,7 @@ async function importTokens() {
 </script>
 
 <template>
-  <MainContent back-on-small-screen>
+  <MainContent back="small-only">
     <template #title>
       <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
         <span>{{ $t('settings.users.label') }}</span>


### PR DESCRIPTION
The `MainContent` component has a `backOnSmallScreen` boolean prop which is a variant of its `back` prop, and is used for settings pages.

Based on the current code, its intent seems to have been to avoid showing a back button when the settings are shown in a 2 column layout, with the settings categories on the left and the content for the currently selected category on the right. This means that the current rendering at a 1024px width is wrong:

![Screenshot of an Elk settings page showing 3 columns: a column of icons on the left, a column of settings categories in the middle, and a form-like settings page on the rightmost column. The rightmost column has a back button in its header.](https://github.com/user-attachments/assets/0325a130-7f10-4648-9288-47d726a1ee14)

This is probably explained by the current template having this logic for rendering the back button:

```vue
<button
  v-if="backOnSmallScreen || back"
  xl:hidden
>
```

Which is inconsistent logic that makes the `back` and `backOnSmallScreen` props identical, and was the result of this commit that removed a conditional class coupled to the `backOnSmallScreen` prop:

https://github.com/elk-zone/elk/commit/af85a5ea8d74e956a3f81969be3e27fb30f76b25#diff-8047d450d250724e6d8a943121218d82f64e307a9055744a041d159325df2d68L20-R20

As a fix, this PR:

- Refactors the `back` and `backOnSmallScreen` props into one `back?: boolean | 'small-only'` prop. (Because setting `{ back: false, backOnSmallScreen: true }` would be illogical.)
- Uses a computed property to determine if we should show the back button, instead of mixing `v-if` and CSS classes.
- Uses breakpoint composables, including a new `isSmallOrMediumScreen` one, to use in that computed property logic.

An alternative and simpler fix is to just live with the behavior that has shipped for 2+ years (i.e. remove the `backOnSmallScreen` prop and change its call sites to use `back` instead). The UI logic for when to show this back button or not in Settings sub-pages is a bit involved and prone to breakage, so maybe just having those back buttons displayed (as in the screenshot above) is best?