### PR TITLE
fix: fix issue on preview card size detection

### DIFF
--- a/app/components/status/StatusPreviewCardNormal.vue
+++ b/app/components/status/StatusPreviewCardNormal.vue
@@ -15,6 +15,7 @@ const ogImageWidth = 400
 const alt = computed(() => `${card.title} - ${card.title}`)
 const isSquare = computed(() => (
   smallPictureOnly
+  || !card.image
   || card.width === card.height
   || Number(card.width || 0) < ogImageWidth
   || Number(card.height || 0) < ogImageWidth / 2


### PR DESCRIPTION
Some post's preview card has been broken. This was due to the false assumption on `card.width` and `card.height` values when the post has no image.

The expected `card` property in the post has object like this:

```
{
  "url": "https://xn--berholt-m2a.schule/",
  "title": "überholt.schule – Überholtes Wissen aus der Schule",
  "description": "Entdecke überholtes Wissen aus der Schule – Fakten, die früher als wahr galten, heute aber widerlegt sind.",
  "language": "de",
  "type": "link",
  "authorName": "",
  "authorUrl": "",
  "providerName": "",
  "providerUrl": "",
  "html": "",
  "width": 0,
  "height": 0,
  "image": null,
  "imageDescription": "",
  "embedUrl": "",
  "blurhash": null,
  "publishedAt": null,
  "authors": []
}
```

However, Mastodon seems to return non-0 value in some cases even if the post has no image (example: https://mastodon.social/@MastodonEngineering/114989758950079893). The original code assumes width and height are always 0 when the image is `null`, causing Elk think the post has the rectangular image.

This change ensures to use correct layout for the post without any image.

### Before

<img width="851" height="766" alt="Screenshot of preview card with broken layout" src="https://github.com/user-attachments/assets/65949969-c774-480d-bb75-f73c7d29d17f" />


### After
<img width="851" height="655" alt="Screenshot of preview card" src="https://github.com/user-attachments/assets/ea9c9174-3d05-4dfb-91aa-541c612f4421" />
