### PR TITLE
fix: iterate `removeHTMLTags` until stable

### DIFF
--- a/app/composables/misc.ts
+++ b/app/composables/misc.ts
@@ -38,5 +38,11 @@ export function isEmptyObject(object: object) {
 }
 
 export function removeHTMLTags(str: string) {
-  return str.replaceAll(HTMLTagRE, '')
+  let result = str
+  let prev: string
+  do {
+    prev = result
+    result = result.replaceAll(HTMLTagRE, '')
+  } while (result !== prev)
+  return result
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to Elk! 💛
  Please fill in the sections below and tick the checklist before opening your PR.
-->

## Description

avoids double-encodings of html tags

## Checklist

- [x] I understand every change in this PR and take responsibility for it — including any parts written with AI help
- [x] I wrote this PR description in my own words, and the PR title follows [Semantic Pull Request](https://www.conventionalcommits.org/en/v1.0.0/#summary) (see successful PRs for examples).
- [x] `pnpm test:unit` passes (snapshots updated if needed)
- [x] `pnpm test:typecheck` passes
- [x] _(Recommended)_ I [signed off](../blob/main/CONTRIBUTING.md#signing-off-your-work-recommended) each commit myself (e.g., using `git commit -s`)

<!--
IMPORTANT: Used an AI coding agent for any part of this change? 🤖👋
- That's welcome — but you still need to read, understand, and take responsibility for every edit an agent made before it lands here. See the our guidance for [AI-assistance](../blob/main/CONTRIBUTING.md#using-ai-assistance) for the details. Thanks for keeping Elk in good hands!
-->
