### PR TITLE
chore: pin vue scroller to 2.0.0 beta 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "vue": "^3.5.4",
     "vue-advanced-cropper": "^2.8.9",
     "vue-i18n": "^11.1.12",
-    "vue-virtual-scroller": "2.0.0-beta.4",
+    "vue-virtual-scroller": "2.0.0-beta.3",
     "workbox-build": "^7.1.1",
     "workbox-cacheable-response": "^7.1.0",
     "workbox-expiration": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,8 +285,8 @@ importers:
         specifier: ^11.1.12
         version: 11.1.12(vue@3.5.22(typescript@5.9.2))
       vue-virtual-scroller:
-        specifier: 2.0.0-beta.4
-        version: 2.0.0-beta.4(vue@3.5.22(typescript@5.9.2))
+        specifier: 2.0.0-beta.3
+        version: 2.0.0-beta.3(vue@3.5.22(typescript@5.9.2))
       workbox-build:
         specifier: ^7.1.1
         version: 7.3.0
@@ -9471,8 +9471,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue-virtual-scroller@2.0.0-beta.4:
-    resolution: {integrity: sha512-JfFRyMCUzjPg+lbDXP4SpWy1aE8lpCbe1AZgwXmQPHZr1eayX5n8GgEuntUi0ixFCzBQzdH7WQwPpchp8UgjtA==}
+  vue-virtual-scroller@2.0.0-beta.3:
+    resolution: {integrity: sha512-k0hTAkZRmm3TXpfhW5Ig1fd8VV7+CmgnkebbQ4Uw6wnuQF52YJoaMQTFD3IV/Qi2WNadDB4ETrLUbVdnWboSjg==}
     peerDependencies:
       vue: ^3.5.4
 
@@ -21300,7 +21300,7 @@ snapshots:
       '@vue/language-core': 2.2.12(typescript@5.9.2)
       typescript: 5.9.2
 
-  vue-virtual-scroller@2.0.0-beta.4(vue@3.5.22(typescript@5.9.2)):
+  vue-virtual-scroller@2.0.0-beta.3(vue@3.5.22(typescript@5.9.2)):
     dependencies:
       mitt: 2.1.0
       vue: 3.5.22(typescript@5.9.2)


### PR DESCRIPTION
@darrinlrogers can you test with the pr preview here

Looks like beta 5 has wrong logic: https://github.com/Akryum/vue-virtual-scroller/issues/795

We should add vue scroller to ignoreDeps at renovate.json file until fixed

resolves #3457