### PR TITLE
chore: remove legacy querystring alias and polyfill

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,9 @@ import { pwa } from './config/pwa'
 
 const { resolve } = createResolver(import.meta.url)
 
-const mockProxy = resolveModulePath('mocked-exports/proxy', { from: import.meta.url })
+const mockProxy = resolveModulePath('mocked-exports/proxy', {
+  from: import.meta.url,
+})
 
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-11',
@@ -33,10 +35,10 @@ export default defineNuxtConfig({
     '@nuxtjs/i18n',
     // temporary disable module during test
     // ref. https://github.com/nuxt-modules/color-mode/issues/335
-    ...isTest ? [] : ['@nuxtjs/color-mode'],
+    ...(isTest ? [] : ['@nuxtjs/color-mode']),
     '@unlazy/nuxt',
     '@nuxt/test-utils/module',
-    ...(isDevelopment || isWindows) ? [] : ['nuxt-security'],
+    ...(isDevelopment || isWindows ? [] : ['nuxt-security']),
   ],
   vue: {
     propsDestructure: true,
@@ -71,7 +73,6 @@ export default defineNuxtConfig({
     '~/styles/dropdown.css',
   ],
   alias: {
-    'querystring': 'rollup-plugin-node-polyfills/polyfills/qs',
     'change-case': 'scule',
     'semver': resolve('./mocks/semver'),
   },
@@ -82,17 +83,20 @@ export default defineNuxtConfig({
       './composables/settings',
       './composables/tiptap/index.ts',
     ],
-    imports: [{
-      name: 'useI18n',
-      from: '~/utils/i18n',
-      priority: 100,
-    }],
+    imports: [
+      {
+        name: 'useI18n',
+        from: '~/utils/i18n',
+        priority: 100,
+      },
+    ],
     injectAtEnd: true,
   },
   vite: {
     define: {
       'process.env.VSCODE_TEXTMATE_DEBUG': 'false',
-      'process.mock': ((!isCI || isPreview) && process.env.MOCK_USER) || 'false',
+      'process.mock':
+        ((!isCI || isPreview) && process.env.MOCK_USER) || 'false',
       'process.test': 'false',
     },
     build: {
@@ -227,15 +231,15 @@ export default defineNuxtConfig({
     'nitro:config': function (config) {
       const nuxt = useNuxt()
       config.virtual = config.virtual || {}
-      config.virtual['#storage-config'] = `export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}`
+      config.virtual['#storage-config']
+        = `export const driver = ${JSON.stringify(nuxt.options.appConfig.storage.driver)}`
     },
     'vite:extendConfig': function (config, { isServer }) {
       if (isServer) {
         const alias = config.resolve!.alias as Record<string, string>
         for (const dep of ['eventemitter3', 'isomorphic-ws'])
           alias[dep] = resolve('./mocks/class')
-        for (const dep of ['fuse.js'])
-          alias[dep] = mockProxy
+        for (const dep of ['fuse.js']) alias[dep] = mockProxy
         const resolver = createResolver(import.meta.url)
 
         config.plugins!.unshift({
@@ -250,7 +254,12 @@ export default defineNuxtConfig({
         })
 
         const noExternal = config.ssr!.noExternal as string[]
-        noExternal.push('masto', '@fnando/sparkline', 'vue-i18n', '@mastojs/ponyfills')
+        noExternal.push(
+          'masto',
+          '@fnando/sparkline',
+          'vue-i18n',
+          '@mastojs/ponyfills',
+        )
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "prosemirror-highlight": "^0.13.0",
     "prosemirror-state": "^1.4.3",
     "punycode": "^2.3.1",
-    "rollup-plugin-node-polyfills": "^0.2.1",
     "shiki": "^3.20.0",
     "simple-git": "^3.19.1",
     "slimeform": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,9 +236,6 @@ importers:
       punycode:
         specifier: ^2.3.1
         version: 2.3.1
-      rollup-plugin-node-polyfills:
-        specifier: ^0.2.1
-        version: 0.2.1
       shiki:
         specifier: ^3.20.0
         version: 3.20.0
@@ -6483,9 +6480,6 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
-  estree-walker@0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
-
   estree-walker@1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
 
@@ -8985,13 +8979,6 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup-plugin-inject@3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-
-  rollup-plugin-node-polyfills@0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
-
   rollup-plugin-visualizer@6.0.3:
     resolution: {integrity: sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==}
     engines: {node: '>=18'}
@@ -9004,9 +8991,6 @@ packages:
         optional: true
       rollup:
         optional: true
-
-  rollup-pluginutils@2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
   rollup@2.79.2:
     resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
@@ -17829,8 +17813,6 @@ snapshots:
 
   estraverse@5.3.0: {}
 
-  estree-walker@0.6.1: {}
-
   estree-walker@1.0.1: {}
 
   estree-walker@2.0.2: {}
@@ -21289,16 +21271,6 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup-plugin-inject@3.0.2:
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
-
-  rollup-plugin-node-polyfills@0.2.1:
-    dependencies:
-      rollup-plugin-inject: 3.0.2
-
   rollup-plugin-visualizer@6.0.3(rollup@4.52.5):
     dependencies:
       open: 8.4.2
@@ -21316,10 +21288,6 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       rollup: 4.53.3
-
-  rollup-pluginutils@2.8.2:
-    dependencies:
-      estree-walker: 0.6.1
 
   rollup@2.79.2:
     optionalDependencies:


### PR DESCRIPTION
- Remove legacy querystring alias and rollup-plugin-node-polyfills dependency.
- These were introduced in 2022 (https://github.com/elk-zone/elk/commit/9cc837f5df6594f0ce94cc1c8ef71bfcde3a9ce7) to support masto.js v4 and are no longer required for the current codebase (https://github.com/shuuji3/masto.js/commit/458340e07c3d4b0fd6061c4bc14fe3345a2bb2c3 removed `'querystring'`).