### PR TITLE
docs: add a Markdown support page

### DIFF
--- a/docs/content/1.guide/5.markdown-support.md
+++ b/docs/content/1.guide/5.markdown-support.md
@@ -1,0 +1,66 @@
+---
+title: Markdown support
+description: Which Markdown-style formatting Elk renders in posts, and which it does not.
+---
+
+# Markdown support
+
+Elk renders a small subset of Markdown-style formatting in post content and in the compose editor.
+This is a client-side convenience: Elk converts a few inline shortcuts to rich text when it displays a post, and the compose editor can produce the same markup.
+
+::callout{type="warning"}
+Vanilla Mastodon does not support Markdown in posts.
+When someone reads your post in the standard Mastodon web app or in another client, they may see the raw characters (for example, `**bold**`) instead of formatted text.
+::
+
+## Supported syntax
+
+Elk converts the following inline shortcuts as it renders a post:
+
+| Formatting    | Type this           | Renders as          |
+| ------------- | ------------------- | ------------------- |
+| Bold          | `**bold**`          | **bold**            |
+| Italic        | `*italic*`          | *italic*            |
+| Bold italic   | `***bold italic***` | ***bold italic***   |
+| Strikethrough | `~~struck~~`        | ~~struck~~          |
+| Inline code   | `` `code` ``        | `code`              |
+
+Fenced code blocks are also supported.
+Start a line with three backticks (or three tildes), then close the block with a matching fence:
+
+````md
+```ts
+const answer = 42
+```
+````
+
+An optional language after the opening fence, such as ` ```ts `, selects syntax highlighting.
+See [Features](/guide/features#code-blocks) for the list of highlighted languages.
+
+A few things to keep in mind:
+
+- Bold and italic use asterisks only. The underscore forms (`__bold__`, `_italic_`) are not converted.
+- The compose editor tools menu (the **Aa** button) has shortcuts for Code block, Bold, and Italic. Strikethrough has no button, but `~~struck~~` typed as plain text still renders when the post is displayed.
+
+## Not supported
+
+Elk does not turn the following Markdown into formatting.
+Typed into a post, these characters stay as plain text:
+
+| Markdown        | Example                                |
+| --------------- | -------------------------------------- |
+| Headings        | `# Heading`                            |
+| Unordered lists | `- item`                               |
+| Ordered lists   | `1. item`                              |
+| Blockquotes     | `> quote`                              |
+| Links           | `[label](https://example.com)`         |
+| Images          | `![alt](https://example.com/img.png)`  |
+| Tables          | pipe-delimited rows                    |
+
+Regular URLs and `@mentions` are still detected and linked automatically, so you do not need Markdown link syntax for them.
+
+::callout{type="info"}
+Some Mastodon servers (for example, glitch-soc or Hollo) support Markdown or HTML posts on the server side.
+If your server sends already-formatted HTML, Elk displays headings, lists, blockquotes, and underlined text as well.
+Elk itself never generates these from Markdown text, and tables are removed for safety.
+::


### PR DESCRIPTION
## What

Adds a "Markdown support" docs page (`docs/content/1.guide/5.markdown-support.md`) documenting which Markdown-style formatting Elk renders in posts vs which it does not, as requested in #3606 and greenlit in discussion #2403.

## Grounding

Rather than relying on the earlier community probe, the supported/unsupported lists are derived from Elk's actual renderer:

- Supported inline shortcuts come from `_markdownReplacements` in `app/composables/content-parse.ts`: bold (`**`), italic (`*`), bold-italic (`***`), strikethrough (`~~`), inline code (`` ` ``), plus fenced code blocks (with optional language for highlighting).
- Not-supported syntax (headings, lists, blockquotes, links, images, tables) has no conversion rule there, so it renders as literal text.
- An info callout notes that headings/lists/blockquotes/underline display only when a server (e.g. glitch-soc, Hollo) sends already-formatted HTML — the sanitizer allows those tags, but Elk never generates them from Markdown, and tables are stripped.

It also documents the asterisk-only bold/italic (underscore forms aren't converted) and the compose-editor toolbar (Bold / Italic / Code block).

## Verification

The page matches the sibling Nuxt Content / Docus pages (front-matter, callouts, GFM tables, numeric filename prefix for nav ordering) and lints clean under Elk's ESLint config, including the docs-markdown overrides. I used the `5.` prefix to avoid renumbering existing guide pages — happy to reorder if you'd prefer it right after Features.

Closes #3606.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). The supported/unsupported syntax was grounded in `app/composables/content-parse.ts` (cited above), and the page was linted against Elk's config.*
