### PR TITLE
fix(ui): auto-profile-hover-on-history-view

### DIFF
--- a/app/components/modal/ModalContainer.vue
+++ b/app/components/modal/ModalContainer.vue
@@ -82,7 +82,7 @@ function handleFavouritedBoostedByClose() {
     >
       <ModalMediaPreview v-if="isMediaPreviewOpen" @close="closeMediaPreview()" />
     </ModalDialog>
-    <ModalDialog v-model="isEditHistoryDialogOpen" max-w-125>
+    <ModalDialog v-model="isEditHistoryDialogOpen" :focus-first-element="false" max-w-125>
       <StatusEditPreview v-if="statusEdit" :edit="statusEdit" />
     </ModalDialog>
     <ModalDialog v-model="isCommandPanelOpen" max-w-fit flex>

--- a/app/components/modal/ModalDialog.vue
+++ b/app/components/modal/ModalDialog.vue
@@ -10,6 +10,7 @@ const {
   closeByMask = true,
   useVIf = true,
   keepAlive = false,
+  focusFirstElement = true,
 } = defineProps<{
   // level of depth
   zIndex?: number
@@ -21,6 +22,8 @@ const {
   keepAlive?: boolean
   // The aria-labelledby id for the dialog.
   dialogLabelledBy?: string
+  // Whether to focus on the first element when the modal opens.
+  focusFirstElement?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -45,6 +48,7 @@ const { activate } = useFocusTrap(elDialogRoot, {
   escapeDeactivates: true,
   preventScroll: true,
   returnFocusOnDeactivate: true,
+  initialFocus: focusFirstElement ? undefined : false,
 })
 
 defineExpose({


### PR DESCRIPTION
**Summary**
This PR fixes an issue where a user's profile would automatically enter a hover state when opening a post from its edit history.

**Related Issue**
Closes #3367

**Changes**
Modified the logic to prevent the hover event for the profile from automatically firing during the screen transition.

**How to Test**
1.  Edit a post, then open the post details from its edit history.
2.  Confirm that the profile does not automatically enter a hover state when the screen loads.
3.  Confirm that hovering over the profile manually causes it to enter the hover state.