### PR TITLE
docs: fix #slot in markdown components failing lint 

### DIFF
--- a/docs/content/1.guide/1.index.md
+++ b/docs/content/1.guide/1.index.md
@@ -1,4 +1,3 @@
-<!-- eslint-disable markdown/no-missing-atx-heading-space -->
 ---
 title: Introduction
 description: Get started with Elk, the nimble Mastodon web client.
@@ -25,7 +24,7 @@ On a mobile device, you can install the app to your home screen right from your 
 (This is called a Progressive  Web App, or [PWA](../pwa.md).)
 
 Want to try it out?
-Visit https://elk.zone, type in your Mastodon server address, then log in.
+Visit <https://elk.zone>, type in your Mastodon server address, then log in.
 Or, visit one of the other Elk installs in the [Elk ecosystem](https://github.com/elk-zone/elk#ecosystem).
 
 ## What is Mastodon?
@@ -48,6 +47,7 @@ When you visit or sign in to a Mastodon server, you use the standard Mastodon cl
 
 A Mastodon client performs similar functions as the standard web interfaces.
 Using a client, you can
+
 - View posts from accounts you follow
 - Boost, like, or bookmark posts
 - Create new posts from your own account
@@ -62,30 +62,7 @@ Using a client, you can
 
 ### Installed Mastodon Clients
 
-You may be most familiar with Mastodon Clients through your phone or tablet.
-The app you download from an app store and install on your device to access your Mastodon account is a Mastodon Client.
-
-::card{icon="logos:android-icon"}
-#title
-Android
-#description
-[Fedilab](https://fedilab.app/), [Tusky](https://tusky.app/), or [Tooot](https://tooot.app/), among others.
-::
-
-::card{icon="logos:apple"}
-#title
-Apple
-#description
-[Ivory](https://tapbots.com/ivory/), [Ice Cubes](https://apps.apple.com/us/app/ice-cubes-for-mastodon/id6444915884), [Metatext](https://github.com/metabolist/metatext), or [Toot](https://apps.apple.com/app/toot/id1229021451?ls=1)
-::
-::card{icon="mdi:desktop-classic"}
-#title
-Desktop
-#description
-[TheDesk](https://thedesk.top/en/), [Whalebird](https://whalebird.social/en), or [Sengi](https://nicolasconstant.github.io/sengi/)
-::
-
-All of these apps provide some combination of the features a typical Mastodon user expects for their account.
+You may be most familiar with Mastodon Clients through your phone or tablet. The app you download from an app store and install on your device to access your Mastodon account is a Mastodon Client. These apps provide some combination of the features a typical Mastodon user expects for their account.
 
 ### Browser-based Mastodon Clients
 

--- a/docs/content/1.guide/1.index.md
+++ b/docs/content/1.guide/1.index.md
@@ -62,7 +62,31 @@ Using a client, you can
 
 ### Installed Mastodon Clients
 
-You may be most familiar with Mastodon Clients through your phone or tablet. The app you download from an app store and install on your device to access your Mastodon account is a Mastodon Client. These apps provide some combination of the features a typical Mastodon user expects for their account.
+You may be most familiar with Mastodon Clients through your phone or tablet.
+The app you download from an app store and install on your device to access your Mastodon account is a Mastodon Client.
+
+::card{icon="logos:android-icon"}
+#title
+Android
+#description
+[Fedilab](https://fedilab.app/), [Tusky](https://tusky.app/), or [Tooot](https://tooot.app/), among others.
+::
+
+::card{icon="logos:apple"}
+#title
+Apple
+#description
+[Ivory](https://tapbots.com/ivory/), [Ice Cubes](https://apps.apple.com/us/app/ice-cubes-for-mastodon/id6444915884), [Metatext](https://github.com/metabolist/metatext), or [Toot](https://apps.apple.com/app/toot/id1229021451?ls=1)
+::
+
+::card{icon="mdi:desktop-classic"}
+#title
+Desktop
+#description
+[TheDesk](https://thedesk.top/en/), [Whalebird](https://whalebird.social/en), or [Sengi](https://nicolasconstant.github.io/sengi/)
+::
+
+All of these apps provide some combination of the features a typical Mastodon user expects for their account.
 
 ### Browser-based Mastodon Clients
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -4,7 +4,6 @@ seo:
   description: A nimble Mastodon web client that provides a fresh and intuitive social media experience with modern features and elegant design.
   ogImage: https://docs.elk.zone/elk-screenshot.png
 ---
-<!-- eslint-disable markdown/no-missing-atx-heading-space -->
 
 ::u-page-hero
 ---

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,15 @@ export default await antfu(
       'node/prefer-global/process': 'off',
     },
   },
+  {
+    files: ['docs/content/**/*.md'],
+    rules: {
+      // the markdown plugin misreads `#slot` as a malformed heading
+      // MDC components (https://content.nuxt.com/docs/files/markdown#vue-components)
+      // use this `#slot` syntax
+      'markdown/no-missing-atx-heading-space': 'off',
+    },
+  },
   // Sort local files
   {
     files: ['locales/**.json'],


### PR DESCRIPTION
The index page for the guides are broken: https://docs.elk.zone/guide

This PR fixes the page by:
- removing eslint skip comment by bot
- configuring eslint to ignore `#slot` syntax in markdown components

### Screenshot (problem)

<img width="1290" height="554" alt="Screenshot 2026-03-21 at 22 10 36" src="https://github.com/user-attachments/assets/29bd1a50-f5bd-4652-af0a-6da3ac47b7a3" />
