### PR TITLE
fix(a11y): server thumbnail alt descriptions

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -68,7 +68,7 @@ const instance = computed(() => instanceStorage.value[currentServer.value])
             <!-- server info -->
             <div v-if="!currentUser && instance" grid gap-3 m3>
               <span text-size-lg text-primary font-bold>{{ instance.title }}</span>
-              <img rounded-3 :src="instance.thumbnail?.url">
+              <img v-if="instance.thumbnail?.url" rounded-3 :src="instance.thumbnail.url" :alt="$t('server.thumbnail_description', [instance.title])">
               <p text-secondary>
                 {{ instance.description }}
               </p>

--- a/app/pages/[[server]]/index.vue
+++ b/app/pages/[[server]]/index.vue
@@ -10,6 +10,6 @@ catch (err) {
 
 <template>
   <MainContent text-base grid gap-3 m3>
-    <img v-if="instance !== undefined" rounded-3 :src="instance.thumbnail.url">
+    <img v-if="instance?.thumbnail?.url" rounded-3 :src="instance.thumbnail.url" :alt="instance.title">
   </MainContent>
 </template>

--- a/app/pages/[[server]]/index.vue
+++ b/app/pages/[[server]]/index.vue
@@ -10,6 +10,6 @@ catch (err) {
 
 <template>
   <MainContent text-base grid gap-3 m3>
-    <img v-if="instance?.thumbnail?.url" rounded-3 :src="instance.thumbnail.url" :alt="instance.title">
+    <img v-if="instance?.thumbnail?.url" rounded-3 :src="instance.thumbnail.url" :alt="$t('server.thumbnail_description', [instance.title])">
   </MainContent>
 </template>

--- a/locales/en.json
+++ b/locales/en.json
@@ -461,6 +461,9 @@
     "search_desc": "Search for people & hashtags",
     "search_empty": "Could not find anything for these search terms"
   },
+  "server": {
+    "thumbnail_description": "Thumbnail for {0} server"
+  },
   "settings": {
     "about": {
       "built_at": "Built",


### PR DESCRIPTION
This adds an `alt` text to the server thumbnails shown when no user is logged in. I also added a new translation string for the alt. The default English alt text, for example, will be "Thumbnail for webtoo.ls server"
