### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elk-zone/elk",
   "type": "module",
   "version": "0.17.3",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "license": "MIT",
   "homepage": "https://elk.zone/",
   "main": "./nuxt.config.ts",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,5 @@
 ignoreWorkspaceRootCheck: true
 
-packageManagerStrict: false
-
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -90,15 +88,13 @@ overrides:
   vitest: 4.1.5
   vue: ^3.5.4
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@tailwindcss/oxide'
-  - esbuild
-  - vue-demi
-
-onlyBuiltDependencies:
-  - better-sqlite3
-  - sharp
-  - simple-git-hooks
-
 verifyDepsBeforeRun: install
+
+allowBuilds:
+  '@parcel/watcher': false
+  '@tailwindcss/oxide': false
+  better-sqlite3: true
+  esbuild: false
+  sharp: true
+  simple-git-hooks: true
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`