### PR TITLE
test: fix vmenu warning in test by mocking `AccountTagHoverWrapper`

### DIFF
--- a/tests/nuxt/__snapshots__/content-rich.test.ts.snap
+++ b/tests/nuxt/__snapshots__/content-rich.test.ts.snap
@@ -187,19 +187,11 @@ exports[`content-rich > handles html within code blocks 1`] = `
 exports[`content-rich > hashtag adds bdi 1`] = `
 "<p dir="auto">
   Testing bdi is added
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/turkey"
-        ><bdi>#<span>turkey</span></bdi></a
-      ></VMenu
-    ></span
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/turkey"
+    ><bdi>#<span>turkey</span></bdi></a
   >
 </p>
 "
@@ -208,18 +200,12 @@ exports[`content-rich > hashtag adds bdi 1`] = `
 exports[`content-rich > hashtag doesn't add 2 bdi 1`] = `
 "<p dir="auto">
   Testing bdi not added
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/turkey"
-        ><bdi></bdi></a></VMenu
-  ></span>
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/turkey"
+    ><bdi></bdi
+  ></a>
 </p>
 "
 `;
@@ -329,33 +315,17 @@ exports[`content-rich > root p includes dir="auto" attr when mixed content 1`] =
     alt="🐤"
   />
   ;). كما أن النموذج الخاص بـ 0 يحتاج إلى إصلاح
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/turkey"
-        ><bdi>#<span>turkey</span></bdi></a
-      ></VMenu
-    ></span
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/turkey"
+    ><bdi>#<span>turkey</span></bdi></a
   >
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9"
-        ><bdi>#<span>العربية</span></bdi></a
-      ></VMenu
-    ></span
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9"
+    ><bdi>#<span>العربية</span></bdi></a
   >
   .
 </p>
@@ -391,33 +361,17 @@ exports[`content-rich > root p includes dir="auto" attr when mixed content 1`] =
     alt="🐤"
   />
   ;). Also, the form for 0 needs to be fixed
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/turkey"
-        ><bdi>#<span>turkey</span></bdi></a
-      ></VMenu
-    ></span
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/turkey"
+    ><bdi>#<span>turkey</span></bdi></a
   >
-  <span
-    ><VMenu
-      placement="bottom-start"
-      class="inline-block"
-      close-on-content-click="false"
-      no-auto-focus
-      ><a
-        class="mention hashtag"
-        rel="nofollow noopener noreferrer"
-        to="/m.webtoo.ls/tags/%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9"
-        ><bdi>#<span>العربية</span></bdi></a
-      ></VMenu
-    ></span
+  <a
+    class="mention hashtag"
+    rel="nofollow noopener noreferrer"
+    to="/m.webtoo.ls/tags/%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9"
+    ><bdi>#<span>العربية</span></bdi></a
   >
   .
 </p>

--- a/tests/nuxt/content-rich.test.ts
+++ b/tests/nuxt/content-rich.test.ts
@@ -280,3 +280,10 @@ mockComponent('AccountHoverWrapper', {
     return () => slots?.default?.()
   },
 })
+
+mockComponent('AccountTagHoverWrapper', {
+  props: ['tagName', 'class'],
+  setup(_, { slots }) {
+    return () => slots?.default?.()
+  },
+})


### PR DESCRIPTION
fix #2934

The vitest has shown warning message telling `<VMenu>` resolution failed for a while:

```shell
Run pnpm test:ci
$ vitest run

 RUN  v4.1.6 /home/runner/work/elk/elk

Importing from "vitest/environments" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
Importing from "vitest/environments" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
The Vitest environment nuxt defines the "transformMode". This options was deprecated in Vitest 4 and will be removed in the next major version. Please, use "viteEnvironment" instead.
The Vitest environment nuxt defines the "transformMode". This options was deprecated in Vitest 4 and will be removed in the next major version. Please, use "viteEnvironment" instead.
 ✓  nuxt  ../tests/unit/reorder-timeline.test.ts (2 tests) 6ms
Importing from "vitest/environments" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
The Vitest environment nuxt defines the "transformMode". This options was deprecated in Vitest 4 and will be removed in the next major version. Please, use "viteEnvironment" instead.
stdout | ../tests/nuxt/html-parse.test.ts
<Suspense> is an experimental feature and its API will likely change.

stdout | ../tests/unit/language.test.ts
<Suspense> is an experimental feature and its API will likely change.

stdout | ../tests/nuxt/content-rich.test.ts
<Suspense> is an experimental feature and its API will likely change.

 ✓  nuxt  ../tests/unit/language.test.ts (1 test) 18ms
 ✓  nuxt  ../tests/nuxt/html-parse.test.ts (10 tests) 103ms
Importing from "vitest/environments" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
The Vitest environment nuxt defines the "transformMode". This options was deprecated in Vitest 4 and will be removed in the next major version. Please, use "viteEnvironment" instead.
Importing from "vitest/environments" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
The Vitest environment nuxt defines the "transformMode". This options was deprecated in Vitest 4 and will be removed in the next major version. Please, use "viteEnvironment" instead.
stderr | ../tests/nuxt/content-rich.test.ts > content-rich > hashtag adds bdi
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="turkey" class="inline-block" > 
  at <App>

stderr | ../tests/nuxt/content-rich.test.ts > content-rich > hashtag doesn't add 2 bdi
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="turkey" class="inline-block" > 
  at <App>

stderr | ../tests/nuxt/content-rich.test.ts > content-rich > root p includes dir="auto" attr when mixed content
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="turkey" class="inline-block" > 
  at <App>
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9" class="inline-block" > 
  at <App>
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="turkey" class="inline-block" > 
  at <App>
[Vue warn]: Failed to resolve component: VMenu
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <AccountTagHoverWrapper tagName="%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9" class="inline-block" > 
  at <App>

 ✓  nuxt  ../tests/nuxt/content-rich.test.ts (27 tests) 210ms
stdout | ../tests/unit/permalinks.test.ts
<Suspense> is an experimental feature and its API will likely change.

stdout | ../tests/nuxt/html-to-text.test.ts
<Suspense> is an experimental feature and its API will likely change.

 ✓  nuxt  ../tests/unit/permalinks.test.ts (6 tests) 4ms
 ✓  nuxt  ../tests/nuxt/html-to-text.test.ts (3 tests) 12ms

 Test Files  6 passed (6)
      Tests  49 passed (49)
   Start at  04:43:46
   Duration  8.03s (transform 11.93s, setup 13.78s, import 2.80s, tests 353ms, environment 3.29s)
```

This was due to the lack of `AccountTagHoverWrapper` mock in the test. This added a new mock and updated the snapshots.