### PR TITLE
fix: apply client-side content filters for case-insensitive matching

### DIFF
--- a/app/components/conversation/ConversationPaginator.vue
+++ b/app/components/conversation/ConversationPaginator.vue
@@ -7,9 +7,15 @@ defineProps<{
 
 function preprocess(items: mastodon.v1.Conversation[]): mastodon.v1.Conversation[] {
   const isAuthored = (conversation: mastodon.v1.Conversation) => conversation.lastStatus ? conversation.lastStatus.account.id === currentUser.value?.account.id : false
-  return items.filter(item => isAuthored(item) || !item.lastStatus?.filtered?.find(
-    filter => filter.filter.filterAction === 'hide' && filter.filter.context.includes('thread'),
-  ))
+  return items
+    .map((item) => {
+      if (!item.lastStatus || (item.lastStatus.filtered && item.lastStatus.filtered.length > 0))
+        return item
+      return { ...item, lastStatus: applyClientFiltersToStatus(item.lastStatus, 'thread') }
+    })
+    .filter(item => isAuthored(item) || !item.lastStatus?.filtered?.find(
+      filter => filter.filter.filterAction === 'hide' && filter.filter.context.includes('thread'),
+    ))
 }
 </script>
 

--- a/app/components/notification/NotificationPaginator.vue
+++ b/app/components/notification/NotificationPaginator.vue
@@ -139,9 +139,15 @@ function groupItems(items: mastodon.v1.Notification[]): NotificationSlot[] {
 }
 
 function removeFiltered(items: mastodon.v1.Notification[]): mastodon.v1.Notification[] {
-  return items.filter(item => !item.status?.filtered?.find(
-    filter => filter.filter.filterAction === 'hide' && filter.filter.context.includes('notifications'),
-  ))
+  return items
+    .map((item) => {
+      if (!item.status || (item.status.filtered && item.status.filtered.length > 0))
+        return item
+      return { ...item, status: applyClientFiltersToStatus(item.status, 'notifications') }
+    })
+    .filter(item => !item.status?.filtered?.find(
+      filter => filter.filter.filterAction === 'hide' && filter.filter.context.includes('notifications'),
+    ))
 }
 
 function preprocess(items: NotificationSlot[]): NotificationSlot[] {

--- a/app/composables/masto/filters.ts
+++ b/app/composables/masto/filters.ts
@@ -1,0 +1,128 @@
+import type { mastodon } from 'masto'
+
+const _filters = ref<mastodon.v2.Filter[]>([])
+const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/g
+
+export function useFilters() {
+  return _filters
+}
+
+export async function refreshFilters(): Promise<void> {
+  if (!currentUser.value)
+    return
+
+  try {
+    const client = useMastoClient()
+    const paginator = client.v2.filters.list()
+    const result = await paginator.values().next()
+    _filters.value = result.done ? [] : result.value
+  }
+  catch {
+    // Keep existing filters on error
+  }
+}
+
+/**
+ * Build a regex for a filter keyword following Mastodon's implementation guidelines.
+ * @see https://docs.joinmastodon.org/api/guidelines/#filters
+ */
+function buildKeywordRegex(keyword: string, wholeWord: boolean): RegExp {
+  const escaped = keyword.replace(REGEX_SPECIAL_CHARS, '\\$&')
+  const pattern = wholeWord ? `\\b${escaped}\\b` : escaped
+  return new RegExp(pattern, 'i')
+}
+
+function getStatusText(status: mastodon.v1.Status): string {
+  const parts: string[] = []
+  if (status.content)
+    parts.push(removeHTMLTags(status.content))
+  if (status.spoilerText)
+    parts.push(status.spoilerText)
+  return parts.join(' ')
+}
+
+/**
+ * Apply client-side filters to a single status that doesn't already have
+ * server-populated filter results (e.g., statuses from streaming).
+ */
+export function applyClientFiltersToStatus(
+  status: mastodon.v1.Status,
+  context: mastodon.v2.FilterContext,
+): mastodon.v1.Status {
+  return applyClientFilters([status], context)[0]
+}
+
+/**
+ * Apply client-side filters to statuses that don't already have
+ * server-populated filter results (e.g., statuses from streaming).
+ */
+export function applyClientFilters(
+  items: mastodon.v1.Status[],
+  context: mastodon.v2.FilterContext,
+): mastodon.v1.Status[] {
+  const filters = _filters.value
+  if (!filters.length)
+    return items
+
+  // Pre-filter to only active filters for this context
+  const activeFilters = filters.filter((f) => {
+    if (!f.context.includes(context))
+      return false
+    if (f.expiresAt && new Date(f.expiresAt) < new Date())
+      return false
+    return true
+  })
+
+  if (!activeFilters.length)
+    return items
+
+  // Build regex patterns for each filter
+  const filterPatterns = activeFilters.map(filter => ({
+    filter,
+    patterns: filter.keywords.map(kw => ({
+      keyword: kw,
+      regex: buildKeywordRegex(kw.keyword, kw.wholeWord),
+    })),
+  }))
+
+  return items.map((item) => {
+    // Skip if server already provided filter results
+    if (item.filtered && item.filtered.length > 0)
+      return item
+
+    const statusToCheck = item.reblog ?? item
+    const text = getStatusText(statusToCheck)
+    if (!text)
+      return item
+
+    const matchedResults: mastodon.v1.FilterResult[] = []
+
+    for (const { filter, patterns } of filterPatterns) {
+      const keywordMatches: string[] = []
+      for (const { keyword, regex } of patterns) {
+        if (regex.test(text))
+          keywordMatches.push(keyword.keyword)
+      }
+      if (keywordMatches.length > 0) {
+        matchedResults.push({
+          filter,
+          keywordMatches,
+          statusMatches: null,
+        })
+      }
+    }
+
+    if (matchedResults.length > 0) {
+      const updatedStatus = { ...item }
+      if (item.reblog) {
+        updatedStatus.reblog = { ...item.reblog, filtered: matchedResults }
+      }
+      else {
+        updatedStatus.filtered = matchedResults
+      }
+      return updatedStatus
+    }
+
+    return item
+  })
+}

--- a/app/composables/timeline.ts
+++ b/app/composables/timeline.ts
@@ -86,7 +86,8 @@ export function reorderTimeline(items: mastodon.v1.Status[]) {
 }
 
 export function filterAndReorderTimeline(items: mastodon.v1.Status[], context: mastodon.v1.FilterContext = 'public') {
-  const itemsWithoutFiltered = removeFilteredItems(items, context)
+  const itemsWithClientFilters = applyClientFilters(items, context)
+  const itemsWithoutFiltered = removeFilteredItems(itemsWithClientFilters, context)
   const itemsWithUserPreference = removeUserPreferenceItems(itemsWithoutFiltered, context)
   return reorderTimeline(itemsWithUserPreference)
 }

--- a/app/composables/users.ts
+++ b/app/composables/users.ts
@@ -120,6 +120,9 @@ export async function loginTo(
   }
 
   currentUserHandle.value = me.acct
+
+  // Fetch user filters for client-side filtering (e.g., streaming events)
+  refreshFilters()
 }
 
 const accountPreferencesMap = new Map<string, Partial<mastodon.v1.Preference>>()


### PR DESCRIPTION
Fixes #3523

## Problem

Elk relies solely on the server-populated `status.filtered` field for content filtering. The Mastodon streaming API does not include filter results on statuses, so posts received via real-time streaming bypass all user-defined content filters. This means a filter rule for "trump" won't match "Trump" in streamed posts — or any streamed post at all — because the `filtered` field is simply absent.

## Fix

- Added `app/composables/masto/filters.ts` — fetches the user's v2 filters on login and caches them
- `applyClientFilters()` matches status content against filter keywords using case-insensitive regex, respecting `wholeWord` boundaries per [Mastodon implementation guidelines](https://docs.joinmastodon.org/api/guidelines/#filters)
- Only applies to statuses that don't already have server-provided `filtered` results (so REST API responses are unaffected)
- Integrated into timeline preprocessing (`filterAndReorderTimeline`), notification filtering, and conversation filtering

## What it doesn't change

- No changes to the filter UI or settings
- Statuses with existing server-side filter results are left as-is
- No new dependencies