### PR TITLE
fix: blocked user profile shows 'Blocked following' button

### DIFF
--- a/app/components/account/AccountFollowButton.vue
+++ b/app/components/account/AccountFollowButton.vue
@@ -90,7 +90,7 @@ const buttonStyle = computed(() => {
         <span elk-group-hover="hidden">{{ $t('account.blocking') }}</span>
         <span hidden elk-group-hover="inline">{{ $t('account.unblock') }}</span>
       </template>
-      <template v-if="relationship?.muting">
+      <template v-else-if="relationship?.muting">
         <span elk-group-hover="hidden">{{ $t('account.muting') }}</span>
         <span hidden elk-group-hover="inline">{{ $t('account.unmute') }}</span>
       </template>


### PR DESCRIPTION
## What

Fixes #3535.

When viewing a profile of a user you had blocked while previously following them, the follow button showed **"Blocked following"** — two labels rendered simultaneously.

## Root Cause

In `AccountFollowButton.vue`, the blocking and muting template branches both used standalone `v-if`, breaking the mutual-exclusivity chain:

```html
<!-- blocking renders ✓ -->
<template v-if="relationship?.blocking"> … </template>

<!-- muting is a NEW v-if chain — independent of blocking -->
<template v-if="relationship?.muting"> … </template>

<!-- v-else-if chains off muting, NOT blocking -->
<!-- so when blocking=true AND muting=false, this also renders ✓ -->
<template v-else-if="relationship?.following"> … </template>
```

When `blocking=true` and `muting=false`, the blocking block rendered AND the following `v-else-if` fired (because `muting` was false), producing "Blocked following".

## Fix

Change `v-if` → `v-else-if` on the muting branch so all label branches form a single exclusive chain: blocking → muting → following → requested → followedBy → follow.

**1 line changed.**

## Testing

- Block a user you are following → button should show only "Blocked" (hover: "Unblock")
- Block a user who follows you (not following them) → button should show only "Blocked"
- Mute a user you are following → button should show only "Muting" (hover: "Unmute")  
- Normal follow/unfollow behavior unchanged