### PR TITLE
chore: fix netlify preview builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,6 @@ NODE_OPTIONS = '--max-old-space-size=4096'
 [context.deploy-preview.environment]
 NUXT_STORAGE_DRIVER = 'memory'
 
-
 # Redirect to Discord server
 [[redirects]]
 from = "https://chat.elk.zone"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,13 @@ command = "pnpm run build"
 [build.environment]
 NODE_OPTIONS = '--max-old-space-size=4096'
 
+# Deploy Previews from forks don't receive the Cloudflare KV
+# credentials, and the storage driver defaults to `cloudflare` in CI —
+# without them the build crashes while initializing the prerenderer.
+[context.deploy-preview.environment]
+NUXT_STORAGE_DRIVER = 'memory'
+
+
 # Redirect to Discord server
 [[redirects]]
 from = "https://chat.elk.zone"


### PR DESCRIPTION
For Netlify deploy previews, set NUXT_STORAGE_DRIVER to 'memory' to prevent build crashes due to missing Cloudflare KV credentials, happening when PR is from forked repo branch 