### PR TITLE
chore: update screenshot labels to include mobile variants

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -382,8 +382,10 @@
     "install": "Install",
     "install_title": "Install Elk",
     "screenshots": {
-      "dark": "Screenshot of Elk running in dark mode",
-      "light": "Screenshot of Elk running in light mode"
+      "dark": "Screenshot of Elk running on desktop in dark mode ",
+      "dark_mobile": "Screenshot of Elk running on mobile in dark mode",
+      "light": "Screenshot of Elk running on desktop in light mode",
+      "light_mobile": "Screenshot of Elk running on mobile in light mode"
     },
     "title": "New Elk update available!",
     "update": "Update",

--- a/modules/pwa/i18n.ts
+++ b/modules/pwa/i18n.ts
@@ -74,13 +74,13 @@ export async function createI18n(): Promise<LocalizedWebManifest> {
     sizes: '1080x2400',
     type: 'image/webp',
     form_factor: 'narrow',
-    label: pwa.screenshots.dark,
+    label: pwa.screenshots.dark_mobile,
   }, {
     src: 'screenshots/light-2.webp',
     sizes: '1080x2400',
     type: 'image/webp',
     form_factor: 'narrow',
-    label: pwa.screenshots.light,
+    label: pwa.screenshots.light_mobile,
   }]
 
   const manifestEntries: Partial<ManifestOptions> = {


### PR DESCRIPTION
follows #3663

Update screenshot image label in the PWA installation panel to distinguish desktop and mobile ones.