### PR TITLE
fix: border typo

### DIFF
--- a/app/components/publish/PublishWidget.vue
+++ b/app/components/publish/PublishWidget.vue
@@ -587,17 +587,17 @@ const detectLanguage = useDebounceFn(async () => {
                 {{ $t('action.remove_quote') }}
               </button>
             </div>
-            <blockquote v-if="quotedStatus" b="~ base 1" rounded-lg overflow-hidden my-3>
+            <blockquote v-if="quotedStatus" border="~ base 1" rounded-lg overflow-hidden my-3>
               <StatusCard
                 :status="quotedStatus"
                 :actions="false"
                 :is-nested="true"
               />
             </blockquote>
-            <div v-else-if="quoteFetchError" text-danger b="base 1" rounded-lg hover:bg-active my-3 p-3>
+            <div v-else-if="quoteFetchError" text-danger border="base 1" rounded-lg hover:bg-active my-3 p-3>
               {{ $t('error.quote_fetch_error') }} ({{ quoteFetchError }})
             </div>
-            <StatusCardSkeleton v-else b="base 1" rounded-lg hover:bg-active my-3 />
+            <StatusCardSkeleton v-else border="base 1" rounded-lg hover:bg-active my-3 />
           </template>
 
           <!-- toolbar -->

--- a/app/components/status/StatusQuote.vue
+++ b/app/components/status/StatusQuote.vue
@@ -51,43 +51,43 @@ const quotedStatus = computed(() => {
     <template v-if="isNested && quoteState">
       <div
         v-if="quoteState === 'pending'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post pending for approval by author
       </div>
       <div
         v-else-if="quoteState === 'revoked'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post removed by author
       </div>
       <div
         v-else-if="quoteState === 'blocked_account'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post by blocked author
       </div>
       <div
         v-else-if="quoteState === 'blocked_domain'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post from blocked server
       </div>
       <div
         v-else-if="quoteState === 'muted_account'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post by muted author
       </div>
       <div
         v-else-if="quoteState === 'deleted' || quoteState === 'rejected' || quoteState === 'unauthorized'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post is unavailable
       </div>
       <div
         v-else-if="quoteState === 'accepted'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post by
         <AccountInlineInfo :account="quotedStatus.account" :link="false" mx-1 />
@@ -96,19 +96,19 @@ const quotedStatus = computed(() => {
     <template v-else>
       <div
         v-if="quoteState === 'pending'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post pending for approval by author
       </div>
       <div
         v-else-if="quoteState === 'revoked'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post removed by author
       </div>
       <div
         v-else-if="quoteState === 'deleted' || quoteState === 'rejected' || quoteState === 'unauthorized'"
-        flex b="~ 1" rounded-lg bg-card mt-3 p-3
+        flex border="~ 1" rounded-lg bg-card mt-3 p-3
       >
         Post is unavailable
       </div>
@@ -120,7 +120,7 @@ const quotedStatus = computed(() => {
           :status="quotedStatus"
           :actions="false"
           :is-nested="true"
-          b="base 1" rounded-lg hover:bg-active my-3
+          border="base 1" rounded-lg hover:bg-active my-3
         />
       </blockquote>
     </template>


### PR DESCRIPTION
The border on quote retweets is defaulting to white instead of base. The relevant elements have `b="base 1"`, but the correct Tailwind syntax for border seems to be `border="base 1"`. This is relevant/noticeable in dark mode.

Before (first QRT in my timeline of course, post isn't relevant):
<img width="600" height="486" alt="Screenshot 2026-02-23 at 8 26 33 AM" src="https://github.com/user-attachments/assets/978aa86d-d0db-4abd-b34c-7091f5937d6c" />

After:
<img width="607" height="482" alt="Screenshot 2026-02-23 at 8 29 46 AM" src="https://github.com/user-attachments/assets/9f1fabee-4bc2-443c-ac8e-25b6f8d4fbba" />