### PR TITLE
fix(ui): deduplicate profile link icons

### DIFF
--- a/app/components/account/AccountHeader.vue
+++ b/app/components/account/AccountHeader.vue
@@ -65,13 +65,17 @@ async function toggleNotifications() {
 watchEffect(() => {
   const named: mastodon.v1.AccountField[] = []
   const icons: mastodon.v1.AccountField[] = []
+  const seenIcons = new Set<string>()
 
   account.fields?.forEach((field) => {
     const icon = getAccountFieldIcon(field.name)
-    if (icon)
+    if (icon && !seenIcons.has(icon)) {
+      seenIcons.add(icon)
       icons.push(field)
-    else
+    }
+    else {
       named.push(field)
+    }
   })
   icons.push({
     name: 'Joined',


### PR DESCRIPTION
Fixes #1957

Noticed this on a profile with both a "Website" and "Portfolio" field — they both map to the same link icon so you end up with two identical icons in a row. Same thing happens with "GPG" / "OpenPGP" (both key icons).

Fix: deduplicate by icon name before rendering. First field wins, any subsequent fields with the same icon still show up in the named section so the values aren't lost.

Tested on profiles with duplicate icon mappings and on profiles with no duplicates (no change).