### PR TITLE
fix: prevent empty home timeline in qoto-mastodon server

### DIFF
--- a/app/components/timeline/TimelineHome.vue
+++ b/app/components/timeline/TimelineHome.vue
@@ -14,8 +14,14 @@ function preprocess(items: mastodon.v1.Status[]) {
 let followedTags: mastodon.v1.Tag[]
 if (currentUser.value !== undefined) {
   const { client } = useMasto()
-  const paginator = client.value.v1.followedTags.list()
-  followedTags = (await paginator.values().next()).value ?? []
+  try {
+    const paginator = client.value.v1.followedTags.list()
+    followedTags = (await paginator.values().next()).value ?? []
+  }
+  catch (e) {
+    console.error('Failed to fetch followed tags', e)
+    followedTags = []
+  }
 }
 </script>
 

--- a/app/composables/users.ts
+++ b/app/composables/users.ts
@@ -60,6 +60,8 @@ export const currentServer = computed<string>(() => currentUser.value?.server ||
 export const currentNodeInfo = computed<null | Record<string, any>>(() => nodes.value[currentServer.value] || null)
 export const isGotoSocial = computed(() => currentNodeInfo.value?.software?.name === 'gotosocial')
 export const isGlitchEdition = computed(() => currentInstance.value?.version?.includes('+glitch'))
+// TODO: currentNodeInfo is null for qoto instance
+// export const isQoto = computed(() => currentNodeInfo.value?.software?.version?.includes('qoto'))
 
 export function useUsers() {
   return users


### PR DESCRIPTION
fix #1472

The `followed_tags` endpoint is not supported by qoto instance, causing the crash before rendering the home timeline.

This fix ensure rendering home timeline when the followed tags requests fails.