### PR TITLE
fix: strip bidi control characters from URLs

### DIFF
--- a/app/composables/content-parse.ts
+++ b/app/composables/content-parse.ts
@@ -24,6 +24,7 @@ const HTML_ESCAPE_REGEX = {
 const INLINE_CODE_REGEX = /`([^`\n]*)`/g
 const WHITESPACE_SPLIT_REGEX = /\s/g
 const AMPERSAND_REGEX = /&amp;/g
+const BIDI_CONTROL_CHARS_REGEX = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g
 const EMOJI_SPLIT_REGEX = {
   WITH_COLON: /\s?:([\w-]+):/g,
   WITHOUT_COLON: /:([\w-]+):/g,
@@ -405,6 +406,9 @@ function filterHref() {
   return (href: string | undefined) => {
     if (href === undefined)
       return undefined
+
+    // Strip bidirectional control characters that can be used for domain spoofing
+    href = href.replace(BIDI_CONTROL_CHARS_REGEX, '')
 
     // Allow relative links
     if (href.startsWith('/') || href.startsWith('.'))


### PR DESCRIPTION
<!--
  Thanks for contributing to Elk! 💛
  Please fill in the sections below and tick the checklist before opening your PR.
-->

## Description

strips bi-directional control characters from urls

## Checklist

- [x] I understand every change in this PR and take responsibility for it — including any parts written with AI help
- [x] I wrote this PR description in my own words, and the PR title follows [Semantic Pull Request](https://www.conventionalcommits.org/en/v1.0.0/#summary) (see successful PRs for examples).
- [x] `pnpm test:unit` passes (snapshots updated if needed)
- [x] `pnpm test:typecheck` passes
- [x] _(Recommended)_ I [signed off](../blob/main/CONTRIBUTING.md#signing-off-your-work-recommended) each commit myself (e.g., using `git commit -s`)

<!--
IMPORTANT: Used an AI coding agent for any part of this change? 🤖👋
- That's welcome — but you still need to read, understand, and take responsibility for every edit an agent made before it lands here. See the our guidance for [AI-assistance](../blob/main/CONTRIBUTING.md#using-ai-assistance) for the details. Thanks for keeping Elk in good hands!
-->
