### PR TITLE
test: run reorder-timeline test in nuxt environment

### DIFF
--- a/tests/unit/reorder-timeline.test.ts
+++ b/tests/unit/reorder-timeline.test.ts
@@ -1,5 +1,3 @@
-/** @vitest-environment happy-dom */
-
 import type { mastodon } from 'masto'
 import { describe, expect, it } from 'vitest'
 import { removeFilteredItems, reorderTimeline } from '../../app/composables/timeline'


### PR DESCRIPTION
spotted a [regression in nuxt's ecosystem-ci](https://github.com/nuxt/ecosystem-ci/actions/runs/29616277122/job/88007194577)

the issue is that we are opting out of nuxt's environment (=> happy-dom) but _not_ opting out of a lot of nuxt's build plugins because this is still in a nuxt runtime _project_

the other option would be to create an entirely separate vitest project that doesn't use nuxt's runtime environment at all