### PR TITLE
fix(oauth): drop scope param from token exchange

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -2,6 +2,8 @@ import type { mastodon } from 'masto'
 
 export const APP_NAME = 'Elk'
 
+export const DEFAULT_OAUTH_SCOPES = 'read write follow push'
+
 export const DEFAULT_POST_CHARS_LIMIT = 500
 export const DEFAULT_FONT_SIZE = '15px'
 

--- a/server/api/[server]/login.ts
+++ b/server/api/[server]/login.ts
@@ -1,5 +1,7 @@
 import { stringifyQuery } from 'ufo'
 
+import { DEFAULT_OAUTH_SCOPES } from '~/constants'
+
 export default defineEventHandler(async (event) => {
   let { server } = getRouterParams(event)
   if (!server) {
@@ -22,7 +24,7 @@ export default defineEventHandler(async (event) => {
   const query = stringifyQuery({
     client_id: app.client_id,
     force_login: force_login === true ? 'true' : 'false',
-    scope: 'read write follow push',
+    scope: DEFAULT_OAUTH_SCOPES,
     response_type: 'code',
     lang,
     redirect_uri: getRedirectURI(origin, server),

--- a/server/api/[server]/oauth/[origin].ts
+++ b/server/api/[server]/oauth/[origin].ts
@@ -41,7 +41,6 @@ export default defineEventHandler(async (event) => {
         redirect_uri: getRedirectURI(origin, server),
         grant_type: 'authorization_code',
         code,
-        scope: 'read write follow push',
       },
       retry: 3,
     })
@@ -76,7 +75,6 @@ export default defineEventHandler(async (event) => {
             redirect_uri: getRedirectURI(origin, server),
             grant_type: 'authorization_code',
             code,
-            scope: 'read write follow push',
           },
           retry: 1,
         })

--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -11,7 +11,7 @@ import memory from 'unstorage/drivers/memory'
 import vercelKVDriver from 'unstorage/drivers/vercel-kv'
 
 import { version } from '~~/config/env'
-import { APP_NAME } from '~/constants'
+import { APP_NAME, DEFAULT_OAUTH_SCOPES } from '~/constants'
 
 import cached from '../cache-driver'
 
@@ -64,7 +64,7 @@ async function fetchAppInfo(origin: string, server: string) {
         client_name: APP_NAME + (env !== 'release' ? ` (${env})` : ''),
         website: origin,
         redirect_uris: getRedirectURI(origin, server),
-        scopes: 'read write follow push',
+        scopes: DEFAULT_OAUTH_SCOPES,
       },
     }),
     $fetch(`https://${server}/api/v2/instance`, {


### PR DESCRIPTION
This will:
- drop scope param from token exchange
- and dedupe scope constant

Per RFC 6749, the `scope` parameter is not used with the `authorization_code` grant type when exchanging the code for a token — the granted scope is fixed by the authorization request. See linked issue for details

Added a constant to use everywhere we need the scopes string

Verified with `pnpm test:unit` & `pnpm test:typecheck` but it seems we have a flaky CI test. Also tested preview deploy manually :)

fixes #3306