### PR TITLE
fix: error accessing thumbnail when instance is not defined

### DIFF
--- a/app/pages/[[server]]/index.vue
+++ b/app/pages/[[server]]/index.vue
@@ -10,6 +10,6 @@ catch (err) {
 
 <template>
   <MainContent text-base grid gap-3 m3>
-    <img rounded-3 :src="instance.thumbnail.url">
+    <img v-if="instance !== undefined" rounded-3 :src="instance.thumbnail.url">
   </MainContent>
 </template>


### PR DESCRIPTION
Prevent error on server index page causing the redirect to public timeline to fail.