### PR TITLE
fix(ui): improve timeline title spacing, truncation

### DIFF
--- a/app/components/main/MainContent.vue
+++ b/app/components/main/MainContent.vue
@@ -4,8 +4,6 @@ defineProps<{
   backOnSmallScreen?: boolean
   /** Show the back button on both small and big screens */
   back?: boolean
-  /** Do not applying overflow hidden to let use floatable components in title */
-  noOverflowHidden?: boolean
 }>()
 
 const container = ref()
@@ -36,7 +34,7 @@ const containerClass = computed(() => {
       }"
     >
       <div flex justify-between gap-2 min-h-53px px5 py1 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
-        <div flex gap-2 items-center :overflow-hidden="!noOverflowHidden ? '' : false" w-full>
+        <div flex gap-2 items-center overflow-hidden w-full>
           <button
             v-if="backOnSmallScreen || back"
             btn-text flex items-center ms="-3" p-3 xl:hidden
@@ -45,7 +43,7 @@ const containerClass = computed(() => {
           >
             <div text-lg i-ri:arrow-left-line class="rtl-flip" />
           </button>
-          <div :truncate="!noOverflowHidden ? '' : false" flex w-full data-tauri-drag-region class="native-mac:justify-start native-mac:text-center">
+          <div truncate flex w-full data-tauri-drag-region class="native-mac:justify-start native-mac:text-center">
             <slot name="title" />
           </div>
           <div sm:hidden h-7 w-1px />

--- a/app/components/main/MainContent.vue
+++ b/app/components/main/MainContent.vue
@@ -33,22 +33,22 @@ const containerClass = computed(() => {
         'backdrop-blur': !getPreferences(userSettings, 'optimizeForLowPerformanceDevice'),
       }"
     >
-      <div flex justify-between gap-2 min-h-53px px5 py1 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
-        <div flex gap-2 items-center overflow-hidden w-full>
+      <div flex="~ justify-between" min-h-53px px-2 py-1 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
+        <div flex="~ items-center" w-full>
           <button
             v-if="backOnSmallScreen || back"
-            btn-text flex items-center ms="-3" p-3 xl:hidden
+            btn-text flex items-center p-3 xl:hidden
             :aria-label="$t('nav.back')"
             @click="$router.go(-1)"
           >
             <div text-lg i-ri:arrow-left-line class="rtl-flip" />
           </button>
-          <div truncate flex w-full data-tauri-drag-region class="native-mac:justify-start native-mac:text-center">
+          <div flex w-full data-tauri-drag-region class="native-mac:justify-start">
             <slot name="title" />
           </div>
           <div sm:hidden h-7 w-1px />
         </div>
-        <div flex items-center flex-shrink-0 gap-x-2>
+        <div flex="~ items-center shrink-0 gap-x-2" px-3>
           <slot name="actions" />
           <PwaBadge xl:hidden />
           <NavUser v-if="isHydrated" />

--- a/app/components/main/MainTitle.vue
+++ b/app/components/main/MainTitle.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+const { as = 'div' } = defineProps<{
+  as?: string
+  icon?: string
+  secondary?: boolean
+}>()
+
+function doScroll({ currentTarget, metaKey, ctrlKey }: MouseEvent | KeyboardEvent) {
+  // Ctrl+click or Command+click to open the link in a new tab
+  // should not scroll the current tab's timeline
+  if ((metaKey || ctrlKey) && (currentTarget as HTMLElement)?.nodeName === 'A') {
+    return
+  }
+  useNuxtApp().$scrollToTop()
+}
+</script>
+
+<template>
+  <component
+    :is="as"
+    class="
+      flex items-center gap-2 min-h-10 px-3
+      text-start text-lg lh-tight font-bold cursor-pointer
+    "
+    :class="{ 'text-primary': !secondary }"
+    @click="doScroll($event)"
+  >
+    <span v-if="icon" :class="icon" />
+    <span min-w-8 line-clamp-2>
+      <slot />
+    </span>
+  </component>
+</template>

--- a/app/error.vue
+++ b/app/error.vue
@@ -36,7 +36,7 @@ async function reload() {
   <NuxtLayout>
     <MainContent>
       <template #title>
-        <span timeline-title-style>Error</span>
+        <MainTitle>Error</MainTitle>
       </template>
       <slot>
         <form p5 grid gap-y-4 @submit="reload">

--- a/app/pages/[[server]]/@[account]/index.vue
+++ b/app/pages/[[server]]/@[account]/index.vue
@@ -23,12 +23,13 @@ onReactivated(() => {
 <template>
   <MainContent back>
     <template #title>
-      <ContentRich
-        timeline-title-style
-        :content="account ? getDisplayName(account) : t('nav.profile')"
-        :show-emojis="!getPreferences(userSettings, 'hideUsernameEmojis')"
-        :markdown="false"
-      />
+      <MainTitle>
+        <ContentRich
+          :content="account ? getDisplayName(account) : t('nav.profile')"
+          :show-emojis="!getPreferences(userSettings, 'hideUsernameEmojis')"
+          :markdown="false"
+        />
+      </MainTitle>
     </template>
 
     <template v-if="pending" />

--- a/app/pages/[[server]]/explore.vue
+++ b/app/pages/[[server]]/explore.vue
@@ -42,10 +42,9 @@ const tabs = computed<CommonRouteTabOption[]>(() => [
 <template>
   <MainContent>
     <template #title>
-      <span timeline-title-style flex items-center gap-2 cursor-pointer @click="$scrollToTop">
-        <div i-ri:compass-3-line />
-        <span>{{ t('nav.explore') }}</span>
-      </span>
+      <MainTitle icon="i-ri:compass-3-line">
+        {{ t('nav.explore') }}
+      </MainTitle>
     </template>
 
     <template #header>

--- a/app/pages/[[server]]/lists.vue
+++ b/app/pages/[[server]]/lists.vue
@@ -9,10 +9,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/lists" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:list-check />
-        <span text-lg font-bold>{{ t('nav.lists') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/lists" icon="i-ri:list-check">
+        {{ t('nav.lists') }}
+      </MainTitle>
     </template>
     <NuxtPage v-if="isHydrated" />
   </MainContent>

--- a/app/pages/[[server]]/public/index.vue
+++ b/app/pages/[[server]]/public/index.vue
@@ -9,10 +9,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/public" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:earth-line />
-        <span>{{ $t('title.federated_timeline') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/public" icon="i-ri:earth-line">
+        {{ $t('title.federated_timeline') }}
+      </MainTitle>
     </template>
 
     <TimelinePublic v-if="isHydrated" />

--- a/app/pages/[[server]]/public/local.vue
+++ b/app/pages/[[server]]/public/local.vue
@@ -9,10 +9,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/public/local" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:group-2-line />
-        <span>{{ t('title.local_timeline') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/public/local" icon="i-ri:group-2-line">
+        {{ $t('title.local_timeline') }}
+      </MainTitle>
     </template>
 
     <TimelinePublicLocal v-if="isHydrated" />

--- a/app/pages/[[server]]/search.vue
+++ b/app/pages/[[server]]/search.vue
@@ -25,10 +25,9 @@ watch(keys['/'], (v) => {
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/search" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:search-line class="rtl-flip" />
-        <span>{{ $t('nav.search') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/search" icon="i-ri:search-line rtl-flip">
+        {{ $t('nav.search') }}
+      </MainTitle>
     </template>
 
     <div px2 mt3>

--- a/app/pages/blocks.vue
+++ b/app/pages/blocks.vue
@@ -13,7 +13,7 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <span timeline-title-style>{{ $t('nav.blocked_users') }}</span>
+      <MainTitle>{{ $t('nav.blocked_users') }}</MainTitle>
     </template>
 
     <TimelineBlocks v-if="isHydrated" />

--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/bookmarks" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:bookmark-line />
-        <span>{{ t('nav.bookmarks') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/bookmarks" icon="i-ri:bookmark-line">
+        {{ t('nav.bookmarks') }}
+      </MainTitle>
     </template>
 
     <TimelineBookmarks v-if="isHydrated" />

--- a/app/pages/compose.vue
+++ b/app/pages/compose.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/compose" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:quill-pen-line />
-        <span>{{ $t('nav.compose') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/compose" icon="i-ri:quill-pen-line">
+        {{ $t('nav.compose') }}
+      </MainTitle>
     </template>
     <PublishWidgetFull />
   </MainContent>

--- a/app/pages/conversations.vue
+++ b/app/pages/conversations.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/conversations" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:at-line />
-        <span>{{ t('nav.conversations') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/conversations" icon="i-ri:at-line">
+        {{ t('nav.conversations') }}
+      </MainTitle>
     </template>
 
     <TimelineConversations v-if="isHydrated" />

--- a/app/pages/domain_blocks.vue
+++ b/app/pages/domain_blocks.vue
@@ -13,7 +13,7 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <span timeline-title-style>{{ $t('nav.blocked_domains') }}</span>
+      <MainTitle>{{ $t('nav.blocked_domains') }}</MainTitle>
     </template>
 
     <TimelineDomainBlocks v-if="isHydrated" />

--- a/app/pages/favourites.vue
+++ b/app/pages/favourites.vue
@@ -14,10 +14,12 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/favourites" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div :class="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'" />
-        <span>{{ t('nav.favourites') }}</span>
-      </NuxtLink>
+      <MainTitle
+        as="router-link" to="/favourites"
+        :icon="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'"
+      >
+        {{ t('nav.favourites') }}
+      </MainTitle>
     </template>
 
     <TimelineFavourites v-if="isHydrated" />

--- a/app/pages/hashtags.vue
+++ b/app/pages/hashtags.vue
@@ -9,10 +9,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/hashtags" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div class="i-ri:hashtag" />
-        <span>{{ t('nav.hashtags') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/hashtags" icon="i-ri:hashtag">
+        {{ t('nav.hashtags') }}
+      </MainTitle>
     </template>
 
     <NuxtPage v-if="isHydrated && currentUser" />

--- a/app/pages/home.vue
+++ b/app/pages/home.vue
@@ -18,10 +18,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/home" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:home-5-line />
-        <span>{{ $t('nav.home') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/home" icon="i-ri:home-5-line">
+        {{ $t('nav.home') }}
+      </MainTitle>
     </template>
 
     <TimelineHome v-if="isHydrated" />

--- a/app/pages/mutes.vue
+++ b/app/pages/mutes.vue
@@ -13,7 +13,7 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <span timeline-title-style>{{ $t('nav.muted_users') }}</span>
+      <MainTitle>{{ $t('nav.muted_users') }}</MainTitle>
     </template>
 
     <TimelineMutes v-if="isHydrated" />

--- a/app/pages/notifications.vue
+++ b/app/pages/notifications.vue
@@ -72,10 +72,9 @@ const moreOptions = computed<CommonRouteTabMoreOption>(() => ({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/notifications" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:notification-4-line />
-        <span>{{ t('nav.notifications') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/notifications" icon="i-ri:notification-4-line">
+        {{ t('nav.notifications') }}
+      </MainTitle>
     </template>
 
     <template #actions>

--- a/app/pages/pinned.vue
+++ b/app/pages/pinned.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent>
     <template #title>
-      <NuxtLink to="/pinned" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:pushpin-line />
-        <span>{{ t('account.pinned') }}</span>
-      </NuxtLink>
+      <MainTitle as="router-link" to="/pinned" icon="i-ri:pushpin-line">
+        {{ t('account.pinned') }}
+      </MainTitle>
     </template>
 
     <TimelinePinned v-if="isHydrated && currentUser" />

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -20,10 +20,9 @@ const isRootPath = computed(() => route.name === 'settings')
       <div border="e base" :class="isRootPath ? 'block lg:flex-none flex-1' : 'hidden lg:block'">
         <MainContent>
           <template #title>
-            <div timeline-title-style flex items-center gap-2 @click="$scrollToTop">
-              <div i-ri:settings-3-line />
-              <span>{{ $t('nav.settings') }}</span>
-            </div>
+            <MainTitle icon="i-ri:settings-3-line">
+              {{ $t('nav.settings') }}
+            </MainTitle>
           </template>
           <div xl:w-97 lg:w-78 w-full>
             <SettingsItem

--- a/app/pages/settings/about/index.vue
+++ b/app/pages/settings/about/index.vue
@@ -19,9 +19,9 @@ function handleShowCommit() {
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.about.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.about.label') }}
+      </MainTitle>
     </template>
 
     <div flex="~ col gap4" w-full items-center justify-center my5>

--- a/app/pages/settings/interface/index.vue
+++ b/app/pages/settings/interface/index.vue
@@ -9,9 +9,9 @@ useHydratedHead({
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.interface.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.interface.label') }}
+      </MainTitle>
     </template>
     <div px-6 pt-3 pb-6 flex="~ col gap6">
       <SettingsFontSize />

--- a/app/pages/settings/language/index.vue
+++ b/app/pages/settings/language/index.vue
@@ -17,9 +17,9 @@ const status = computed(() => {
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.language.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.language.label') }}
+      </MainTitle>
     </template>
     <div p6>
       <section space-y-2>

--- a/app/pages/settings/notifications/index.vue
+++ b/app/pages/settings/notifications/index.vue
@@ -14,9 +14,9 @@ useHydratedHead({
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.notifications.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.notifications.label') }}
+      </MainTitle>
     </template>
 
     <SettingsItem

--- a/app/pages/settings/notifications/notifications.vue
+++ b/app/pages/settings/notifications/notifications.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:test-tube-line />
-        <span>{{ $t('settings.notifications.notifications.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary icon="i-ri:test-tube-line">
+        {{ $t('settings.notifications.notifications.label') }}
+      </MainTitle>
     </template>
     <div text-center mt-10>
       <h1 text-4xl>

--- a/app/pages/settings/notifications/push-notifications.vue
+++ b/app/pages/settings/notifications/push-notifications.vue
@@ -16,9 +16,9 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.notifications.push_notifications.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.notifications.push_notifications.label') }}
+      </MainTitle>
     </template>
     <NotificationPreferences show />
   </MainContent>

--- a/app/pages/settings/preferences/index.vue
+++ b/app/pages/settings/preferences/index.vue
@@ -11,9 +11,9 @@ const userSettings = useUserSettings()
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <h1 text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
+      <MainTitle as="h1" secondary>
         {{ $t('settings.preferences.label') }}
-      </h1>
+      </MainTitle>
     </template>
     <section>
       <h2 px6 py4 mt2 font-bold text-xl flex="~ gap-1" items-center sr-only>

--- a/app/pages/settings/profile/appearance.vue
+++ b/app/pages/settings/profile/appearance.vue
@@ -105,9 +105,9 @@ onReactivated(refreshInfo)
 <template>
   <MainContent back>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.profile.appearance.title') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.profile.appearance.title') }}
+      </MainTitle>
     </template>
 
     <form space-y-5 @submit.prevent="submit">

--- a/app/pages/settings/profile/featured-tags.vue
+++ b/app/pages/settings/profile/featured-tags.vue
@@ -13,10 +13,9 @@ useHydratedHead({
 <template>
   <MainContent back>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <div i-ri:test-tube-line />
-        <span>{{ $t('settings.profile.featured_tags.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary icon="i-ri:test-tube-line">
+        {{ $t('settings.profile.featured_tags.label') }}
+      </MainTitle>
     </template>
     <div text-center mt-10>
       <h1 text-4xl>

--- a/app/pages/settings/profile/index.vue
+++ b/app/pages/settings/profile/index.vue
@@ -13,9 +13,9 @@ useHydratedHead({
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.profile.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.profile.label') }}
+      </MainTitle>
     </template>
 
     <SettingsItem

--- a/app/pages/settings/users/index.vue
+++ b/app/pages/settings/users/index.vue
@@ -68,9 +68,9 @@ async function importTokens() {
 <template>
   <MainContent back-on-small-screen>
     <template #title>
-      <div text-lg font-bold flex items-center gap-2 @click="$scrollToTop">
-        <span>{{ $t('settings.users.label') }}</span>
-      </div>
+      <MainTitle as="h1" secondary>
+        {{ $t('settings.users.label') }}
+      </MainTitle>
     </template>
     <div p6>
       <template v-if="loggedInUsers.length">

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -65,8 +65,6 @@ export default defineConfig({
       'flex-v-center': 'items-center',
       'flex-h-center': 'justify-center',
       'bg-hover-overflow': 'relative z-0 transition-colors duration-250 after-content-empty after:(absolute inset--4px bg-transparent rounded-full z--1 transition-colors duration-250) hover:after:(bg-active)',
-
-      'timeline-title-style': 'text-primary text-lg font-bold',
     },
     [/^elk-group-hover[:-]([a-z0-9/-]+)$/, ([,r]) => `media-mouse-group-hover-${r} group-active-${r}`],
   ],


### PR DESCRIPTION
### Header title UI issues

I started this as a follow-up to https://github.com/elk-zone/elk/pull/3325 because it turns out that the improved target area of the back button was clipped on the left by an `overflow: hidden` on a container, as shown here:

<img width="360" height="60" alt="Elk mobile view header showing the back button with its target area painted as a purple background. The left side of the button shows less padding than the right side." src="https://github.com/user-attachments/assets/fd63ad46-2f84-49a7-9a67-ca426abd6513" />

As I looked into this, I found a few more issues with the layout of the left-side elements of the `MainContent` header (back button and/or title):

1. There is the `overflow: hidden` issue as shown above. This can be fixed by reducing the padding on the header, removing this `overflow: hidden` if not needed, and using padding on the children (buttons and titles) instead.

2. Most titles are clickable and have `@click="$scrollToTop`, but their target areas are a bit small because they have no padding, meaning that if you end up clicking just a bit above, below or at the right of the text (just left of the icon) then nothing happens. If these titles are treated as clickable buttons, they should follow general usability rules for buttons. This can be fixed with a bit of padding. Here's a before and after:

<img width="440" height="180" alt="elk-header-title-area" src="https://github.com/user-attachments/assets/04fff39d-71a8-4c23-b712-2403cb793ccf" />

3. Titles are supposed to be truncated if they overflow, but it doesn't work. That's because the element containing the title, which inherit `white-space: nowrap`, are flex children with an initial style of `min-width: auto`, and here `auto` translates to the full width of the uninterrupted line of text. (A common fix is using `min-width: 0` or some other small value for `min-width`.)

<img width="280" height="60" alt="Screenshot of the Elk timeline header for the Federated Timeline view, on a narrow mobile screen, where the word Timeline is clipped at the middle and does not show the intended ellipsis dots." src="https://github.com/user-attachments/assets/2cd2c414-9c1b-47dc-8bed-18478542c43a" />

4. The styles for `MainContent` header titles are mostly duplicated across 20+ views. There is a shared `timeline-title-style` style that applies a few text styles, but all the structure and spacing (especially when there is an icon) is duplicated. This makes it challenging to evolve this style to modify the spacing or fix the truncation issue.

5. There is duplicated logic as well, because most of the instances of the `MainContent` titles use `@click="$scrollToTop"`, but a few don't, and when they don't it doesn't seem to be for a specific reason, so I suspect it could be an oversight.

### Proposed refactoring with a new component

For all those reasons, I propose creating a shared component, tentatively named `MainTitle` (`app/components/main/MainTitle.vue`), which renders a timeline title with an optional icon, with appropriate spacing and truncation, and the `scrollToTop` behavior by default.

This creates a pretty big diff, but it's a straightforward refactor overall. The simpler usage looks like:

```diff
  <template #title>
-   <div timeline-title-style>{{ $t('some.title') }}</div>
+   <MainTitle>{{ $t('some.title') }}</MainTitle>
  </template>
```

When the title had an icon, we get:

```diff
  <template #title>
-   <div timeline-title-style flex items-center gap-2 cursor-pointer @click="$scrollToTop">
-     <div i-ri:some-icon />
-     <span>{{ t('some.title') }}</span>
-   </div>
+   <MainTitle icon="i-ri:some-icon">
+     {{ t('some.title') }}
+   </MainTitle>
  </template>
```

Finally, half the titles doubled as links, using `NuxtLink`. This is a bit more tricky to implement using a single component. One option would be to wrap `<NuxtLink><MainTitle>{{ title }}</MainTitle></NuxtLink>`, but I don't love the verbosity — or the unstyled `<a>` wrapper element, which could cause styling or layout issues. I opted for this pattern, which has limitations in terms of TypeScript autocompletions for props, and requires using `RouterLink` instead of `NuxtLink` for some reasons I cannot fathom:

```diff
  <template #title>
-   <NuxtLink to="/some/route" timeline-title-style flex items-center gap-2 cursor-pointer @click="$scrollToTop">
-     <div i-ri:some-icon />
-     <span>{{ t('some.title') }}</span>
-   </NuxtLink>
+   <MainTitle as="router-link" to="/some/route" icon="i-ri:some-icon">
+     {{ t('some.title') }}
+   </MainTitle>
  </template>
```

### Outsanding questions

**Can `as="router-link"` be inferred from props?**

I tried only passing the `to` prop and then inferring the value of the `is` prop (`<component :is="to ? 'router-link' : 'div'">`), but it doesn't work and shows JS errors in the console.

**Should the title be a H1?**

- Currently in the codebase it's usually a `<span>`, a `<div>` or a `<a>`, with only one instance where it's a `<h1>` (in one of the Settings views).
- Defaulting to a H1 or H2 would be easy, but when the element is rendered as a `router-link` (i.e. as a `<a>` element) then we wouldn't have a title. This can be fixed by nesting elements a little bit, however.

**Do we need the primary-vs-secondary styles?**

Currently the header title colors are:

- Orange (`var(--c-primary)`) for most views.
- White (default color) for the titles used in the Settings sub-pages.

I implemented the white style for the settings sub-pages using a `secondary?: boolean` prop, but it could make sense to drop this style and just usage orange everywhere.

**Should we harmonize the design of those titles and of the back button?**

The icon for the header's back button and the new `<MainTitle icon="foo" />` have similar sizes and spacing, and appear in the same place.

When we show _either_ a back button _or_ a `<MainTitle>` with an icon, things look pretty good and consistent.

One possible issue is when there is both a back button and a `<MainTitle>` in the header. Both the button and the title have padding, and end up spaced pretty far apart. See the difference between the `title_icon ↔︎ title` spacing (2 steps, i.e. `0.5rem`) and the `back_icon ↔︎title` spacing (2x3 steps, i.e. `1.5rem`).

It should be possible to harmonize both, possibly by folding the back button feature within the `<MainTitle>` component and turning it into a split button when there is both a back button and a title to display. Should we go with that, or is that too much of a change?