### PR TITLE
feat: check user session before subscribing to streaming

### DIFF
--- a/app/composables/masto/masto.ts
+++ b/app/composables/masto/masto.ts
@@ -25,7 +25,7 @@ export function mastoLogin(masto: ElkMasto, user: Pick<UserLogin, 'server' | 'to
   const url = `https://${server}`
   const instance: ElkInstance = reactive(getInstanceCache(server) || { uri: server, accountDomain: server })
   const accessToken = user.token
-  const streamingApiUrl = instance?.configuration?.urls?.streaming
+
   const createStreamingClient = (streamingApiUrl: string | undefined) => {
     // Only create the streaming client when there is a user session
     return streamingApiUrl && currentUser.value
@@ -33,6 +33,7 @@ export function mastoLogin(masto: ElkMasto, user: Pick<UserLogin, 'server' | 'to
       : undefined
   }
 
+  const streamingApiUrl = instance?.configuration?.urls?.streaming
   masto.client.value = createRestAPIClient({ url, accessToken })
   masto.streamingClient.value = createStreamingClient(streamingApiUrl)
 


### PR DESCRIPTION
This will check if there is a user session before creating a streaming client to make sure there is a valid token for subscribing to the instance's web sockets endpoint.

### Inspecting mastodon web behavior

Mastodon does not allow streaming on the client when no user is logged in, which can be seen, for example, by inspecting the dev tools Network tab -> WS on this page: https://m.webtoo.ls/public/local

...then comparing when there is a logged in user (top window) and not logged in (bottom window):

<img width="2444" height="806" alt="Screenshot from 2025-11-23 11-40-42" src="https://github.com/user-attachments/assets/6ff12c67-81df-4f7a-9eb0-96080c8f2c78" />

### Preventing errors for elk.zone

This will prevent the following errors when opening https://elk.zone without a user session

<img width="846" height="244" alt="Screenshot from 2025-11-23 11-42-29" src="https://github.com/user-attachments/assets/4dd294bd-d022-480c-a313-8d02f047532c" />
<img width="846" height="244" alt="Screenshot from 2025-11-23 11-42-52" src="https://github.com/user-attachments/assets/c133e598-b011-4c7e-a603-5aec541eefb1" />
