### PR TITLE
chore: disable autoplay by default

### DIFF
--- a/app/composables/settings/definition.ts
+++ b/app/composables/settings/definition.ts
@@ -85,7 +85,7 @@ export const DEFAULT__PREFERENCES_SETTINGS: PreferencesSettings = {
   hideRepliesInTimeline: false,
   hideBoostsInTimeline: false,
   grayscaleMode: false,
-  enableAutoplay: true,
+  enableAutoplay: false,
   unmuteVideos: false,
   optimizeForLowPerformanceDevice: false,
   enableDataSaving: false,


### PR DESCRIPTION
Currently, only this "Enable autoplay" option is checked in the initial state and it feels a bit inconsistent. We could flip the meaning of option to "Disable autoplay" and keep the current default behavior, but I think the autoplaying video is one of the strong attention seeking elements, so disabling autoplay by default would be a good fit to the default behavior for Elk.

<img width="1052" height="1831" alt="screenshot of setting page, only autoplay is enabled in main options" src="https://github.com/user-attachments/assets/23d63400-19bf-4d93-b191-018a41d144a0" />
