### PR TITLE
refactor(CommonScrollIntoView): CommonScrollIntoView props type

### DIFF
--- a/app/components/common/CommonScrollIntoView.vue
+++ b/app/components/common/CommonScrollIntoView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
+
 const { as = 'div', active } = defineProps<{
-  as: any
+  as?: string | Component
   active: boolean
 }>()
 


### PR DESCRIPTION
This pull request introduces the following improvements to the CommonScrollIntoView.vue component:

### Resolves `vue/no-required-prop-with-default `Warning
The "Prop as should be optional" warning that appeared when running the `lint:fix` command has been resolved. This eliminates the linter warning and improves code quality.

### Elimination of `any `Type and Stricter Type Definitions

The use of the `any` type within the `CommonScrollIntoView` component's prop definitions has been eliminated, and more specific types have been applied. This tightens type checking for the component's props, which is expected to lead to earlier detection of potential bugs during development, improved code readability, and enhanced maintainability.

These changes are purely type corrections and quality improvements that do not affect the component's behavior, but your review would be appreciated.