### PR TITLE
style:  hover cursor & background on status cards

### DIFF
--- a/app/components/notification/NotificationGroupedLikes.vue
+++ b/app/components/notification/NotificationGroupedLikes.vue
@@ -18,7 +18,13 @@ const likesTimeAgo = useTimeAgo(() => likesTimeAgoCreatedAt.value ?? '', timeAgo
 
 <template>
   <article flex flex-col relative>
-    <StatusLink :status="group.status!" pb4 pt5>
+    <StatusLink
+      cursor-pointer
+      hover-bg-active
+      rounded-3
+      transition-100
+      :status="group.status!" pb4 pt5
+    >
       <div flex flex-col gap-3>
         <div v-if="reblogs.length" flex="~ gap-1">
           <div i-ri:repeat-fill text-xl me-2 color-green />

--- a/app/components/status/StatusCard.vue
+++ b/app/components/status/StatusCard.vue
@@ -75,7 +75,13 @@ const forceShow = ref(false)
 </script>
 
 <template>
-  <StatusLink :status="status" :hover="hover" :disable-link="disableLink">
+  <StatusLink
+    cursor-pointer
+    hover-bg-active
+    rounded-3
+    transition-100
+    :status="status" :hover="hover" :disable-link="disableLink"
+  >
     <!-- Upper border -->
     <div :h="showUpperBorder ? '1px' : '0'" w-auto bg-border mb-1 z--1 />
 


### PR DESCRIPTION
This small PR will apply the same hover style & behavior that we have on the side navigation items into `StatusLink`

This makes sense because the whole `StatusLink` is clickable, but the current behavior does not show this. For example we only have `cursor:pointer` style on the status content/details, when it should be on the whole clickable area.

Additionally, we now use the same hover background on the clickable area of `StatusCard`.

Over all this makes the experience of hovering around feel more polished. :)
