### PR TITLE
fix: switch color mode icons

### DIFF
--- a/app/components/nav/NavFooter.vue
+++ b/app/components/nav/NavFooter.vue
@@ -17,7 +17,7 @@ function toggleDark() {
   <footer p4 text-sm text-secondary-light flex="~ col">
     <div flex="~ gap2" items-center mb4>
       <CommonTooltip :content="$t('nav.toggle_theme')">
-        <button flex i-ri:sun-line dark-i-ri:moon-line text-lg :aria-label="$t('nav.toggle_theme')" @click="toggleDark()" />
+        <button flex dark-i-ri:sun-line i-ri:moon-line text-lg :aria-label="$t('nav.toggle_theme')" @click="toggleDark()" />
       </CommonTooltip>
       <CommonTooltip :content="$t('nav.zen_mode')">
         <button


### PR DESCRIPTION
This PR switches the color mode icons.

When Elk opens in dark mode, it will now show the "sun" icon that represents light mode, instead of showing the "moon" icon that represents dark mode, which is already active.