### PR TITLE
chore: fix eslint warning for as prop

### DIFF
--- a/app/components/common/CommonScrollIntoView.vue
+++ b/app/components/common/CommonScrollIntoView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const { as = 'div', active } = defineProps<{
-  as: any
+  as?: string
   active: boolean
 }>()
 


### PR DESCRIPTION
Current runs of ESLint on CI show a single warning, which shows up in an “Unchanged files with check annotations” in pull requests.

> /home/runner/work/elk/elk/app/components/common/CommonScrollIntoView.vue
> Warning:   3:3  warning  Prop "as" should be optional  vue/no-required-prop-with-default

https://github.com/elk-zone/elk/actions/runs/16146711224/job/45567384692?pr=3326#step:8:11

This PR fixes said warning, which limits noise in pull requests.