### PR TITLE
docs: change docker compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ One could put Elk behind popular reverse proxies with SSL Handling like Traefik,
 1. got into new source dir: ```cd elk```
 1. create local storage directory for settings: ```mkdir elk-storage```
 1. adjust permissions of storage dir: ```sudo chown 911:911 ./elk-storage```
-1. start container: ```docker-compose up --build -d```
+1. start container: ```docker compose up --build -d```
 
 > [!NOTE]
 > The provided Dockerfile creates a container which will eventually run Elk as non-root user and create a persistent named Docker volume upon first start (if that volume does not yet exist). This volume is always created with root permission. Failing to change the permissions of ```/elk/data``` inside this volume to UID:GID 911 (as specified for Elk in the Dockerfile) will prevent Elk from storing it's config for user accounts. You either have to fix the permission in the created named volume, or mount a directory with the correct permission to ```/elk/data``` into the container.


### PR DESCRIPTION
From July 2023, Compose v1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

https://docs.docker.com/compose/releases/migrate/#how-do-i-switch-to-compose-v2